### PR TITLE
Armored Core Oldgen - Face and NormalW fixes

### DIFF
--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER0/Mesh.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER0/Mesh.cs
@@ -159,7 +159,9 @@ namespace SoulsFormats
                         }
                         else
                         {
-                            if (vi1 != vi2 && vi1 != vi3 && vi2 != vi3)
+                            // On a few ACFA skybox models of version 0x12, degenerate faces must be included or faces will get flipped
+                            bool includeDegenerateFaces = version == 0x12;
+                            if (includeDegenerateFaces || (vi1 != vi2 && vi1 != vi3 && vi2 != vi3))
                             {
                                 // Every time the triangle strip restarts, compare the average vertex normal to the face normal
                                 // and flip the starting direction if they're pointing away from each other.

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER0/Mesh.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER0/Mesh.cs
@@ -159,8 +159,9 @@ namespace SoulsFormats
                         }
                         else
                         {
-                            // On a few ACFA skybox models of version 0x12, degenerate faces must be included or faces will get flipped
-                            bool includeDegenerateFaces = version == 0x12;
+                            // On a few ACFA skybox models of version 0x12 and 0x14, degenerate faces must be included or faces will get flipped
+                            // 0x13 is for now assumed to have the same issue
+                            bool includeDegenerateFaces = version >= 0x12 && version <= 0x14;
                             if (includeDegenerateFaces || (vi1 != vi2 && vi1 != vi3 && vi2 != vi3))
                             {
                                 // Every time the triangle strip restarts, compare the average vertex normal to the face normal

--- a/src/StudioCore/Editors/MapEditor/Universe.cs
+++ b/src/StudioCore/Editors/MapEditor/Universe.cs
@@ -366,6 +366,12 @@ public class Universe
             asset = ModelLocator.GetChrModel(modelname, modelname);
             filt = RenderFilter.Character;
         }
+        else if (modelname.StartsWith("e", StringComparison.CurrentCultureIgnoreCase))
+        {
+            loadflver = true;
+            asset = ModelLocator.GetEneModel(modelname);
+            filt = RenderFilter.Character;
+        }
         else if (modelname.StartsWith("o", StringComparison.CurrentCultureIgnoreCase) || modelname.StartsWith("AEG"))
         {
             loadflver = true;


### PR DESCRIPTION
Fixed an issue where triangulation of FLVER0 faces were not including degenerate faces, causing ACFA skyboxes to have odd flipped faces  

Fixed an issue where ene was missing from GetModelDrawable, still unsure if it should just be merged into character loading instead  

Fixed a major issue where almost all enemy models were transforming incorrectly due to a normalW bug in ACFA, ACV, and ACVD. Some ACFA obj models were affected as well.