### PR TITLE
feat: Display model masks on enemies in map editor

### DIFF
--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/FaceSet.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/FaceSet.cs
@@ -34,6 +34,11 @@ namespace SoulsFormats
                 LodLevel2 = 0x0200_0000,
 
                 /// <summary>
+                /// Extremely low detail mesh.
+                /// </summary>
+                LodLevelEx = 0x0400_0000,
+
+                /// <summary>
                 /// Not confirmed, but suspected to indicate when indices are edge-compressed.
                 /// </summary>
                 EdgeCompressed = 0x4000_0000,

--- a/src/StudioCore/Editors/ModelEditor/ModelEditorScreen.cs
+++ b/src/StudioCore/Editors/ModelEditor/ModelEditorScreen.cs
@@ -874,7 +874,7 @@ public class ModelEditorScreen : EditorScreen, IResourceEventListener
             }
 
             _renderMesh = MeshRenderableProxy.MeshRenderableFromFlverResource(
-                RenderScene, asset.AssetVirtualPath, ModelMarkerType.None);
+                RenderScene, asset.AssetVirtualPath, ModelMarkerType.None, null);
             _renderMesh.World = Matrix4x4.Identity;
         }
     }
@@ -891,7 +891,7 @@ public class ModelEditorScreen : EditorScreen, IResourceEventListener
                     _renderMesh.Dispose();
                 }
 
-                _renderMesh = MeshRenderableProxy.MeshRenderableFromFlverResource(RenderScene, modelAsset.AssetVirtualPath, ModelMarkerType.None);
+                _renderMesh = MeshRenderableProxy.MeshRenderableFromFlverResource(RenderScene, modelAsset.AssetVirtualPath, ModelMarkerType.None, null);
                 _renderMesh.World = Matrix4x4.Identity;
             }
         }

--- a/src/StudioCore/Scene/RenderableProxy.cs
+++ b/src/StudioCore/Scene/RenderableProxy.cs
@@ -852,9 +852,9 @@ public class MeshRenderableProxy : RenderableProxy, IMeshProviderEventListener
                               cameraDistanceInt));
     }
 
-    public static MeshRenderableProxy MeshRenderableFromFlverResource(RenderScene scene, string virtualPath, ModelMarkerType modelType)
+    public static MeshRenderableProxy MeshRenderableFromFlverResource(RenderScene scene, string virtualPath, ModelMarkerType modelType, IEnumerable<int>? masks)
     {
-        var meshProvider = MeshProviderCache.GetFlverMeshProvider(virtualPath);
+        var meshProvider = MeshProviderCache.GetFlverMeshProvider(virtualPath, masks);
 
         MeshRenderableProxy renderable = new(scene.OpaqueRenderables, meshProvider, modelType);
 


### PR DESCRIPTION
* Displays enemies with their correct model masks set based on the NPCParam
* To add this, the MeshProviderCache was improved to accept unique keys, otherwise it would load the same model for all enemies
  * This is technically a performance loss, duplicate flver resources per model mask variation of an enemy
* Added missing FaceSet flag

Pitfalls:
* ER only
* Hardcoding param field names from NPCParamID for the display masks
* I haven't looked into what other systems use such a masking system

![2024-07-10_03-00-22__Smithbox](https://github.com/vawser/Smithbox/assets/1077140/e2a00067-b17a-4b81-aef3-2739a4a04e38)
![image](https://github.com/vawser/Smithbox/assets/1077140/ddfbb455-e805-4cc7-9fcf-45002de17065)
