### PR TITLE
Allow reordering param rows and fields in GUI

### DIFF
--- a/src/StudioCore/Configuration/CFG.cs
+++ b/src/StudioCore/Configuration/CFG.cs
@@ -477,6 +477,7 @@ public class CFG
     public bool Param_UseProjectMeta = false;
 
     public bool Param_AdvancedMassedit = false;
+    public bool Param_AllowRowReorder = false;
     public bool Param_AllowFieldReorder = true;
     public bool Param_AlphabeticalParams = true;
     public bool Param_DisableLineWrapping = false;

--- a/src/StudioCore/Editor/EditorDecorations.cs
+++ b/src/StudioCore/Editor/EditorDecorations.cs
@@ -1204,6 +1204,23 @@ public class EditorDecorations
             sourceListToModify[indexOfPin + 1] = currentElement;
         }
     }
+    
+    public static void ListReorderOptions<T>(List<T> sourceListToModify, T currentElement, int index = -1)
+    {
+        if (index == -1) index = sourceListToModify.IndexOf(currentElement);
+        if (index > 0 && ImGui.Selectable("Move up"))
+        {
+            T prevKey = sourceListToModify[index - 1];
+            sourceListToModify[index] = prevKey;
+            sourceListToModify[index - 1] = currentElement;
+        }
+        if (index >= 0 && index < sourceListToModify.Count - 1 && ImGui.Selectable("Move down"))
+        {
+            T nextKey = sourceListToModify[index + 1];
+            sourceListToModify[index] = nextKey;
+            sourceListToModify[index + 1] = currentElement;
+        }
+    }
 
     /// <summary>
     ///     Displays information about the provided property.

--- a/src/StudioCore/Editors/ParamEditor/ParamMeta.cs
+++ b/src/StudioCore/Editors/ParamEditor/ParamMeta.cs
@@ -128,6 +128,18 @@ public class ParamMetaData
                 }
             }
 
+            XmlAttribute AltRowOrd = self.Attributes["AlternateRowOrder"];
+            if (AltRowOrd != null)
+            {
+                AlternateRowOrder = new List<string>(AltRowOrd.InnerText.Replace("\n", "")
+                    .Split(',', StringSplitOptions.RemoveEmptyEntries));
+
+                for (var i = 0; i < AlternateRowOrder.Count; i++)
+                {
+                    AlternateRowOrder[i] = AlternateRowOrder[i].Trim();
+                }
+            }
+
             XmlAttribute CCD = self.Attributes["CalcCorrectDef"];
             if (CCD != null)
             {
@@ -222,6 +234,11 @@ public class ParamMetaData
     ///     Provides a reordering of fields for display purposes only
     /// </summary>
     public List<string> AlternateOrder { get; set; }
+    
+    /// <summary>
+    ///     Provides a reordering of rows for display purposes only
+    /// </summary>
+    public List<string> AlternateRowOrder { get; set; }
 
     /// <summary>
     ///     Provides a set of fields the define a CalcCorrectGraph
@@ -366,6 +383,7 @@ public class ParamMetaData
         SetIntXmlProperty("FixedOffset", FixedOffset, _xml, "PARAMMETA", "Self");
         SetBoolXmlProperty("Row0Dummy", Row0Dummy, _xml, "PARAMMETA", "Self");
         SetStringListXmlProperty("AlternativeOrder", AlternateOrder, x => x, "-,", _xml, "PARAMMETA", "Self");
+        SetStringListXmlProperty("AlternateRowOrder", AlternateRowOrder, x => x, "-,", _xml, "PARAMMETA", "Self");
         SetStringXmlProperty("CalcCorrectDef", CalcCorrectDef?.getStringForm(), false, _xml, "PARAMMETA", "Self");
         SetStringXmlProperty("SoulCostDef", SoulCostDef?.getStringForm(), false, _xml, "PARAMMETA", "Self");
     }

--- a/src/StudioCore/Interface/Settings/ParamEditorTab.cs
+++ b/src/StudioCore/Interface/Settings/ParamEditorTab.cs
@@ -62,6 +62,9 @@ public class ParamEditorTab
 
             ImGui.Checkbox("Disable row grouping", ref CFG.Current.Param_DisableRowGrouping);
             ImguiUtils.ShowHoverTooltip("Disable the grouping of connected rows in certain params, such as ItemLotParam within the Row View list.");
+
+            ImGui.Checkbox("Allow row reordering", ref CFG.Current.Param_AllowRowReorder);
+            ImguiUtils.ShowHoverTooltip("Allow the row order to be changed by an alternative order as defined within the Paramdex META file.");
         }
 
         // Fields


### PR DESCRIPTION
- Adds the ability to reorder param rows (disabled by default)
- Adds GUI for reordering param rows & fields while in Editor Mode via context menus

The ability to reorder param *fields* already existed, using the attribute `AlternativeOrder` in paramdex meta files, and was gated behind the option `Param_AllowFieldReorder`. I used that same model to allow the reordering of rows, going off of their ID. There was, however, no GUI available for editing these orderings. I implemented that using roughly the same code that pin ordering uses, but with some extra consideration for separators. 

Tested working with DS1 and Elden Ring params.

Potential concerns:
- Some params have a shared paramdex file (e.g. the AtkParams in DS1) which means they also share the ordering of rows (this was already an issue, but is magnified by exposing the ability to reorder in UI)
- Due to the number of rows in some param files, the XML for row ordering can get unwieldy
- Some params have padding fields, which are hidden by default even in Editor Mode. This means moving a field up or down can have no apparent effect if it swaps places with a padding field
- Due to the way they're placed not really making sense when rows aren't sorted by ID, separators in the rows view aren't shown while row reordering is enabled
- When searching fields or rows, moving them up or down can potentially have no apparent effect (this was already true for moving pinned rows and fields, though)
- "Tools->Sort Rows" seems to do nothing while row reordering is enabled, because row reordering preempts any other ordering