### PR TITLE
fix: Gizmo position with selected non-transform entities

### DIFF
--- a/src/StudioCore/Editors/MapEditor/Gizmos.cs
+++ b/src/StudioCore/Editors/MapEditor/Gizmos.cs
@@ -402,8 +402,10 @@ public class Gizmos
                         }
                     }
 
-                    OriginalTransform = new Transform(accumPos / _selection.GetSelection().Count,
-                        sels.First().GetRootLocalTransform().EulerRotation);
+                    OriginalTransform = new Transform(
+                        accumPos / sels.Count(),
+                        sels.First().GetRootLocalTransform().EulerRotation
+                    );
                 }
 
                 if (Space == GizmosSpace.World)


### PR DESCRIPTION
Gizmo had a weird position when you are also selecting events and the likes, this fixes it