### PR TITLE
Names for Gargoyles, DLC NPCs & Furnace Golems, and Misc

### DIFF
--- a/src/StudioCore/Assets/Paramdex/ER/Names/CharaInitParam.txt
+++ b/src/StudioCore/Assets/Paramdex/ER/Names/CharaInitParam.txt
@@ -3142,57 +3142,57 @@
 2019952 
 2019953 
 2019954 
-2024030 
-2024032 
-2024060 
+2024030 Drake Warrior Igon (Co-op) (Jagged Peak)
+2024032 Igon (NPC)
+2024060 Dragon Communion Priestess (NPC)
 2024061 
-2024070 
-2024071 
-2024090 Swordhand of Night Jolan 
-2024091 Swordhand of Night Jolan (Ymir Boss Fight)
-2024120 
-2024121 
-2024130 
-2024131 
+2024070 Ancient Dragon-Man (Boss) (Dragon's Pit)
+2024071 Ancient Dragon-Man (Invader) (Gravesite Plain - North of Scorched Ruins)
+2024090 Swordhand of Night Jolan (NPC)
+2024091 Swordhand of Night Jolan (Invader) (Cathedral of Manus Metyr)
+2024120 Swordhand of Night Anna (Invader) (Finger Ruins of Miyr)
+2024121 Swordhand of Night Anna (NPC)
+2024130 Fire Knight Queelign (NPC)
+2024131 Fire Knight Queelign (Invader) (Church of the Crusade)
 2024132 
-2024140 
-2024141 
-2024150 
-2024151 
-2024152 
-2024160 
-2024161 
-2024162 
-2024170 (Redmane Freyja Boss) 
-2024171 
+2024140 Hornsent (NPC)
+2024141 Hornsent (Invader) (Ancient Ruins of Rauh - Rot Ruins)
+2024150 Moore (NPC)
+2024151 Moore (Invader)
+2024152 Moore (Boss) (Enir-Ilim)
+2024160 Sir Ansbach (NPC)
+2024161 Sir Ansbach (Invasion) (Specimen Storehouse)
+2024162 Pureblood Knight Ansbach (NPC) (Enir-Ilim)
+2024170 Redmane Freyja (NPC)
+2024171 Redmane Freyja (Co-op)
 2024172 
-2024173 
-2024174 
-2024180 
-2024181 
-2024182 
-2024183 
-2024190 
-2024191 
-2024192 
-2024193 
-2024194 
-2024200 Count Ymir, Mother of Fingers (Boss)
-2024201 
-2024210 
-2024220 
-2024230 Rakshasa (Boss)
-2024240 Knight of the Solitary Gaol (Boss)
-2024250 Dryleaf Dane (Moorth RUins Boss)
-2024251 
-2024252 
-2024260 
-2024270 
-2024271 
-2024280 
-2024290 
-2024310 
-2024320 
+2024173 Redmane Freyja (NPC) (Enir-Ilim)
+2024174 Redmane Freyja (Boss) (Enir-Ilim)
+2024180 Needle Knight Leda (NPC)
+2024181 Needle Knight Leda (Co-op)
+2024182 Needle Knight Leda (Invasion Target)
+2024183 Needle knight Leda (Boss) (Enir-Ilim)
+2024190 Thiollier (NPC)
+2024191 Thiollier (Co-op)
+2024192 Thiollier (Invader) (Stone Coffin Fissure)
+2024193 Thiollier (NPC) (Stone Coffin Fissure)
+2024194 Thiollier (NPC) (Enir-Ilim)
+2024200 Count Ymir, High Priest (NPC) (Cathedral of Manus Metyr)
+2024201 Count Ymir, Mother of Fingers (Boss)
+2024210 (Tarnished) Red Bear (Boss) (Northern Nameless Mausoleum)
+2024220 Dancer of Ranah (Boss) (Southern Nameless Mausoleum)
+2024230 Rakshasa (Boss) (Western Nameless Mausoleum)
+2024240 Knight of the Solitary Gaol (Boss) (Western Nameless Mausoleum)
+2024250 Dryleaf Dane (NPC)
+2024251 Dryleaf Dane (Combat Set)
+2024252 Dryleaf Dane (Boss) (Enir-Ilim)
+2024260 Sanguine Noble Nataan (Helpful Spirit) (Enir-Ilim)
+2024270 Lamenter (Boss) (Lamenter's Gaol)
+2024271 Lamenter (Illusion) (Lamenter's Gaol)
+2024280 Greater Potentate (Bonny Village)
+2024290 Madding Hand (Woodland Trail)
+2024310 Logur, the Beast Claw (Gravesite Plain - South of Scorched Ruins)
+2024320 Moonrithyll, Carian Knight (West Castle Ensis)
 2029997 
 2029998 
 2029999 

--- a/src/StudioCore/Assets/Paramdex/ER/Names/NpcParam.txt
+++ b/src/StudioCore/Assets/Paramdex/ER/Names/NpcParam.txt
@@ -3981,25 +3981,25 @@
 47601000 Fire Giant
 47601050 Fire Giant
 47601900 Fire Giant
-47700000 Black Blade Kindred
-47700033 Black Blade Kindred
-47700034 Black Blade Kindred (Leyndell- Royal Capital)
-47700070 Black Blade Kindred
-47700100 Black Blade Kindred
-47700165 Valiant Gargoyle (Twinblade)
+47700000 Gargoyle
+47700033 Gargoyle (Capital Outskirts)
+47700034 Gargoyle (Leyndell - Royal Capital)
+47700070 Gargoyle (Leyndell - Ashen Capital)
+47700100 Gargoyle (Poison Breath)
+47700165 Valiant Gargoyle (Twinblade) (Nokron)
 47700200 Black Blade Kindred
 47700250 Black Blade Kindred (Forbidden Lands)
-47701000 Black Blade Kindred
-47701034 Black Blade Kindred (Leyndell- Royal Capital)
-47701100 Black Blade Kindred
-47701165 Valiant Gargoyle
-47701200 Black Blade Kindred
-47701242 Black Blade Kindred
-47702000 Black Blade Kindred Ruin
-47702034 Black Blade Kindred Ruin  (Leyndell- Royal Capital)
-47702066 Black Blade Kindred Ruin
-47709900 Black Blade Kindred
-47709910 Black Blade Kindred
+47701000 Gargoyle (Greatsword)
+47701034 Gargoyle (Greatsword) (Leyndell - Royal Capital)
+47701100 Gargoyle (Greatsword + Poison Breath)
+47701165 Valiant Gargoyle (Nokron)
+47701200 Black Blade Kindred (Greatsword)
+47701242 Black Blade Kindred (Dragonbarrow - Bestial Sanctum)
+47702000 Ruined Gargoyle
+47702034 Ruined Gargoyle (Leyndell - Royal Capital)
+47702066 Ruined Gargoyle (Deeproot Depths)
+47709900 Gargoyle -Passive Battle State-
+47709910 Gargoyle (Greatsword) -Passive Battle State-
 48000000 Mohg- The Omen
 48000068 Mohg, Lord of Blood
 48001000 Mohg- The Omen
@@ -4307,18 +4307,18 @@
 51602398 Fire Knight
 51700000 Furnace Golem
 51700001 Furnace Golem
-51700080 Furnace Golem
-51700083 Furnace Golem
-51700090 Furnace Golem
-51700091 Furnace Golem
+51700080 Furnace Golem (Southwest Gravesite Plain - Scorched Ruins)
+51700083 Furnace Golem (Southeast Gravesite Plain - Ellac River End)
+51700090 Furnace Golem (Central Scadu Altus - Shadow Keep Main Gate)
+51700091 Furnace Golem (Central Scadu Altus - Ruins of Unte)
 51700094 Furnace Golem
 51701000 Furnace Golem
 51701001 Furnace Golem
-51701084 Furnace Golem
-51701090 Furnace Golem
+51701084 Furnace Golem (Southwest Cerulean Coast - Charo's Hidden Grave)
+51701090 Furnace Golem (Central Scadu Altus - Church District Highroad)
 51702000 Furnace Golem
 51702001 Furnace Golem
-51702094 Furnace Golem
+51702094 Furnace Golem (Rauh Ruins)
 51709000 Furnace Golem
 51800000 Dummy Entity
 51800080 Dummy Entity
@@ -6766,95 +6766,95 @@
 523920000 
 523930000 
 524030000 Igon
-524030081 Igon
-524030085 Igon
+524030081 Igon (NPC) (Gravesite Plain - Pillar Path Waypoint)
+524030085 Igon (NPC) (Foot of the Jagged Peak - Drake Duo Area)
 524060000 Dragon Communion Priestess
-524060084 Dragon Communion Priestess
+524060084 Dragon Communion Priestess (NPC) (Foot of the Jagged Peak - Grand Altar)
 524070000 Ancient Dragon-Man
 524070001 Ancient Dragon-Man
-524070081 Ancient Dragon-Man (Boss)
+524070081 Ancient Dragon-Man (Boss) (Dragon's Pit)
 524090000 Swordhand of Night Jolan
-524090090 Swordhand of Night Jolan
+524090090 Swordhand of Night Jolan (NPC) (Scadu Altus - Cathedral of Manus Metyr)
 524090100 Swordhand of Night Jolan
-524090190 Swordhand of Night Jolan (Ymir Boss Fight)
-524090290 Swordhand of Night Jolan
+524090190 Swordhand of Night Jolan (Invader) (Scadu Altus - Cathedral of Manus Metyr)
+524090290 Swordhand of Night Jolan (NPC) (Scadu Altus - Cathedral of Manus Metyr)
 524120000 Swordhand of Night Anna
-524120090 Swordhand of Night Anna
+524120090 Swordhand of Night Anna (NPC) (Scadu Altus - Rabbath's Rise)
 524130000 Fire Knight Queelign
-524130098 Fire Knight Queelign
+524130098 Fire Knight Queelign (NPC) (Shadow Keep - Church District)
 524140000 Hornsent
-524140080 Hornsent
-524140089 Hornsent
-524140090 Hornsent
-524140099 Hornsent
-524140189 Hornsent (Boss)
-524140198 Hornsent
+524140080 Hornsent (NPC) (Gravesite Plain - Three-Path Cross)
+524140089 Hornsent (NPC) (Enir-Ilim)
+524140090 Hornsent (NPC) (Scadu Altus - Highroad Cross)
+524140099 Hornsent (NPC) (Specimen Storehouse)
+524140189 Hornsent (Boss) (Enir-Ilim)
+524140198 Hornsent (Invasion Target) (Shadow Keep)
 524140289 Hornsent
 524150000 Moore
-524150080 Moore
-524150089 Moore
-524150090 Moore
-524150189 Moore
+524150080 Moore (NPC) (Gravesite Plain - Belurat Main Gate Cross)
+524150089 Moore (NPC) (Enir-Ilim)
+524150090 Moore (NPC) (Scadu Altus - Church of the Crusade)
+524150189 Moore (Boss) (Enir-Ilim)
 524150289 Moore
 524160000 Sir Ansbach
-524160080 Sir Ansbach
-524160089 Sir Ansbach
-524160099 Sir Ansbach
-524160199 Sir Ansbach
+524160080 Sir Ansbach (NPC) (Gravesite Plain - Belurat Main Gate Cross)
+524160089 Sir Ansbach (NPC) (Enir-Ilim)
+524160099 Sir Ansbach (NPC) (Specimen Storehouse)
+524160199 Sir Ansbach (Invasion Target) (Specimen Storehouse)
 524160289 Pureblood Knight Ansbach
 524170000 Redmane Freyja
-524170080 Redmane Freyja
-524170089 Redmane Freyja
-524170099 Redmane Freyja
-524170189 Redmane Freyja
-524170289 Redmane Freyja (Boss)
+524170080 Redmane Freyja (NPC) (Gravesite Plain - Three-Path Cross)
+524170089 Redmane Freyja (NPC) (Enir-Ilim)
+524170099 Redmane Freyja (NPC) (Specimen Storehouse)
+524170189 Redmane Freyja (Boss) (Enir-Ilim)
+524170289 Redmane Freyja
 524180000 Needle Knight Leda
-524180068 Needle Knight Leda
-524180089 Needle Knight Leda
-524180090 Needle Knight Leda
-524180189 Needle Knight Leda
-524180198 Needle Knight Leda
-524180199 Needle Knight Leda
-524180289 Needle Knight Leda (Boss)
+524180068 Needle Knight Leda (NPC) (Mohgwyn Palace)
+524180089 Needle Knight Leda (NPC) (Enir-Ilim)
+524180090 Needle Knight Leda (NPC) (Scadu Altus - Highroad Cross)
+524180189 Needle Knight Leda (Boss) (Enir-Ilim)
+524180198 Needle Knight Leda (Invasion Target) (Shadow Keep)
+524180199 Needle Knight Leda (Invasion Target) (Specimen Storehouse)
+524180289 Needle Knight Leda
 524190000 Thiollier
-524190081 Thiollier
-524190087 Thiollier
-524190089 Thiollier
+524190081 Thiollier (NPC) (Gravesite Plain - Pillar Path Cross)
+524190087 Thiollier (NPC) (Stone Coffin Fissure)
+524190089 Thiollier (NPC) (Enir-Ilim)
 524190189 Thiollier
 524200000 Count Ymir, High Priest
-524200090 Count Ymir, High Priest
+524200090 Count Ymir, High Priest (NPC) (Scadu Altus - Cathedral of Manus Metyr)
 524200190 Count Ymir, Mother of Fingers (Boss)
-524210000 Red Bear - Human
-524210001 Red Bear - Human
-524210090 Red Bear - Human
-524210095 Red Bear - Human (Boss)
+524210000 (Tarnished) Red Bear
+524210001 (Tarnished) Red Bear
+524210090 (Tarnished) Red Bear
+524210095 (Tarnished) Red Bear (Boss) (Gravesite Plain - Northern Nameless Mausoleum)
 524220000 Dancer of Ranah
 524220001 Dancer of Ranah
-524220083 Dancer of Ranah (Boss)
+524220083 Dancer of Ranah (Boss) (Cerulean Coast - Southern Nameless Mausoleum)
 524230000 Rakshasa
 524230090 Rakshasa
-524230091 Rakshasa (Boss)
+524230091 Rakshasa (Boss) (Scadu Altus - Western Nameless Mausoleum)
 524240000 Knight of the Solitary Gaol
-524240080 Knight of the Solitary Gaol (Boss)
+524240080 Knight of the Solitary Gaol (Boss) (Gravesite Plain - Western Nameless Mausoleum)
 524250000 Dryleaf Dane
 524250001 Dryleaf Dane
 524250002 Dryleaf Dane
-524250089 Dryleaf Dane
-524250090 Dryleaf Dane
-524250189 Dryleaf Dane
-524250190 Dryleaf Dane (Moorth Ruins Boss)
-524250289 Dryleaf Dane (Enir Elim Boss)
+524250089 Dryleaf Dane (NPC) (Enir-Ilim)
+524250090 Dryleaf Dane (NPC) (Scadu Altus - Moorth Ruins)
+524250189 Dryleaf Dane (Boss) (Enir-Ilim)
+524250190 Dryleaf Dane (Miniboss) (Scadu Altus - Moorth Ruins)
+524250289 Dryleaf Dane
 524270000 Lamenter
-524270001 Lamenter
-524270084 Lamenter (Boss)
+524270001 Lamenter (Illusion) (Lamenter's Gaol)
+524270084 Lamenter (Boss) (Lamenter's Gaol)
 524280000 Greater Potentate
-524280090 Greater Potentate
+524280090 Greater Potentate (Scadu Altus - Bonny Village)
 524290000 Madding Hand
-524290086 Madding Hand
+524290086 Madding Hand (Abyssal Woods - Woodland Trail)
 524310000 Logur, the Beast Claw
-524310080 Logur, the Beast Claw
+524310080 Logur, the Beast Claw (Gravesite Plain - South of Scorched Ruins)
 524320000 Moonrithyll, Carian Knight
-524320082 Moonrithyll, Carian Knight
+524320082 Moonrithyll, Carian Knight (Gravesite Plain - West Castle Ensis)
 526000000 
 526050000 
 526060000 
@@ -6936,42 +6936,42 @@
 533900056 Polyanna, Youngest Sister
 534000000 
 534031000 Igon
-534031085 Drake Warrior Igon
+534031085 Drake Warrior Igon (Co-op) (Jagged Peak)
 534090000 Swordhand of Night Jolan
-534090083 Swordhand of Night Jolan
-534090093 Swordhand of Night Jolan
-534090099 Swordhand of Night Jolan
+534090083 Swordhand of Night Jolan (Co-op) (Cerulean Coast - Dragon Area)
+534090093 Swordhand of Night Jolan (Co-op) (Scadu Altus - Hinterlands)
+534090099 Swordhand of Night Jolan (Co-op) (Specimen Storehouse)
 534100000 
 534140000 Hornsent
-534140098 Hornsent
-534140099 Hornsent
-534140198 Hornsent
+534140098 Hornsent (Co-op) (Shadow Keep)
+534140099 Hornsent (Co-op) (Specimen Storehouse)
+534140198 Hornsent (Assisted Spirit) (Shadow Keep)
 534160000 Sir Ansbach
-534160089 Pureblood Knight Ansbach
-534160099 Sir Ansbach
-534160189 Pureblood Knight Ansbach
+534160089 Pureblood Knight Ansbach (Co-op) (Enir-Ilim)
+534160099 Sir Ansbach (Assisted Spirit) (Specimen Storehouse)
+534160189 Pureblood Knight Ansbach (Helpful Spirit) (Enir-Ilim)
 534160289 Pureblood Knight Ansbach
 534170000 Redmane Freyja
-534170088 Redmane Freyja
-534170090 Redmane Freyja
-534170098 Redmane Freyja
+534170088 Redmane Freyja (Co-op) (Belurat, Tower Settlement)
+534170090 Redmane Freyja (Co-op) (Rauh Base - Northwest Great Red Bear)
+534170098 Redmane Freyja (Co-op) (Shadow Keep)
 534180000 Needle Knight Leda
-534180082 Needle Knight Leda
+534180082 Needle Knight Leda (Co-op) (Gravesite Plain - East Castle Ensis)
 534180094 Needle Knight Leda
-534180098 Needle Knight Leda
-534180099 Needle Knight Leda
+534180098 Needle Knight Leda (Helpful Spirit) (Shadow Keep)
+534180099 Needle Knight Leda (Helpful Spirit) (Specimen Storehouse)
 534181000 Needle Knight Leda
 534190000 Thiollier
-534190087 Thiollier
-534190089 Thiollier
-534190189 Thiollier
+534190087 Thiollier (Co-op) (Stone Coffin Fissure)
+534190089 Thiollier (Co-op) (Enir-Ilim)
+534190189 Thiollier (Helpful Spirit) (Enir-Ilim)
 534190289 Thiollier
 534200000 Count Ymir, Hight Priest
 534250000 Dryleaf Dane
-534250082 Dryleaf Dane
-534250094 Dryleaf Dane
+534250082 Dryleaf Dane (Co-op) (Gravesite Plain - East Castle Ensis) (REMOVED)
+534250094 Dryleaf Dane (Co-op) (Ancient Ruins of Rauh - North Church of the Bud)
 534260000 Sanguine Noble Nataan
-534260089 Sanguine Noble Nataan
+534260089 Sanguine Noble Nataan (Helpful Spirit) (Enir-Ilim)
 534260189 Sanguine Noble Nataan
 534300000 
 534400000 
@@ -7000,33 +7000,33 @@
 543850000 Mad Tongue Alberich
 543850079 Mad Tongue Alberich
 544000000 
-544070000 Ancient-Dragon-Man
-544070081 Ancient-Dragon-Man
+544070000 Ancient Dragon-Man
+544070081 Ancient Dragon-Man (Invader) (Gravesite Plain - North of Scorched Ruins)
 544090000 Swordhand of Night Jolan
 544100000 
 544120000 Swordhand of Night Anna
-544120090 Swordhand of Night Anna (Invader)
+544120090 Swordhand of Night Anna (Invader) (Scadu Altus - Finger Ruins of Miyr)
 544130000 Fire Knight Queelign
-544130088 Fire Knight Queelign
-544130090 Fire Knight Queelign
+544130088 Fire Knight Queelign (Invader) (Belurat, Tower Settlement)
+544130090 Fire Knight Queelign (Invader) (Scadu Altus - Church of the Crusade)
 544130188 Fire Knight Queelign
 544130190 Fire Knight Queelign
 544140000 Hornsent
-544140094 Hornsent
+544140094 Hornsent (Invader) (Ancient Ruins of Rauh - Rot Ruins)
 544150000 Moore
-544150080 Moore
+544150080 Moore (Invader) (Gravesite Plain - Prospect Town)
 544150081 Moore
-544150083 Moore
-544150090 Moore
-544150180 Moore
+544150083 Moore (Invader) (Gravesite Plain - Ellac River End)
+544150090 Moore (Invader) (Scadu Altus)
+544150180 Moore (Hostile) (Gravesite Plain - Prospect Town)
 544150181 Moore
-544150183 Moore
-544150190 Moore
+544150183 Moore (Hostile) (Gravesite Plain - Ellac River End)
+544150190 Moore (Hostile) (Scadu Altus)
 544160000 Sir Ansbach
 544170000 Redmane Freyja
 544180000 Needle Knight Leda
 544190000 Thiollier
-544190087 Thiollier
+544190087 Thiollier (Invader) (Stone Coffin Fissure)
 544200000 
 544250000 Dryleaf Dane
 544300000 

--- a/src/StudioCore/Assets/Paramdex/ER/Names/NpcThinkParam.txt
+++ b/src/StudioCore/Assets/Paramdex/ER/Names/NpcThinkParam.txt
@@ -1108,23 +1108,23 @@
 47500000 Godrick the Grafted
 47600000 Fire Giant
 47600900 Fire Giant
-47700000 Valiant Gargoyle
-47700010 Valiant Gargoyle
-47700011 Valiant Gargoyle
-47700050 Valiant Gargoyle
-47700200 Valiant Gargoyle
-47700900 Valiant Gargoyle
-47701000 Valiant Gargoyle
-47701010 Valiant Gargoyle
-47701200 Valiant Gargoyle
-47702000 Valiant Gargoyle
-47702010 Valiant Gargoyle
-47702100 Valiant Gargoyle
-47705000 Valiant Gargoyle
-47705900 Valiant Gargoyle
-47705950 Valiant Gargoyle
-47706000 Valiant Gargoyle
-47706900 Valiant Gargoyle
+47700000 Gargoyle
+47700010 Gargoyle
+47700011 Gargoyle
+47700050 Gargoyle
+47700200 Valiant Gargoyle (Twinblade) (Nokron)
+47700900 Gargoyle
+47701000 Gargoyle (Greatsword) (Leyndell - Royal Capital)
+47701010 Gargoyle
+47701200 Valiant Gargoyle (Nokron)
+47702000 Ruined Gargoyle (Leyndell - Royal Capital)
+47702010 Gargoyle
+47702100 Ruined Gargoyle (Leyndell - Royal Capital)
+47705000 Gargoyle
+47705900 Gargoyle
+47705950 Black Blade Kindred (Forbidden Lands)
+47706000 Gargoyle
+47706900 Black Blade Kindred (Dragonbarrow - Bestial Sanctum)
 48000000 Mohg, Lord of Blood
 48001000 Mohg the Omen
 48100000 Erdtree Avatar
@@ -2085,39 +2085,39 @@
 523910000 
 523920000 
 523930000 
-524030000 
-524060000 
-524070000 
-524090000 
-524090100 
-524120000 
-524130000 
-524140000 
-524140100 
-524140200 
-524150000 
+524030000 Igon
+524060000 Dragon Communion Priestess
+524070000 Ancient Dragon-Man
+524090000 Swordhand of Night Jolan
+524090100 Swordhand of Night Jolan (Invader) (Scadu Altus - Cathedral of Manus Metyr)
+524120000 Swordhand of Night Anna
+524130000 Fire Knight Queelign
+524140000 Hornsent
+524140100 Hornsent (Invasion Target) (Shadow Keep)
+524140200 Hornsent (Boss) (Enir-Ilim)
+524150000 Moore
 524150100 
-524150200 
-524160000 
-524160100 
-524170000 
-524180000 
-524180100 
-524190000 
-524200000 
-524200100 
-524210000 
-524220000 
-524230000 
-524240000 
-524250000 
-524250100 
-524270000 
-524270100 
-524280000 
-524290000 
-524310000 
-524320000 
+524150200 Moore (Invader)
+524160000 Sir Ansbach
+524160100 Moore (Boss) (Enir-Ilim)/ Sir Ansbach (Invasion Target) (Specimen Storehouse)
+524170000 Redmane Freyja
+524180000 Needle Knight Leda
+524180100 Needle Knight Leda (Invasion Target)
+524190000 Thiollier
+524200000 Count Ymir, High Priest
+524200100 Count Ymir, Mother of Fingers (Boss)
+524210000 (Tarnished) Red Bear (Boss)
+524220000 Dancer of Ranah (Boss)
+524230000 Rakshasa (Boss)
+524240000 Knight of the Solitary Gaol (Boss)
+524250000 Dryleaf Dane
+524250100 Dryleaf Dane (Miniboss) (Scadu Altus - Moorth Ruins)
+524270000 Lamenter (Boss)
+524270100 Lamenter (Illusion)
+524280000 Greater Potentate
+524290000 Madding Hand
+524310000 Logur, the Beast Claw
+524320000 Moonrithyll, Carian Knight
 526000000 
 526010000 
 526020000 
@@ -2159,20 +2159,20 @@
 533890000 Amy Third Sister
 533900000 Polyanna Youngest Sister
 534000000 
-534031000 
-534090000 
+534031000 Igon (Co-op)
+534090000 Swordhand of Night Jolan (Co-op)
 534100000 
-534140000 
-534160000 
-534161000 
-534170000 
-534180000 
-534181000 
-534190000 
-534191000 
-534200000 
-534250000 
-534260000 
+534140000 Hornsent (Co-op)
+534160000 Sir Ansbach (Co-op)
+534161000 Pureblood Knight Ansbach (Helpful Spirit) (Enir-Ilim)
+534170000 Redmane Freyja (Co-op)
+534180000 Needle Knight Leda (Helpful Spirit)
+534181000 Needle Knight Leda (Co-op) (Gravesite Plain - East Castle Ensis)
+534190000 Thiollier (Co-op)
+534191000 Thiollier (Helpful Spirit) (Enir-Ilim)
+534200000 Count Ymir, High Priest
+534250000 Dryleaf Dane (Co-op)
+534260000 Sanguine Noble Nataan (Helpful Spirit)
 534300000 
 534400000 
 534500000 
@@ -2192,18 +2192,18 @@
 543690000 Sage Gowry
 543850000 Mad Tongue Alberich
 544000000 
-544070000 
+544070000 Ancient Dragon-Man (Invader)
 544090000 
 544100000 
-544130000 
-544140000 
-544150000 
-544160000 
-544170000 
-544180000 
-544190000 
+544130000 Fire Knight Queelign (Invader)
+544140000 Hornsent (Invader)
+544150000 Moore (Invader)
+544160000 Sir Ansbach
+544170000 Redmane Freyja (Boss) (Enir-Ilim)
+544180000 Needle Knight Leda (Boss) (Enir-Ilim)
+544190000 Thiollier (Invader) (Stone Coffin Fissure)
 544200000 
-544250000 
+544250000 Dryleaf Dane (Boss) (Enir-Ilim)
 544300000 
 544400000 
 544500000 

--- a/src/StudioCore/Assets/Paramdex/ER/Names/SpEffectParam.txt
+++ b/src/StudioCore/Assets/Paramdex/ER/Names/SpEffectParam.txt
@@ -975,9 +975,9 @@
 4289 
 4290 
 4291 
-4300 Enemy: Fade after death
-4301 Enemy: Fade after death (boss)
-4302 Enemy: Fade after death (blue)
+4300 Enemy: Fade After Death
+4301 Enemy: Fade After Death (Boss)
+4302 Enemy: Fade After Death (Blue)
 4305 
 4306 
 4307 
@@ -4771,48 +4771,48 @@
 17552 
 17553 
 17554 
-17600 
-17601 
-17602 
-17603 
-17604 
-17605 
+17600 (Gargoyles) ???
+17601 (Gargoyles) Cancel Opportunity to 3001/ 3011
+17602 (Gargoyles) Cancel Opportunity to 3009
+17603 (Gargoyles) Evading Backwards - Don't Take Certain Actions
+17604 (Gargoyles) Cancel Opportunity to 3010
+17605 (Gargoyles) Cancel Opportunity to 3003/ 3013
 17606 
 17607 
-17608 
-17609 
-17610 
-17611 
+17608 (Gargoyles) Cancel Opportunity to 3019/ 3027
+17609 (Gargoyles) Cancel Opportunity to 3019/ 3021/ 3022/ 3026/ 3027/ 3033
+17610 (Gargoyles) Cancel Opportunity to 3017/ 3024/ 3028
+17611 (Gargoyles) Cancel Opportunity to 3021/ 3022/ 3027/ 3031/ 3033
 17612 
-17613 
+17613 (Gargoyles) Cancel Opportunity to 3024/ 3028
 17614 
-17615 
-17616 
-17617 
-17618 
-17619 
-17620 
+17615 (Gargoyles) ???
+17616 (Gargoyles) Cancel Opportunity to 3029/ 3034
+17617 (Gargoyles) Cancel Opportunity to 3025/ 3029
+17618 (Gargoyles) Cancel Opportunity to 3016/ 3024
+17619 (Gargoyles) Cancel Opportunity to 3030
+17620 (Gargoyles) Cancel Opportunity to 3018/ 3019/ 3027
 17625 
-17626 
-17628 
+17626 (Gargoyles) Currently Walking
+17628 (Gargoyles) ???
 17629 
-17630 
-17631 
-17632 
-17633 
-17634 
-17635 
-17636 
+17630 (Gargoyles) Accumulator 1 - Base
+17631 (Gargoyles) Accumulator 1 - [Trigger] Enemy LUA AI Probabilities Change
+17632 (Gargoyles) Accumulator 1 - Reset
+17633 (Gargoyles) Accumulator 1 - On Attack +10
+17634 (Gargoyles) Accumulator 1 - Battle Movement +10
+17635 (Gargoyles) Evading Sideways - Don't Take Certain Actions
+17636 (Gargoyles) ???
 17637 
-17638 
-17639 
-17640 
-17641 
-17642 
-17643 
-17644 
-17645 
-17646 
+17638 (Gargoyles) Greatsword Attack Set
+17639 (Gargoyles) Halberd Attack Set
+17640 (Gargoyles) Greataxe Attack Set
+17641 (Gargoyles) Twinblade Attack Set
+17642 (Gargoyles) Ruined Attack Set
+17643 (Gargoyles) Can Use Poison Breath
+17644 (Gargoyles) Black Blade Kindred
+17645 (Gargoyles) Less Aggressive Battle State
+17646 (Gargoyles) Less Aggressive Battle State
 17648 
 17649 
 17650 
@@ -5863,7 +5863,7 @@
 90020 NPC: Disable Hemorrhage
 90030 NPC: Disable Blight
 90040 NPC: Disable Frostbite
-90060 NPC: Disable Madness 
+90060 NPC: Disable Madness
 90061 
 90100 NPC: Ignore Fake Targets - All
 90110 NPC: Ignore Fake Targets - Normal
@@ -9679,7 +9679,7 @@
 20011111 
 20011112 
 20011113 
-20011114 
+20011114 [DLC] Furnace Golem (Head Critical Damage)
 20011115 
 20011116 
 20011117 

--- a/src/StudioCore/Assets/Paramdex/ER/Names/SpEffectSetParam.txt
+++ b/src/StudioCore/Assets/Paramdex/ER/Names/SpEffectSetParam.txt
@@ -20,8 +20,8 @@
 108010 
 108100 
 108110 
-109000 
-109010 
+109000 Enemy: Fade After Death (Boss)
+109010 Enemy: Fade After Death
 1200000 
 1200010 
 1200020 


### PR DESCRIPTION
New convention for the Valiant Gargoyles where 'Valiant' is removed on all but the Boss' Params. Also includes a ton of their SpEffects named courtesy of a lot of digging into the AI LUA and ANIBND for them.

Heavy use of matt's Entity dump to name all NPCs properly (as far as I can ensure). Includes location tags for them, the Furnace Golems, and Gargoyles.