### PR TITLE
feat: AC6 Paramdex update - Identify and rename AC6 MissionParam field Unk0x124 as missionDebriefingTalk and adding related metadata.

### DIFF
--- a/src/StudioCore/Assets/Paramdex/AC6/Defs/MissionParam.xml
+++ b/src/StudioCore/Assets/Paramdex/AC6/Defs/MissionParam.xml
@@ -84,7 +84,7 @@
     <Field Def="u16 sortId"></Field>
     <Field Def="s32 forcedLoadoutCharaInitParamID"></Field>
     <Field Def="s32 unkMapBoundryEntityId"></Field>
-    <Field Def="s32 Unk0x124"></Field>
+    <Field Def="s32 missionDebriefingTalk"></Field>
     <Field Def="s32 Unk0x128"></Field>
     <Field Def="s32 Unk0x12C"></Field>
     <Field Def="s32 Unk0x130"></Field>

--- a/src/StudioCore/Assets/Paramdex/AC6/Meta/MissionParam.xml
+++ b/src/StudioCore/Assets/Paramdex/AC6/Meta/MissionParam.xml
@@ -92,6 +92,8 @@
     
     <unkMapBoundryEntityId AltName="Map Boundry Entity ID" />
     
+    <missionDebriefingTalk AltName="Mission Debriefing Talk ID" Wiki="The ID of a post-mission debriefing talk sequence to play. This ID, where present, maps to a 80XXXX000 TalkParam ID." />
+    
     <unkEntityId AltName="Entity ID" />
     
     <mapBoundryBottom AltName="Map Boundry Bottom" />


### PR DESCRIPTION
## Description

Identify and rename AC6 MissionParam field `Unk0x124` as `missionDebriefingTalk` and add related metadata.

⚠️**Please note that English is not my first language, so I am open to suggestions for names that might better describe the field in question.**

## Context & Corroborating Evidence

Mission debriefings are talk sequences that play after completing certain Armored Core VI missions.

These debriefings seem to be associated with `80XXXX000` TalkParam sequences, where `XXXX` denotes the value of the `missionDebriefingTalk` MissionParam field, but the mapping may also be represented algebraically as `800000000 + 10000 * missionDebriefingTalk`.

The lack of naked references to `80XXXX000` TalkParam IDs in MQB or ESD files seems to indicate that there's a separate, dedicated command for triggering these sequences, though I've not managed to identify one so far.

Only missions with a missionDebriefingTalk (Unk0x124) seem to play mission debriefings and, as can be seen in the following table, the values and their respective TalkParam IDs seem to line up in all but one case.

|MissionParam ID|MissionParam paramdexName|MissionParam missionDebriefingTalk|TalkParam ID|TalkParam paramdexName|
|------------------|----------------------------------|----------------------------------------|--------------|------------------------------|
|2010|Illegal Entry|2000|802000000|*None* (see notes)|
|2050|Attack the Watchpoint|2010|802010000|"...A friend of mine sent me this observational data."|
|2055|Attack the Watchpoint (ALT)|2010|802010000|"...A friend of mine sent me this observational data."|
|3011|"Steal the Survey Data"|2020|802020000|"Hey, Raven. It's me, Rusty— old buddy from the Vespers."|
|3043|Attack the Old Spaceport|2025|802025000|"Here's the situation, 621."|
|3230|Destroy the Ice Worm|2030|802030000|"The temporary alliance between the Arquebus and groups turned the tide of war..."|
|4030|Reach the Coral Convergence|2040|802040000 |"Arquebus seized control of the Coral..."|
|4100|MIA|2070|802070000 |"We have entered satellite orbit."|
|5010|Take the Uninhabited Floating City|2050|802050000|"How's the view at 8,000 meters, tourist?"|

## Notes:

Although the debriefing for MissionParam ID 2010 (Illegal Entry), maps to an existing TalkParam entry of ID `802000000` spoken by the "Narrator", but all entries in this sequence seem to reference invalid msgId's. Instead the mission seems to be playing a pre-rendered video associated with the 301102200 TalkID sequence ("`"Cora"—a sublime substance.`").

Whether the 802000000 entries indicates a leftover portion of some cut content or is just part of some hacky workaround for the video is unclear at this point. Please note, that the actual 301102200 TalkParam sequence playing under the video does not seem to be associated with any particular naked parameter in an MQB cutscene file or ESD script either.

There might be some additional flag field that could acts as a precondition for the debriefing to play, although I've not managed to identify one yet.

The somewhat related UnkByte0x44 field seems to be a likely candidate, but there's a slight mismatch between its use and that of the proposed missionDebriefingTalk.

UnkByte0x44 seems to be more associated with chapter transitions that sometimes happen to line up with missions with debriefings.