### PR TITLE
Render group multiselect functionality

### DIFF
--- a/src/StudioCore/Editors/MapEditor/Tools/DisplayGroups/DisplayGroupView.cs
+++ b/src/StudioCore/Editors/MapEditor/Tools/DisplayGroups/DisplayGroupView.cs
@@ -23,6 +23,7 @@ public class DisplayGroupView
     private ViewportSelection Selection;
 
     private int _dispGroupCount = 8;
+    private string _lastHoveredCheckbox;
 
     public readonly HashSet<string> HighlightedGroups = new();
 
@@ -329,6 +330,22 @@ public class DisplayGroupView
                         else
                         {
                             dg.RenderGroups[g] &= ~(1u << i);
+                        }
+                    }
+
+                    if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenBlockedByActiveItem) && ImGui.IsMouseDown(ImGuiMouseButton.Left))
+                    {
+                        if (_lastHoveredCheckbox != cellKey)
+                        {
+                            if (check)
+                            {
+                                dg.RenderGroups[g] &= ~(1u << i);
+                            }
+                            else
+                            {
+                                dg.RenderGroups[g] |= 1u << i;
+                            }
+                            _lastHoveredCheckbox = cellKey;
                         }
                     }
 


### PR DESCRIPTION
The latest public release of Smithbox doesn't support clicking and dragging over multiple render group checkboxes to toggle them. This PR adds support for this functionality, which makes toggling multiple specific render group checkboxes easier.