### PR TITLE
Change program title order

### DIFF
--- a/src/StudioCore/Smithbox.cs
+++ b/src/StudioCore/Smithbox.cs
@@ -613,7 +613,7 @@ public class Smithbox
 
             _projectSettings = settings;
             ChangeProjectSettings(_projectSettings, Path.GetDirectoryName(filename), options);
-            _context.Window.Title = $"{_programTitle}  -  {_projectSettings.ProjectName}";
+            _context.Window.Title = $"{_projectSettings.ProjectName}  -  {_programTitle}";
 
             CFG.RecentProject recent = new()
             {


### PR DESCRIPTION
This bothered me:

![2024-01-23_14-42-35](https://github.com/vawser/Smithbox/assets/1077140/2082f60e-4f1d-4a92-92c4-13a021e3e035)

so I flipped the order of the project name and app name being displayed.