### PR TITLE
Massedit operation for rounding

### DIFF
--- a/src/StudioCore/ParamEditor/MassParamEdit.cs
+++ b/src/StudioCore/ParamEditor/MassParamEdit.cs
@@ -555,7 +555,7 @@ public class MassParamEditRegex
         }
         catch (Exception e)
         {
-            errHelper = "Unknown error";
+            errHelper = e.Message;
         }
 
         if (res == null && col.Item1 == PseudoColumn.ID)
@@ -817,6 +817,29 @@ public class MEValueOperation : MEOperation<object, object>
         operations.Add("min",
             (new[] { "number" }, "Returns the smaller of the current value and number",
                 (ctx, args) => MassParamEdit.WithDynamicOf(ctx, v => Math.Min(v, double.Parse(args[0])))));
+
+        operations.Add("round",
+            (new[] { "number" }, "Rounds the current value to the specified amount of decimals",
+                (ctx, args) => MassParamEdit.WithDynamicOf(ctx, v => Math.Round(double.Parse(v), int.Parse(args[0]), MidpointRounding.AwayFromZero))));
+        operations.Add("roundMode",
+            (new[] { "number", "rounding mode" }, "Rounds the current value to the specified amount of decimals using the specified mode. Options are \"up\", \"down\" and \"even\".",
+                (ctx, args) => MassParamEdit.WithDynamicOf(ctx, v =>
+                {
+                    var mode = MidpointRounding.AwayFromZero;
+                    switch (args[1])
+                    {
+                        case "up":
+                            mode = MidpointRounding.ToPositiveInfinity;
+                            break;
+                        case "down":
+                            mode = MidpointRounding.ToNegativeInfinity;
+                            break;
+                        case "even":
+                            mode = MidpointRounding.ToEven;
+                            break;
+                    }
+                    return Math.Round(double.Parse(v), int.Parse(args[0]), mode);
+                })));
     }
 }
 


### PR DESCRIPTION
![2024-01-19_07-38-55__Smithbox](https://github.com/vawser/Smithbox/assets/1077140/60b81e3e-7c7f-4840-a857-34de98886e61)

Some confusion in the gif due to float precision stuff, but I'm guessing that's just how it is.

Also snuck in a change so that exception messages are printed instead of just saying "Unknown error".