### PR TITLE
Add a warning when PTDE_Collision_Root is empty, plus some bug fixes

### DIFF
--- a/src/StudioCore/Configuration/CFG.cs
+++ b/src/StudioCore/Configuration/CFG.cs
@@ -57,6 +57,7 @@ public class CFG
     //**************
     public bool Project_LoadRecentProjectImmediately = false;
     public string PTDE_Collision_Root = "";
+    public bool PTDE_Collision_Root_Warning = true;
 
     //**************
     // Interface

--- a/src/StudioCore/Core/ProjectHandler.cs
+++ b/src/StudioCore/Core/ProjectHandler.cs
@@ -104,6 +104,7 @@ public class ProjectHandler
 
         SetGameRootPrompt(CurrentProject);
         CheckUnpackedState(CurrentProject);
+        CheckPtdeCollisionRoot(CurrentProject);
 
         // Only proceed if dll are found
         if (!CheckDecompressionDLLs(CurrentProject))
@@ -296,6 +297,27 @@ public class ProjectHandler
             TaskLogs.AddLog(
                 $"The files for {targetProject.Config.GameType} do not appear to be fully unpacked. Functionality will be limited. Please use UXM selective unpacker to unpack game files",
                 LogLevel.Warning);
+        }
+    }
+
+    /// <summary>
+    /// When loading a DS1R project, displays a warning if PTDE_Collision_Root is not set or if the directory it points
+    /// to does not exist.
+    /// </summary>
+    /// <param name="targetProject"></param>
+    public void CheckPtdeCollisionRoot(Project targetProject)
+    {
+        if (targetProject.Config.GameType is not ProjectType.DS1R)
+            return;
+
+        if (CFG.Current.PTDE_Collision_Root == "" && CFG.Current.PTDE_Collision_Root_Warning)
+        {
+            TaskLogs.AddLog("No directory is set for Dark Souls 1 collision files. No collision functionality will be available. You can set the directory or disable this warning under Project Status in settings.",
+                LogLevel.Warning, TaskLogs.LogPriority.High);
+        } 
+        else if (!Directory.Exists(CFG.Current.PTDE_Collision_Root))
+        {
+            TaskLogs.AddLog("The set Dark Souls 1 collision directory does not exist.", LogLevel.Warning);
         }
     }
 

--- a/src/StudioCore/Editors/MapEditor/Entity.cs
+++ b/src/StudioCore/Editors/MapEditor/Entity.cs
@@ -387,7 +387,19 @@ public class Entity : ISelectable, IDisposable
             if (sourceProperty.PropertyType.IsArray)
             {
                 var arr = (Array)sourceProperty.GetValue(obj);
-                Array.Copy(arr, (Array)targetProperty.GetValue(clone), arr.Length);
+                var elemType = sourceProperty.PropertyType.GetElementType();
+                var target = (Array)targetProperty.GetValue(clone);
+                if (elemType.IsClass && elemType != typeof(string))
+                {
+                    for (int i = 0; i < arr.Length; i++)
+                    {
+                        target.SetValue(DeepCopyObject(arr.GetValue(i)), i);
+                    }
+                }
+                else
+                {
+                    Array.Copy(arr, target, arr.Length);
+                }
             }
             else if (sourceProperty.CanWrite)
             {

--- a/src/StudioCore/Editors/MapEditor/Universe.cs
+++ b/src/StudioCore/Editors/MapEditor/Universe.cs
@@ -377,6 +377,8 @@ public class Universe
             asset = ModelLocator.GetMapCollisionModel(amapid,
                 ModelLocator.MapModelNameToAssetName(amapid, modelname), false);
 
+            if (asset == null || asset.AssetPath == null) loadcol = false;
+
             filt = RenderFilter.Collision;
         }
         else if (modelname.ToLower().StartsWith("n"))

--- a/src/StudioCore/Editors/MapEditor/ViewportAction.cs
+++ b/src/StudioCore/Editors/MapEditor/ViewportAction.cs
@@ -249,7 +249,7 @@ public class MultipleEntityPropertyChangeAction : ViewportAction
         ChangedEnts = changedEnts;
         foreach (Entity o in changedEnts)
         {
-            var propObj = PropFinderUtil.FindPropertyObject(prop, o.WrappedObject, classIndex, false);
+            var propObj = PropFinderUtil.FindPropertyObject(prop, o.WrappedObject, index, classIndex, false);
             if (propObj != null)
             {
                 var change = new PropertyChange

--- a/src/StudioCore/Interface/Tabs/ProjectStatusTab.cs
+++ b/src/StudioCore/Interface/Tabs/ProjectStatusTab.cs
@@ -45,7 +45,7 @@ public class ProjectStatusTab
 
             if(Smithbox.ProjectType is ProjectType.DS1R)
             {
-                ImGui.Text($"Project Collision Directory: {CFG.Current.PTDE_Collision_Root}");
+                ImGui.Text($"Project DS1 Collision Directory: {CFG.Current.PTDE_Collision_Root}");
                 ImGui.SameLine();
                 if (ImGui.Button($@"{ForkAwesome.FileO}##collisionDirPicker"))
                 {
@@ -57,6 +57,11 @@ public class ProjectStatusTab
                     }
                 }
                 ImguiUtils.ShowHoverTooltip("When set this will allow collisions to be visible whilst editing Dark Souls: Remastered maps, assuming you have unpacked Dark Souls: Prepare the Die Edition.");
+                var warning = CFG.Current.PTDE_Collision_Root_Warning;
+                if (ImGui.Checkbox("Warning for Missing Collision Directory", ref warning))
+                    CFG.Current.PTDE_Collision_Root_Warning = warning;
+                ImguiUtils.ShowHoverTooltip("When set to true, a warning will be displayed when loading Dark Souls: Remastered projects if the DS1 collision directory is not set.");
+
             }
 
             ImGui.Separator();

--- a/src/StudioCore/Utilities/PropFinderUtil.cs
+++ b/src/StudioCore/Utilities/PropFinderUtil.cs
@@ -24,7 +24,7 @@ public static class PropFinderUtil
     /// <param name="onlyCheckPropName">If true, search only checks property name. Otherwise, it checks unique MetadataToken.</param>
     /// <returns>PropData that has the property if found, otherwise null.</returns>
     /// <summary>
-    private static PropData? GetPropData(PropertyInfo prop, object obj, int classIndex = -1, bool onlyCheckPropName = false)
+    private static PropData? GetPropData(PropertyInfo prop, object obj, int arrayIndex = -1, int classIndex = -1, bool onlyCheckPropName = false)
     {
         foreach (PropertyInfo p in obj.GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public))
         {
@@ -44,7 +44,7 @@ public static class PropFinderUtil
 
             if (p.PropertyType.IsNested)
             {
-                var retObj = GetPropData(prop, p.GetValue(obj), classIndex);
+                var retObj = GetPropData(prop, p.GetValue(obj), arrayIndex, classIndex);
                 if (retObj != null)
                     return retObj;
             }
@@ -54,9 +54,16 @@ public static class PropFinderUtil
                 if (pType.IsNested)
                 {
                     var array = (Array)p.GetValue(obj);
-                    if (classIndex != -1)
+                    if (arrayIndex != -1)
                     {
-                        var retObj = GetPropData(prop, array.GetValue(classIndex), classIndex);
+                        var retObj = GetPropData(prop, array.GetValue(arrayIndex), arrayIndex, classIndex);
+                        if (retObj != null)
+                            return retObj;
+                        
+                    }
+                    else if (classIndex != -1)
+                    {
+                        var retObj = GetPropData(prop, array.GetValue(classIndex), arrayIndex, classIndex);
                         if (retObj != null)
                             return retObj;
                     }
@@ -64,7 +71,7 @@ public static class PropFinderUtil
                     {
                         foreach (var arrayObj in array)
                         {
-                            var retObj = GetPropData(prop, arrayObj, classIndex);
+                            var retObj = GetPropData(prop, arrayObj, arrayIndex, classIndex);
                             if (retObj != null)
                                 return retObj;
                         }
@@ -129,9 +136,9 @@ public static class PropFinderUtil
     ///     Searches an object to find exactly which object contains the property.
     /// </summary>
     /// <returns>Object containing property if found, otherwise null.</returns>
-    public static object? FindPropertyObject(PropertyInfo prop, object obj, int classIndex = -1, bool onlyCheckPropName = false)
+    public static object? FindPropertyObject(PropertyInfo prop, object obj, int arrayIndex = -1, int classIndex = -1, bool onlyCheckPropName = false)
     {
-        var result = GetPropData(prop, obj, classIndex, onlyCheckPropName);
+        var result = GetPropData(prop, obj, arrayIndex, classIndex, onlyCheckPropName);
 
         if (result == null)
             return null;
@@ -145,7 +152,7 @@ public static class PropFinderUtil
     /// <returns>Value of the property within given object if found, otherwise null.</returns>
     public static object? FindPropertyValue(PropertyInfo prop, object obj, bool onlyCheckPropName = false)
     {
-        var propData = GetPropData(prop, obj, -1, onlyCheckPropName);
+        var propData = GetPropData(prop, obj, -1, -1, onlyCheckPropName);
 
         if (propData == null)
             return null;


### PR DESCRIPTION
- Add a toggleable warning if, while loading a DS1R project, `PTDE_Collision_Root` is empty
- Add a warning if, while loading a DS1R project,  the directory `PTDE_Collision_Root` points to does not exist
- Fix crash when trying to load DS1R collision but `PTDE_Collision_Root` is empty
- Fix map property editor not handling arrays correctly
- Fix `Entity.DeepCopyObject` shallow-copying objects inside arrays