### PR TITLE
fix: PartsDrawParamID

### DIFF
--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/MSB/MSB-AC6/PartParam.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/MSB/MSB-AC6/PartParam.cs
@@ -340,7 +340,7 @@ namespace SoulsFormats
             /// </summary>
             [MSBParamReference(ParamName = "PartsDrawParam")]
             [IgnoreProperty]
-            public short PartsDrawParamID { get; set; }
+            public ushort PartsDrawParamID { get; set; }
 
             /// <summary>
             /// Unknown.

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/MSB/MSB-AC6/PartParam.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/MSB/MSB-AC6/PartParam.cs
@@ -577,7 +577,7 @@ namespace SoulsFormats
                 UnkE05 = br.ReadByte();
                 UnkE06 = br.ReadByte();
                 UnkE07 = br.ReadByte();
-                PartsDrawParamID = br.ReadInt16();
+                PartsDrawParamID = br.ReadUInt16();
                 IsPointLightShadowSrc = br.ReadSByte();
                 UnkE0B = br.ReadByte();
                 IsShadowSrc = br.ReadBoolean();
@@ -781,7 +781,7 @@ namespace SoulsFormats
                 bw.WriteByte(UnkE05);
                 bw.WriteByte(UnkE06);
                 bw.WriteByte(UnkE07);
-                bw.WriteInt16(PartsDrawParamID);
+                bw.WriteUInt16(PartsDrawParamID);
                 bw.WriteSByte(IsPointLightShadowSrc);
                 bw.WriteByte(UnkE0B);
                 bw.WriteBoolean(IsShadowSrc);

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/PartsParam.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/PartsParam.cs
@@ -514,7 +514,7 @@ namespace SoulsFormats
                 br.AssertByte(0);
                 br.AssertByte(0);
                 br.AssertByte(0); // Former lantern ID
-                PartsDrawParamID = br.ReadInt16();
+                PartsDrawParamID = br.ReadUInt16();
                 IsPointLightShadowSrc = br.ReadSByte(); // Seems to be 0 or -1
                 UnkE0B = br.ReadByte();
                 IsShadowSrc = br.ReadBoolean();
@@ -706,7 +706,7 @@ namespace SoulsFormats
                 bw.WriteByte(0);
                 bw.WriteByte(0);
                 bw.WriteByte(0);
-                bw.WriteInt16(PartsDrawParamID);
+                bw.WriteUInt16(PartsDrawParamID);
                 bw.WriteSByte(IsPointLightShadowSrc);
                 bw.WriteByte(UnkE0B);
                 bw.WriteBoolean(IsShadowSrc);

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/PartsParam.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/PartsParam.cs
@@ -250,7 +250,7 @@ namespace SoulsFormats
             /// </summary>
             [MSBParamReference(ParamName = "PartsDrawParam")]
             [IgnoreProperty]
-            public short PartsDrawParamID { get; set; }
+            public ushort PartsDrawParamID { get; set; }
 
             /// <summary>
             /// Unknown.


### PR DESCRIPTION
With "short", things in Castle Ensis show PartsDrawParamID -25516 which is actually 40020 as ushort (the correct value).