### PR TITLE
Setting to simplify massedit in field context menu

### DIFF
--- a/src/StudioCore/Configuration/CFG.cs
+++ b/src/StudioCore/Configuration/CFG.cs
@@ -152,6 +152,7 @@ public class CFG
     // Settings: Model Editor
 
     // Settings: Param Editor
+    public bool Param_MasseditPopupInContextMenu = true;
     public bool Param_AdvancedMassedit = false;
     public bool Param_AllowFieldReorder = true;
     public bool Param_AlphabeticalParams = true;

--- a/src/StudioCore/Configuration/SettingsMenu.cs
+++ b/src/StudioCore/Configuration/SettingsMenu.cs
@@ -645,10 +645,11 @@ public class SettingsMenu
 
                 if (CFG.Current.ShowUITooltips)
                 {
-                    ShowHelpMarker("Show additional options within the MassEdit context menu.");
+                    ShowHelpMarker("Show additional options for advanced users within the massedit popup.");
                     ImGui.SameLine();
                 }
-                ImGui.Checkbox("Show advanced massedit options", ref CFG.Current.Param_AdvancedMassedit);
+
+                ImGui.Checkbox("Show advanced options in massedit popup", ref CFG.Current.Param_AdvancedMassedit);
 
                 if (CFG.Current.ShowUITooltips)
                 {
@@ -743,6 +744,15 @@ public class SettingsMenu
                     ImGui.SameLine();
                 }
                 ImGui.Checkbox("Field description in context menu", ref CFG.Current.Param_FieldDescriptionInContextMenu);
+
+                if (CFG.Current.ShowUITooltips)
+                {
+                    ShowHelpMarker(@"If enabled, the right-click context menu for fields shows a comprehensive editing popup for the massedit feature.
+If disabled, simply shows a shortcut to the manual massedit entry element.
+(The full menu is still available from the manual popup)");
+                    ImGui.SameLine();
+                }
+                ImGui.Checkbox("Full massedit popup in context menu", ref CFG.Current.Param_MasseditPopupInContextMenu);
 
                 if (CFG.Current.ShowUITooltips)
                 {

--- a/src/StudioCore/ParamEditor/ParamRowEditor.cs
+++ b/src/StudioCore/ParamEditor/ParamRowEditor.cs
@@ -649,7 +649,8 @@ public class ParamRowEditor
 
         if (col != null)
         {
-            EditorDecorations.ImGui_DisplayPropertyInfo(propType, internalName, isNameMenu, !isNameMenu, altName, col.Def.ArrayLength,
+            EditorDecorations.ImGui_DisplayPropertyInfo(propType, internalName, isNameMenu, !isNameMenu, altName,
+                col.Def.ArrayLength,
                 col.Def.BitSize);
 
             if (isNameMenu && CFG.Current.Param_FieldDescriptionInContextMenu)
@@ -819,27 +820,45 @@ public class ParamRowEditor
         }
 
         ImGui.Separator();
-        if (ImGui.CollapsingHeader("Mass edit", ImGuiTreeNodeFlags.SpanFullWidth))
+        if (!CFG.Current.Param_MasseditPopupInContextMenu)
         {
-            ImGui.Separator();
-            if (ImGui.Selectable("Manually..."))
+            if (ImGui.Selectable("Mass edit"))
             {
                 EditorCommandQueue.AddCommand(
                     $@"param/menu/massEditRegex/selection: {Regex.Escape(internalName)}: ");
             }
 
-            if (ImGui.Selectable("Reset to vanilla..."))
+            if (ImGui.Selectable("Reset to vanilla"))
             {
-                EditorCommandQueue.AddCommand(
-                    $@"param/menu/massEditRegex/selection && !added: {Regex.Escape(internalName)}: = vanilla;");
+                MassParamEditRegex.PerformMassEdit(ParamBank.PrimaryBank,
+                    $"selection && !added: {Regex.Escape(internalName)}: = vanilla;",
+                    _paramEditor._activeView._selection);
             }
-
-            ImGui.Separator();
-            var res = AutoFill.MassEditOpAutoFill();
-            if (res != null)
+        }
+        else
+        {
+            if (ImGui.CollapsingHeader("Mass edit", ImGuiTreeNodeFlags.SpanFullWidth))
             {
-                EditorCommandQueue.AddCommand(
-                    $@"param/menu/massEditRegex/selection: {Regex.Escape(internalName)}: " + res);
+                ImGui.Separator();
+                if (ImGui.Selectable("Manually..."))
+                {
+                    EditorCommandQueue.AddCommand(
+                        $@"param/menu/massEditRegex/selection: {Regex.Escape(internalName)}: ");
+                }
+
+                if (ImGui.Selectable("Reset to vanilla..."))
+                {
+                    EditorCommandQueue.AddCommand(
+                        $@"param/menu/massEditRegex/selection && !added: {Regex.Escape(internalName)}: = vanilla;");
+                }
+
+                ImGui.Separator();
+                var res = AutoFill.MassEditOpAutoFill();
+                if (res != null)
+                {
+                    EditorCommandQueue.AddCommand(
+                        $@"param/menu/massEditRegex/selection: {Regex.Escape(internalName)}: " + res);
+                }
             }
         }
     }


### PR DESCRIPTION
A request by Kirnifr.

![2024-01-18_14-32-51__Smithbox](https://github.com/vawser/Smithbox/assets/1077140/7ff6f7a7-df14-4a7e-903c-709942d97eac)

Before:

![2024-01-18_14-33-43__Smithbox](https://github.com/vawser/Smithbox/assets/1077140/b5501167-f95d-486d-8f3a-9e66f206eadf)

After:

![2024-01-18_14-34-00__Smithbox](https://github.com/vawser/Smithbox/assets/1077140/f6b85b93-7f0e-4bdc-94af-bab47e8cfc1a)

The "mass edit" button does the same thing the "Manually..." button did in the large menu.

The "reset to vanilla" button is changed to immediately execute, and reset the selected field, instead of opening a massedit window.