### PR TITLE
Param Editor context menu display options

### DIFF
--- a/src/StudioCore/Configuration/CFG.cs
+++ b/src/StudioCore/Configuration/CFG.cs
@@ -164,8 +164,8 @@ public class CFG
     public bool Param_ShowHotkeysInContextMenu = true;
     public bool Param_ShowSecondaryNames = true;
     public bool Param_ShowVanillaParams = true;
-    public bool Param_LabelInContextMenu = true;
-    public bool Param_DescriptionInContextMenu = true;
+    public bool Param_FieldNameInContextMenu = true;
+    public bool Param_FieldDescriptionInContextMenu = true;
     public bool Param_SplitContextMenu = false;
     public bool UI_CompactParams = false;
 

--- a/src/StudioCore/Configuration/CFG.cs
+++ b/src/StudioCore/Configuration/CFG.cs
@@ -164,6 +164,9 @@ public class CFG
     public bool Param_ShowHotkeysInContextMenu = true;
     public bool Param_ShowSecondaryNames = true;
     public bool Param_ShowVanillaParams = true;
+    public bool Param_LabelInContextMenu = true;
+    public bool Param_DescriptionInContextMenu = true;
+    public bool Param_SplitContextMenu = false;
     public bool UI_CompactParams = false;
 
     // Settings: Text Editor

--- a/src/StudioCore/Configuration/SettingsMenu.cs
+++ b/src/StudioCore/Configuration/SettingsMenu.cs
@@ -719,17 +719,17 @@ public class SettingsMenu
 
                 if (CFG.Current.ShowUITooltips)
                 {
-                    ShowHelpMarker("Repeat the label in the context menu.");
+                    ShowHelpMarker("Repeat the field name in the context menu.");
                     ImGui.SameLine();
                 }
-                ImGui.Checkbox("Label in context menu", ref CFG.Current.Param_LabelInContextMenu);
+                ImGui.Checkbox("Field name in context menu", ref CFG.Current.Param_FieldNameInContextMenu);
 
                 if (CFG.Current.ShowUITooltips)
                 {
-                    ShowHelpMarker("Repeat the description in the context menu.");
+                    ShowHelpMarker("Repeat the field description in the context menu.");
                     ImGui.SameLine();
                 }
-                ImGui.Checkbox("Description in context menu", ref CFG.Current.Param_DescriptionInContextMenu);
+                ImGui.Checkbox("Field description in context menu", ref CFG.Current.Param_FieldDescriptionInContextMenu);
 
                 if (CFG.Current.ShowUITooltips)
                 {

--- a/src/StudioCore/Configuration/SettingsMenu.cs
+++ b/src/StudioCore/Configuration/SettingsMenu.cs
@@ -716,6 +716,27 @@ public class SettingsMenu
                     ImGui.SameLine();
                 }
                 ImGui.Checkbox("Allow field reordering", ref CFG.Current.Param_AllowFieldReorder);
+
+                if (CFG.Current.ShowUITooltips)
+                {
+                    ShowHelpMarker("Repeat the label in the context menu.");
+                    ImGui.SameLine();
+                }
+                ImGui.Checkbox("Label in context menu", ref CFG.Current.Param_LabelInContextMenu);
+
+                if (CFG.Current.ShowUITooltips)
+                {
+                    ShowHelpMarker("Repeat the description in the context menu.");
+                    ImGui.SameLine();
+                }
+                ImGui.Checkbox("Description in context menu", ref CFG.Current.Param_DescriptionInContextMenu);
+
+                if (CFG.Current.ShowUITooltips)
+                {
+                    ShowHelpMarker("Split the field context menu into separate menus for separate right-click locations.");
+                    ImGui.SameLine();
+                }
+                ImGui.Checkbox("Split context menu", ref CFG.Current.Param_SplitContextMenu);
             }
 
             ImGui.EndTabItem();

--- a/src/StudioCore/Editor/EditorDecorations.cs
+++ b/src/StudioCore/Editor/EditorDecorations.cs
@@ -855,20 +855,29 @@ public class EditorDecorations
     /// </summary>
     public static void ImGui_DisplayPropertyInfo(PropertyInfo prop)
     {
-        ImGui_DisplayPropertyInfo(prop.PropertyType, prop.Name);
+        ImGui_DisplayPropertyInfo(prop.PropertyType, prop.Name, true, true);
     }
 
     /// <summary>
     ///     Displays information about the provided property.
     /// </summary>
-    public static void ImGui_DisplayPropertyInfo(Type propType, string fieldName, string altName = null, int arrayLength = -1, int bitSize = -1)
+    public static void ImGui_DisplayPropertyInfo(Type propType, string fieldName, bool printName, bool printType, string altName = null, int arrayLength = -1, int bitSize = -1)
     {
         if (!string.IsNullOrWhiteSpace(altName))
         {
             fieldName += $"  /  {altName}";
         }
 
-        ImGui.TextColored(new Vector4(1.0f, 0.7f, 0.4f, 1.0f), Utils.ImGuiEscape(fieldName, "", true));
+        if (CFG.Current.Param_LabelInContextMenu && printName)
+        {
+            ImGui.TextColored(new Vector4(1.0f, 0.7f, 0.4f, 1.0f), Utils.ImGuiEscape(fieldName, "", true));
+        }
+
+        if (CFG.Current.Param_SplitContextMenu && !printType)
+        {
+            return;
+        }
+
         if (bitSize != -1)
         {
             var str = $"Bitfield Type within: {fieldName}";
@@ -915,7 +924,5 @@ public class EditorDecorations
                 ImGui.TextColored(new Vector4(.4f, 1f, .7f, 1f), str);
             }
         }
-
-        ImGui.Separator();
     }
 }

--- a/src/StudioCore/Editor/EditorDecorations.cs
+++ b/src/StudioCore/Editor/EditorDecorations.cs
@@ -868,7 +868,7 @@ public class EditorDecorations
             fieldName += $"  /  {altName}";
         }
 
-        if (CFG.Current.Param_LabelInContextMenu && printName)
+        if (CFG.Current.Param_FieldNameInContextMenu && printName)
         {
             ImGui.TextColored(new Vector4(1.0f, 0.7f, 0.4f, 1.0f), Utils.ImGuiEscape(fieldName, "", true));
         }

--- a/src/StudioCore/ParamEditor/ParamRowEditor.cs
+++ b/src/StudioCore/ParamEditor/ParamRowEditor.cs
@@ -326,7 +326,10 @@ public class ParamRowEditor
             ImGui.Selectable("", false, ImGuiSelectableFlags.AllowItemOverlap);
             if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
             {
-                ImGui.OpenPopup("ParamRowCommonMenu");
+                if (!CFG.Current.Param_SplitContextMenu)
+                    ImGui.OpenPopup("ParamRowCommonMenu");
+                else
+                    ImGui.OpenPopup("ParamRowLabelMenu");
             }
 
             ImGui.SameLine();
@@ -354,7 +357,10 @@ public class ParamRowEditor
                 ImGui.EndGroup();
                 if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
                 {
-                    ImGui.OpenPopup("ParamRowCommonMenu");
+                    if (!CFG.Current.Param_SplitContextMenu)
+                        ImGui.OpenPopup("ParamRowCommonMenu");
+                    else
+                        ImGui.OpenPopup("ParamRowLabelMenu");
                 }
             }
         }
@@ -404,7 +410,10 @@ public class ParamRowEditor
 
             if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
             {
-                ImGui.OpenPopup("ParamRowCommonMenu");
+                if (!CFG.Current.Param_SplitContextMenu)
+                    ImGui.OpenPopup("ParamRowCommonMenu");
+                else
+                    ImGui.OpenPopup("ParamRowValueMenu");
             }
 
             if (displayRefTypes || displayFmgRef || displayEnum)
@@ -429,7 +438,10 @@ public class ParamRowEditor
                 EditorDecorations.ParamRefEnumQuickLink(bank, oldval, RefTypes, row, FmgRef, Enum);
                 if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
                 {
-                    ImGui.OpenPopup("ParamRowCommonMenu");
+                    if (!CFG.Current.Param_SplitContextMenu)
+                        ImGui.OpenPopup("ParamRowCommonMenu");
+                    else
+                        ImGui.OpenPopup("ParamRowValueMenu");
                 }
             }
 
@@ -491,7 +503,23 @@ public class ParamRowEditor
         if (ImGui.BeginPopup("ParamRowCommonMenu"))
         {
             PropertyRowNameContextMenuItems(bank, internalName, cellMeta, activeParam, activeParam != null,
-                isPinned, col, selection, propType, Wiki, oldval);
+                isPinned, col, selection, propType, Wiki, oldval, true);
+            PropertyRowValueContextMenuItems(bank, row, internalName, VirtualRef, ExtRefs, oldval, ref newval,
+                RefTypes, FmgRef, Enum);
+            ImGui.EndPopup();
+        }
+
+        if (ImGui.BeginPopup("ParamRowLabelMenu"))
+        {
+            PropertyRowNameContextMenuItems(bank, internalName, cellMeta, activeParam, activeParam != null,
+                isPinned, col, selection, propType, Wiki, oldval, true);
+            ImGui.EndPopup();
+        }
+
+        if (ImGui.BeginPopup("ParamRowValueMenu"))
+        {
+            PropertyRowNameContextMenuItems(bank, internalName, cellMeta, activeParam, activeParam != null,
+                isPinned, col, selection, propType, Wiki, oldval, false);
             PropertyRowValueContextMenuItems(bank, row, internalName, VirtualRef, ExtRefs, oldval, ref newval,
                 RefTypes, FmgRef, Enum);
             ImGui.EndPopup();
@@ -612,7 +640,7 @@ public class ParamRowEditor
 
     private void PropertyRowNameContextMenuItems(ParamBank bank, string internalName, FieldMetaData cellMeta,
         string activeParam, bool showPinOptions, bool isPinned, Param.Column col,
-        ParamEditorSelectionState selection, Type propType, string Wiki, dynamic oldval)
+        ParamEditorSelectionState selection, Type propType, string Wiki, dynamic oldval, bool isNameMenu)
     {
         var scale = Smithbox.GetUIScale();
         var altName = cellMeta?.AltName;
@@ -621,24 +649,38 @@ public class ParamRowEditor
 
         if (col != null)
         {
-            EditorDecorations.ImGui_DisplayPropertyInfo(propType, internalName, altName, col.Def.ArrayLength, col.Def.BitSize);
-            if (Wiki != null)
+            EditorDecorations.ImGui_DisplayPropertyInfo(propType, internalName, isNameMenu, !isNameMenu, altName, col.Def.ArrayLength,
+                col.Def.BitSize);
+
+            if (isNameMenu && CFG.Current.Param_DescriptionInContextMenu)
             {
-                ImGui.TextColored(new Vector4(.4f, .7f, 1f, 1f), $"{Wiki}");
-            }
-            else
-            {
-                ImGui.TextColored(new Vector4(1.0f, 1.0f, 1.0f, 0.7f),
-                    "Info regarding this field has not been written.");
+                if (Wiki != null)
+                {
+                    ImGui.TextColored(new Vector4(.4f, .7f, 1f, 1f), $"{Wiki}");
+                }
+                else
+                {
+                    ImGui.TextColored(new Vector4(1.0f, 1.0f, 1.0f, 0.7f),
+                        "Info regarding this field has not been written.");
+                }
             }
         }
         else
         {
             // Headers
-            ImGui.TextColored(new Vector4(1.0f, 0.7f, 0.4f, 1.0f), Utils.ImGuiEscape(internalName, "", true));
+            if (CFG.Current.Param_LabelInContextMenu)
+                ImGui.TextColored(new Vector4(1.0f, 0.7f, 0.4f, 1.0f), Utils.ImGuiEscape(internalName, "", true));
         }
 
-        ImGui.Separator();
+
+        if (isNameMenu && (CFG.Current.Param_LabelInContextMenu || CFG.Current.Param_DescriptionInContextMenu))
+            ImGui.Separator();
+
+        if (!isNameMenu)
+        {
+            ImGui.PopStyleVar();
+            return;
+        }
 
         if (showPinOptions)
         {
@@ -659,10 +701,13 @@ public class ParamRowEditor
                     pinned.Add(internalName);
                 }
             }
+
             if (isPinned)
             {
-                EditorDecorations.PinListReorderOptions(_paramEditor._projectSettings.PinnedFields[activeParam], internalName);
+                EditorDecorations.PinListReorderOptions(_paramEditor._projectSettings.PinnedFields[activeParam],
+                    internalName);
             }
+
             ImGui.Separator();
         }
 

--- a/src/StudioCore/ParamEditor/ParamRowEditor.cs
+++ b/src/StudioCore/ParamEditor/ParamRowEditor.cs
@@ -329,7 +329,7 @@ public class ParamRowEditor
                 if (!CFG.Current.Param_SplitContextMenu)
                     ImGui.OpenPopup("ParamRowCommonMenu");
                 else
-                    ImGui.OpenPopup("ParamRowLabelMenu");
+                    ImGui.OpenPopup("ParamRowNameMenu");
             }
 
             ImGui.SameLine();
@@ -360,7 +360,7 @@ public class ParamRowEditor
                     if (!CFG.Current.Param_SplitContextMenu)
                         ImGui.OpenPopup("ParamRowCommonMenu");
                     else
-                        ImGui.OpenPopup("ParamRowLabelMenu");
+                        ImGui.OpenPopup("ParamRowNameMenu");
                 }
             }
         }
@@ -509,7 +509,7 @@ public class ParamRowEditor
             ImGui.EndPopup();
         }
 
-        if (ImGui.BeginPopup("ParamRowLabelMenu"))
+        if (ImGui.BeginPopup("ParamRowNameMenu"))
         {
             PropertyRowNameContextMenuItems(bank, internalName, cellMeta, activeParam, activeParam != null,
                 isPinned, col, selection, propType, Wiki, oldval, true);
@@ -652,7 +652,7 @@ public class ParamRowEditor
             EditorDecorations.ImGui_DisplayPropertyInfo(propType, internalName, isNameMenu, !isNameMenu, altName, col.Def.ArrayLength,
                 col.Def.BitSize);
 
-            if (isNameMenu && CFG.Current.Param_DescriptionInContextMenu)
+            if (isNameMenu && CFG.Current.Param_FieldDescriptionInContextMenu)
             {
                 if (Wiki != null)
                 {
@@ -668,12 +668,12 @@ public class ParamRowEditor
         else
         {
             // Headers
-            if (CFG.Current.Param_LabelInContextMenu)
+            if (CFG.Current.Param_FieldNameInContextMenu)
                 ImGui.TextColored(new Vector4(1.0f, 0.7f, 0.4f, 1.0f), Utils.ImGuiEscape(internalName, "", true));
         }
 
 
-        if (isNameMenu && (CFG.Current.Param_LabelInContextMenu || CFG.Current.Param_DescriptionInContextMenu))
+        if (isNameMenu && (CFG.Current.Param_FieldNameInContextMenu || CFG.Current.Param_FieldDescriptionInContextMenu))
             ImGui.Separator();
 
         if (!isNameMenu)


### PR DESCRIPTION
Added some settings for tweaking the Param Editor field context menus.


Default:

![2024-01-17_15-20-15__Smithbox](https://github.com/vawser/Smithbox/assets/1077140/afcd90f2-9b87-46bb-96d5-82d00f9a2dc9)

![2024-01-17_15-19-52__Smithbox](https://github.com/vawser/Smithbox/assets/1077140/99211c2a-913c-4ad9-a95f-b4722e4e4027)

Tweaked:

![2024-01-17_15-21-35__Smithbox](https://github.com/vawser/Smithbox/assets/1077140/33fc228e-e27f-4628-9f08-97332d97269d)

![2024-01-17_15-21-42__Smithbox](https://github.com/vawser/Smithbox/assets/1077140/631f13a9-e0a7-4707-994b-c24cd6cca4ff)

![2024-01-17_15-21-47__Smithbox](https://github.com/vawser/Smithbox/assets/1077140/a8891037-d5d0-44c1-b1cb-53633ced758a)

----

"Split context menu" partially restores the old behavior where the context menu was split into two; one for the field label/name, and one for the entry element.

"Label in context menu" and "Description in context menu" just toggle those things on/off, since IMO they're superfluous when they're already in the question mark and the label itself.