### PR TITLE
A few general resource and editor fixes

### DIFF
--- a/Documentation/smithbox.txt
+++ b/Documentation/smithbox.txt
@@ -40,7 +40,6 @@ Map Editor:
  - ADD: global prop edit
  
  - FIX: asset browser entity change not properly changing Instance ID and Self Parts
- - FIX: DS2 Map Pieces aren't loaded/displayed.
  - FIX: duping assets to new map and then pressing X to bring to camera results in incorrect placement
  
 Model Editor:  

--- a/src/StudioCore/DebugPrimitives/DbgPrimWireSphereForwardUp.cs
+++ b/src/StudioCore/DebugPrimitives/DbgPrimWireSphereForwardUp.cs
@@ -1,0 +1,102 @@
+﻿using StudioCore.Scene;
+using System;
+using System.Drawing;
+using System.Numerics;
+
+namespace StudioCore.DebugPrimitives
+{
+    public class DbgPrimWireSphereForwardUp : DbgPrimWire
+    {
+        private static readonly DbgPrimGeometryData GeometryData = null;
+        
+        public DbgPrimWireSphereForwardUp(Transform location, float radius, Color color, Color forwardColor, 
+            Color upColor, int numVerticalSegments = 11, int numSidesPerSegment = 12)
+        {
+            NameColor = color;
+
+            if (GeometryData != null)
+            {
+                SetBuffers(GeometryData.GeomBuffer);
+            }
+            else
+            {
+                Vector3 topPoint = Vector3.UnitY * radius;
+                Vector3 bottomPoint = -Vector3.UnitY * radius;
+                var points = new Vector3[numVerticalSegments, numSidesPerSegment];
+
+                for (var i = 0; i < numVerticalSegments; i++)
+                {
+                    for (var j = 0; j < numSidesPerSegment; j++)
+                    {
+                        var horizontalAngle = 1.0f * j / numSidesPerSegment * Utils.Pi * 2.0f;
+                        var verticalAngle = (1.0f * (i + 1) / (numVerticalSegments + 1) * Utils.Pi) - Utils.PiOver2;
+                        var altitude = (float)Math.Sin(verticalAngle);
+                        var horizontalDist = (float)Math.Cos(verticalAngle);
+                        points[i, j] = new Vector3((float)Math.Cos(horizontalAngle) * horizontalDist, altitude,
+                            (float)Math.Sin(horizontalAngle) * horizontalDist) * radius;
+                    }
+                }
+
+                for (var i = 0; i < numVerticalSegments; i++)
+                {
+                    for (var j = 0; j < numSidesPerSegment; j++)
+                    {
+                        // On the bottom, we must connect each to the bottom point
+                        if (i == 0)
+                        {
+                            AddLine(points[i, j], bottomPoint, color);
+                        }
+
+                        // On the top, we must connect each point to the top
+                        // Note: this isn't "else if" because with 2 segments, 
+                        // these are both true for the only ring
+                        if (i == numVerticalSegments - 1)
+                        {
+                            AddLine(points[i, j], topPoint, color);
+                        }
+
+                        // Make vertical lines that connect from this 
+                        // horizontal ring to the one above
+                        // Since we are connecting 
+                        // (current) -> (the one above current)
+                        // we dont need to do this for the very last one.
+                        if (i < numVerticalSegments - 1)
+                        {
+                            AddLine(points[i, j], points[i + 1, j], color);
+                        }
+
+
+                        // Make lines that connect points horizontally
+                        //---- if we reach end, we must wrap around, 
+                        //---- otherwise, simply make line to next one
+                        if (j == numSidesPerSegment - 1)
+                        {
+                            AddLine(points[i, j], points[i, 0], color);
+                        }
+                        else
+                        {
+                            AddLine(points[i, j], points[i, j + 1], color);
+                        }
+                    }
+                }
+
+                float m = 1.5f*radius;
+                AddLine(Vector3.Zero, Vector3.UnitX*m, forwardColor);
+                AddLine(Vector3.UnitX*m, new Vector3(1-0.2f, +0.2f, 0)*m, forwardColor);
+                AddLine(Vector3.UnitX*m, new Vector3(1-0.2f, -0.2f, 0)*m, forwardColor);
+                AddLine(Vector3.UnitX*m, new Vector3(1-0.2f, 0, +0.2f)*m, forwardColor);
+                AddLine(Vector3.UnitX*m, new Vector3(1-0.2f, 0, -0.2f)*m, forwardColor);
+                AddLine(Vector3.Zero, Vector3.UnitY*m, upColor);
+                AddLine(Vector3.UnitY*m, new Vector3(0, 1-0.2f, +0.2f)*m, upColor);
+                AddLine(Vector3.UnitY*m, new Vector3(0, 1-0.2f, -0.2f)*m, upColor);
+                AddLine(Vector3.UnitY*m, new Vector3(+0.2f, 1-0.2f, 0f)*m, upColor);
+                AddLine(Vector3.UnitY*m, new Vector3(-0.2f, 1-0.2f, 0f)*m, upColor);
+
+                Renderer.AddBackgroundUploadTask((d, cl) =>
+                {
+                    UpdatePerFrameResources(d, cl, null);
+                });
+            }
+        }
+    }
+}

--- a/src/StudioCore/Editors/MapEditor/Entity.cs
+++ b/src/StudioCore/Editors/MapEditor/Entity.cs
@@ -831,25 +831,50 @@ public class Entity : ISelectable, IDisposable
             var rx = GetPropertyValue("RotationX");
             var ry = GetPropertyValue("RotationY");
             var rz = GetPropertyValue("RotationZ");
-            Vector3 r = Vector3.Zero;
-            if (rx != null)
+            if (rx == null && ry == null && rz == null)
             {
-                r.X = (float)rx;
-            }
+                var forwardN = (Vector3?)GetPropertyValue("Forward");
+                var upwardN = (Vector3?)GetPropertyValue("Upward");
+                if (forwardN == null)
+                {
+                    t.EulerRotation = Vector3.Zero;
+                }
+                else
+                {
+                    var look = Vector3.Normalize(forwardN.Value);
+                    var up = Vector3.Normalize(upwardN ?? Vector3.UnitZ);
+                    var right = Vector3.Normalize(Vector3.Cross(look, up));
 
-            if (ry != null)
+                    t.EulerRotationXZY = EulerUtils.MatrixToEulerXZY(new(
+                        look.X, look.Y, look.Z, 1f,
+                        up.X, up.Y, up.Z, 1f,
+                        right.X, right.Y, right.Z, 1f,
+                        1f, 1f, 1f, 1f
+                    ));
+                }
+            }
+            else
             {
-                r.Y = (float)ry +
-                      180.0f; // According to Vawser, DS2 enemies are flipped 180 relative to map rotations
-            }
+                Vector3 r = Vector3.Zero;
+                if (rx != null)
+                {
+                    r.X = (float)rx;
+                }
 
-            if (rz != null)
-            {
-                r.Z = (float)rz;
-            }
+                if (ry != null)
+                {
+                    r.Y = (float)ry +
+                          180.0f; // According to Vawser, DS2 enemies are flipped 180 relative to map rotations
+                }
 
-            t.EulerRotation = new Vector3(Utils.DegToRadians(r.X), Utils.DegToRadians(r.Y),
-                Utils.DegToRadians(r.Z));
+                if (rz != null)
+                {
+                    r.Z = (float)rz;
+                }
+
+                t.EulerRotation = new Vector3(Utils.DegToRadians(r.X), Utils.DegToRadians(r.Y),
+                    Utils.DegToRadians(r.Z));
+            }
         }
 
         var scale = GetPropertyValue("Scale");

--- a/src/StudioCore/Editors/MapEditor/Universe.cs
+++ b/src/StudioCore/Editors/MapEditor/Universe.cs
@@ -301,7 +301,7 @@ public class Universe
 
     public RenderableProxy GetDummyPolyDrawable(ObjectContainer map, Entity obj)
     {
-        DebugPrimitiveRenderableProxy mesh = DebugPrimitiveRenderableProxy.GetDummyPolyRegionProxy(_renderScene);
+        DebugPrimitiveRenderableProxy mesh = DebugPrimitiveRenderableProxy.GetDummyPolyForwardUpProxy(_renderScene);
         mesh.World = obj.GetWorldMatrix();
         obj.RenderSceneMesh = mesh;
         mesh.SetSelectable(obj);

--- a/src/StudioCore/Editors/ModelEditor/ModelEditorScreen.cs
+++ b/src/StudioCore/Editors/ModelEditor/ModelEditorScreen.cs
@@ -555,9 +555,10 @@ public class ModelEditorScreen : EditorScreen
             ToolWindow.OnProjectChanged();
             ToolSubMenu.OnProjectChanged();
             ActionSubMenu.OnProjectChanged();
+            ViewportHandler.OnProjectChanged();
         }
 
-        ResourceHandler.CurrentFLVERInfo = null;
+        ResourceHandler.OnProjectChange();
         _universe.UnloadAll(true);
     }
 

--- a/src/StudioCore/Editors/ModelEditor/ModelResourceHandler.cs
+++ b/src/StudioCore/Editors/ModelEditor/ModelResourceHandler.cs
@@ -1,6 +1,7 @@
 ﻿using DotNext;
 using HKLib.hk2018;
 using HKLib.Serialization.hk2018.Binary;
+using Microsoft.Extensions.Logging;
 using SoulsFormats;
 using StudioCore.Core;
 using StudioCore.Gui;
@@ -42,10 +43,6 @@ namespace StudioCore.Editors.ModelEditor
         /// <param name="name"></param>
         public void LoadLooseFLVER(string name, string loosePath)
         {
-            Screen.EditorActionManager.Clear();
-            Screen.ModelHierarchy.ResetSelection();
-            Screen.ModelHierarchy.ResetMultiSelection();
-            Screen._selection.ClearSelection();
 
             CurrentFLVERInfo = new FlverModelInfo(name, loosePath);
 
@@ -753,6 +750,21 @@ namespace StudioCore.Editors.ModelEditor
         public void OnResourceUnloaded(IResourceHandle handle, int tag)
         {
             Screen.ViewportHandler.OnResourceUnloaded(handle, tag);
+        }
+
+        public void OnProjectChange()
+        {
+            if (_loadingTask != null)
+            {
+                TaskLogs.AddLog(
+                    "ModelResourceHandler loadingTask was not null during project switch. This may cause unexpected behavior.",
+                    LogLevel.Warning);
+            }
+            CurrentFLVERInfo = null;
+            CurrentFLVER = null;
+            ER_CollisionLow = null;
+            ER_CollisionHigh = null;
+            VirtualResourcePath = "";
         }
     }
 }

--- a/src/StudioCore/Editors/ModelEditor/ModelViewportHandler.cs
+++ b/src/StudioCore/Editors/ModelEditor/ModelViewportHandler.cs
@@ -710,5 +710,16 @@ namespace StudioCore.Editors.ModelEditor
 
             return false;
         }
+
+        public void OnProjectChanged()
+        {
+            ContainerID = "";
+            Screen._universe.UnloadModels(true);
+            _flverhandle?.Unload();
+            _flverhandle = null;
+            _renderMesh?.Dispose();
+            _renderMesh = null;
+            
+        }
     }
 }

--- a/src/StudioCore/Locators/ModelLocator.cs
+++ b/src/StudioCore/Locators/ModelLocator.cs
@@ -57,7 +57,7 @@ public static class ModelLocator
         ret.AssetName = model;
         if (Smithbox.ProjectType == ProjectType.DS2S || Smithbox.ProjectType == ProjectType.DS2)
         {
-            ret.AssetArchiveVirtualPath = $@"map/{mapid}/model/";
+            ret.AssetArchiveVirtualPath = $@"map/{mapid}/model";
             ret.AssetVirtualPath = $@"map/{mapid}/model/{model}.flv.dcx";
         }
         else

--- a/src/StudioCore/Resource/RefCount.cs
+++ b/src/StudioCore/Resource/RefCount.cs
@@ -1,0 +1,72 @@
+﻿using DotNext.Threading;
+using System;
+
+namespace StudioCore.Resource
+{
+    /// <summary>
+    /// A refcounted wrapper around a value. When passing a RefCount, the caller must call Ref().
+    /// Otherwise, a RefCount must be treated like any other IDisposable. When the ref count reaches 0,
+    /// the contained value is automatically disposed if it implements IDisposable.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <typeparam name="T"></typeparam>
+    public class RefCount<T>(T value) : IDisposable
+    {
+        /// <summary>
+        /// The value contained by this RefCount.
+        /// </summary>
+        public readonly T Value = value;
+
+        internal bool isValid = true;
+        internal int Refs = 1;
+
+        /// <summary>
+        /// Increments the ref count.
+        /// </summary>
+        /// <returns></returns>
+        public virtual RefCount<T> Ref()
+        {
+            Refs.IncrementAndGet();
+            return this;
+        }
+
+        /// <summary>
+        /// Determines whether this RefCount is still valid - i.e., true if the contained value has not been
+        /// disposed yet. In threaded or async environments, the returned value may immediately be out of date.
+        /// </summary>
+        /// <returns></returns>
+        public bool IsValid => isValid;
+        
+        /// <summary>
+        /// Decrements the ref count, disposing the contained value if the new count is 0.
+        /// </summary>
+        public virtual void Dispose()
+        {
+            var r = Refs.DecrementAndGet();
+            if (r == 0)
+            {
+                isValid = false;
+                if (Value is IDisposable d) d.Dispose();
+            }
+        }
+    }
+
+    /// <summary>
+    /// A RefCount that has a parent resource. The parent resource is automatically disposed along with the
+    /// contained value when the ref count reaches 0.
+    /// </summary>
+    /// <param name="parent"></param>
+    /// <param name="c"></param>
+    /// <typeparam name="Parent"></typeparam>
+    /// <typeparam name="Child"></typeparam>
+    public class ChildResource<Parent, Child>(IDisposable parent, Child c) : RefCount<Child>(c)
+    {
+        public readonly IDisposable ParentRef = parent;
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            if (Refs == 0) ParentRef.Dispose();
+        }
+    }
+}

--- a/src/StudioCore/Resource/ResourceLoadPipeline.cs
+++ b/src/StudioCore/Resource/ResourceLoadPipeline.cs
@@ -8,7 +8,7 @@ namespace StudioCore.Resource;
 
 public readonly record struct LoadByteResourceRequest(
     string VirtualPath,
-    Memory<byte> Data,
+    RefCount<Memory<byte>> Data,
     AccessLevel AccessLevel);
 
 public readonly record struct LoadFileResourceRequest(
@@ -58,7 +58,7 @@ public class ResourceLoadPipeline<T> : IResourceLoadPipeline where T : class, IR
             var res = new T();
 
             // PIPELINE: Load the byte resource (as the <T> type)
-            var success = res._Load(r.Data, r.AccessLevel, r.VirtualPath);
+            var success = res._Load(r.Data.Value, r.AccessLevel, r.VirtualPath);
 
             // PIPELINE: If resource is loaded successful, add reply to Loaded Resource block
             if (success)
@@ -67,6 +67,8 @@ public class ResourceLoadPipeline<T> : IResourceLoadPipeline where T : class, IR
 
                 _loadedResources.Post(request);
             }
+            
+            r.Data.Dispose();
         }, options);
 
         // PIPELINE: File Requests

--- a/src/StudioCore/Scene/RenderableProxy.cs
+++ b/src/StudioCore/Scene/RenderableProxy.cs
@@ -924,6 +924,7 @@ public class DebugPrimitiveRenderableProxy : RenderableProxy
     private static DbgPrimWireSphere? _regionSphere;
     private static DbgPrimWireSphere? _regionPoint;
     private static DbgPrimWireSphere? _dmyPoint;
+    private static DbgPrimWireSphereForwardUp? _dmySphereFwdUp;
     private static DbgPrimWireSphere? _jointSphere;
     private static DbgPrimWireSpheroidWithArrow? _modelMarkerChr;
     private static DbgPrimWireWallBox? _modelMarkerObj;
@@ -1367,6 +1368,7 @@ public class DebugPrimitiveRenderableProxy : RenderableProxy
         _regionSphere = new DbgPrimWireSphere(Transform.Default, 1.0f, Color.Blue);
         _regionPoint = new DbgPrimWireSphere(Transform.Default, 1.0f, Color.Yellow, 1, 4);
         _dmyPoint = new DbgPrimWireSphere(Transform.Default, 0.05f, Color.Yellow, 1, 4);
+        _dmySphereFwdUp = new DbgPrimWireSphereForwardUp(Transform.Default, 0.05f, Color.Yellow, Color.Blue, Color.White, 1, 4);
         _jointSphere = new DbgPrimWireSphere(Transform.Default, 0.05f, Color.Blue, 6, 6);
         _modelMarkerChr = new DbgPrimWireSpheroidWithArrow(Transform.Default, .9f, Color.Firebrick, 4, 10, true);
         _modelMarkerObj = new DbgPrimWireWallBox(Transform.Default, new Vector3(-1.5f, 0.0f, -0.75f),
@@ -1424,6 +1426,14 @@ public class DebugPrimitiveRenderableProxy : RenderableProxy
     public static DebugPrimitiveRenderableProxy GetDummyPolyRegionProxy(RenderScene scene)
     {
         DebugPrimitiveRenderableProxy r = new(scene.OverlayRenderables, _dmyPoint);
+        r.BaseColor = GetRenderableColor(CFG.Current.GFX_Renderable_DummyPoly_BaseColor);
+        r.HighlightedColor = GetRenderableColor(CFG.Current.GFX_Renderable_DummyPoly_HighlightColor);
+        return r;
+    }
+
+    public static DebugPrimitiveRenderableProxy GetDummyPolyForwardUpProxy(RenderScene scene)
+    {
+        DebugPrimitiveRenderableProxy r = new(scene.OpaqueRenderables, _dmySphereFwdUp);
         r.BaseColor = GetRenderableColor(CFG.Current.GFX_Renderable_DummyPoly_BaseColor);
         r.HighlightedColor = GetRenderableColor(CFG.Current.GFX_Renderable_DummyPoly_HighlightColor);
         return r;


### PR DESCRIPTION
- The `ResourceManager` pipeline now uses a ref counted wrapper around `BinderReader`s to avoid disposing them too early
- The model editor now cleans up a few leftover resources it previously didn't when loading a new project
- DS2 map pieces now load
- Dummy polys in the model editor now rotate according to their forward and up fields
- Dummy polys in the model editor now have arrows showing the directions of the forward and up vectors