### PR TITLE
feat: rudimentary speedtree detection

### DIFF
--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/Dummy.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/Dummy.cs
@@ -1,16 +1,6 @@
-﻿using SoulsFormats;
-using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Linq;
+﻿using System.Drawing;
 using System.Numerics;
-using System.Text;
-using System.Text.Json;
-using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 
-// FLVER implementation for Model Editor usage
-// Credit to The12thAvenger
 namespace SoulsFormats
 {
     public partial class FLVER

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER0/BufferLayout.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER0/BufferLayout.cs
@@ -14,6 +14,8 @@ namespace SoulsFormats
             /// </summary>
             public int Size => this.Sum(member => member.Size);
 
+            public BufferLayout() { }
+
             internal BufferLayout(BinaryReaderEx br) : base()
             {
                 short memberCount = br.ReadInt16();

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER0/FLVER0.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER0/FLVER0.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
-using System.IO;
 using System.Numerics;
 
 namespace SoulsFormats
@@ -12,7 +11,7 @@ namespace SoulsFormats
     public partial class FLVER0 : SoulsFile<FLVER0>, IFlver
     {
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-        public FLVERHeader Header { get; set; }
+        public FLVER0Header Header { get; set; }
 
         public List<FLVER.Dummy> Dummies { get; set; }
         IReadOnlyList<FLVER.Dummy> IFlver.Dummies => Dummies;
@@ -48,12 +47,19 @@ namespace SoulsFormats
         /// <returns>A matrix representing the world transform of the bone.</returns>
         public Matrix4x4 ComputeBoneWorldMatrix(int index)
         {
-            var bone = Nodes[index];
-            Matrix4x4 matrix = bone.ComputeLocalTransform();
-            while (bone.ParentIndex != -1)
+            if(index == -1)
             {
-                bone = Nodes[bone.ParentIndex];
-                matrix *= bone.ComputeLocalTransform();
+                return Matrix4x4.Identity;
+            }
+            var bone = Nodes[index];
+            Matrix4x4 matrix = Nodes[index].ComputeLocalTransform();
+            if (bone.ParentIndex != -1)
+            {
+                do
+                {
+                    bone = Nodes[bone.ParentIndex];
+                    matrix *= bone.ComputeLocalTransform();
+                } while (bone.ParentIndex != -1);
             }
 
             return matrix;
@@ -61,7 +67,7 @@ namespace SoulsFormats
 
         protected override void Read(BinaryReaderEx br)
         {
-            Header = new FLVERHeader();
+            Header = new FLVER0Header();
 
             br.AssertASCII("FLVER\0");
             Header.BigEndian = br.AssertASCII(["L\0", "B\0"]) == "B\0";
@@ -110,6 +116,22 @@ namespace SoulsFormats
             Meshes = new List<Mesh>(meshCount);
             for (int i = 0; i < meshCount; i++)
                 Meshes.Add(new Mesh(br, this, dataOffset, Header.Version));
+        }
+
+        /// <summary>
+        /// A hack to try to fix the messed up endianness for some ACFA test FLVER0 values on version 0x11.
+        /// </summary>
+        /// <param name="br">The reader.</param>
+        /// <param name="version">The FLVER version.</param>
+        /// <returns>The read value.</returns>
+        internal static int ReadVarEndianInt32(BinaryReaderEx br, int version)
+        {
+            int value = br.ReadInt32();
+            if (version != 0x11 || !br.BigEndian)
+                return value;
+
+            int leValue = BinaryPrimitives.ReverseEndianness(value);
+            return (int)Math.Min((uint)value, (uint)leValue);
         }
 
         protected override void Write(BinaryWriterEx bw)
@@ -201,57 +223,6 @@ namespace SoulsFormats
         public bool IsSpeedtree()
         {
             return false;
-        }
-
-        /// <summary>
-        /// A hack to try to fix the messed up endianness for some ACFA test FLVER0 values on version 0x11.
-        /// </summary>
-        /// <param name="br">The reader.</param>
-        /// <param name="version">The FLVER version.</param>
-        /// <returns>The read value.</returns>
-        internal static int ReadVarEndianInt32(BinaryReaderEx br, int version)
-        {
-            int value = br.ReadInt32();
-            if (version != 0x11 || !br.BigEndian)
-                return value;
-
-            int leValue = BinaryPrimitives.ReverseEndianness(value);
-            return (int)Math.Min((uint)value, (uint)leValue);
-        }
-
-        public class FLVERHeader
-        {
-            public bool BigEndian { get; set; }
-
-            public int Version { get; set; }
-
-            public Vector3 BoundingBoxMin { get; set; }
-
-            public Vector3 BoundingBoxMax { get; set; }
-
-            public byte VertexIndexSize { get; set; }
-
-            public bool Unicode { get; set; }
-
-            public byte Unk4A { get; set; }
-
-            public byte Unk4B { get; set; }
-
-            public int Unk4C { get; set; }
-
-            public int Unk5C { get; set; }
-
-            public FLVERHeader()
-            {
-                BigEndian = true;
-                Version = 0x14;
-                Unicode = false;
-            }
-
-            public FLVERHeader Clone()
-            {
-                return (FLVERHeader)MemberwiseClone();
-            }
         }
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
     }

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER0/FLVER0.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER0/FLVER0.cs
@@ -198,6 +198,11 @@ namespace SoulsFormats
             bw.FillInt32("DataSize", (int)bw.Position - dataOffset);
         }
 
+        public bool IsSpeedtree()
+        {
+            return false;
+        }
+
         /// <summary>
         /// A hack to try to fix the messed up endianness for some ACFA test FLVER0 values on version 0x11.
         /// </summary>

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER0/FLVER0Header.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER0/FLVER0Header.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SoulsFormats
+{
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+    public class FLVER0Header
+    {
+        public bool BigEndian { get; set; }
+
+        public int Version { get; set; }
+
+        public Vector3 BoundingBoxMin { get; set; }
+
+        public Vector3 BoundingBoxMax { get; set; }
+
+        public byte VertexIndexSize { get; set; }
+
+        public bool Unicode { get; set; }
+
+        public byte Unk4A { get; set; }
+
+        public byte Unk4B { get; set; }
+
+        public int Unk4C { get; set; }
+
+        public int Unk5C { get; set; }
+    }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
+}

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER0/Material.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER0/Material.cs
@@ -1,6 +1,5 @@
 ﻿using System.Buffers.Binary;
 using System.Collections.Generic;
-using System.IO;
 
 namespace SoulsFormats
 {
@@ -17,6 +16,11 @@ namespace SoulsFormats
             IReadOnlyList<IFlverTexture> IFlverMaterial.Textures => Textures;
 
             public List<BufferLayout> Layouts { get; set; }
+
+            public Material()
+            {
+
+            }
 
             internal Material(BinaryReaderEx br, bool useUnicode, int version)
             {

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER0/Mesh.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER0/Mesh.cs
@@ -20,7 +20,7 @@ namespace SoulsFormats
 
             public short DefaultBoneIndex { get; set; }
 
-            public short[] BoneIndices { get; private set; }
+            public short[] BoneIndices { get; set; }
 
             public short Unk46 { get; set; }
 
@@ -30,6 +30,11 @@ namespace SoulsFormats
             IReadOnlyList<FLVER.Vertex> IFlverMesh.Vertices => Vertices;
 
             public int LayoutIndex { get; set; }
+
+            public Mesh()
+            {
+
+            }
 
             internal Mesh(BinaryReaderEx br, FLVER0 flv, int dataOffset, int version)
             {

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER0/Texture.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER0/Texture.cs
@@ -9,6 +9,11 @@
 
             public string Path { get; set; }
 
+            public Texture()
+            {
+
+            }
+
             internal Texture(BinaryReaderEx br, bool useUnicode)
             {
                 int pathOffset = br.ReadInt32();

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER0/VertexBuffer.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER0/VertexBuffer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace SoulsFormats
 {

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/BufferLayout.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/BufferLayout.cs
@@ -1,13 +1,7 @@
-﻿using SoulsFormats;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using static SoulsFormats.FLVER;
 
-// FLVER implementation for Model Editor usage
-// Credit to The12thAvenger
 namespace SoulsFormats
 {
     public partial class FLVER2
@@ -96,7 +90,7 @@ namespace SoulsFormats
                     return false;
                 }
 
-                LayoutMember tangentLayout = new LayoutMember(LayoutType.Byte4C, LayoutSemantic.Tangent, 0, 0);
+                FLVER.LayoutMember tangentLayout = new FLVER.LayoutMember(FLVER.LayoutType.Byte4C, FLVER.LayoutSemantic.Tangent, 0, 0);
                 Insert(normalIndex + 1, tangentLayout);
                 return true;
             }

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/BufferLayout.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/BufferLayout.cs
@@ -18,9 +18,9 @@ namespace SoulsFormats
         public class BufferLayout : List<FLVER.LayoutMember>
         {
             /// <summary>
-            /// The total size of all ValueTypes in this layout.
+            /// The total size of all ValueTypes in this layout. Accounts for Speedtree members which do NOT add to this size.
             /// </summary>
-            public int Size => this.Sum(member => member.Size);
+            public int Size => this.Sum(member => member.SpecialModifier == -32768 ? 0 : member.Size);
 
             /// <summary>
             /// Creates a new empty BufferLayout.

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/EdgeIndexCompression.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/EdgeIndexCompression.cs
@@ -1,0 +1,64 @@
+﻿using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace SoulsFormats
+{
+    public partial class FLVER2
+    {
+        public partial class FaceSet
+        {
+            // This is basically shitcode which makes a lot of dubious assumptions.
+            // If I ever intend to implement edge writing this will require much more investigation.
+            private static class EdgeIndexCompression
+            {
+                [DllImport("EdgeIndexDecompressor.dll")]
+                private static extern void DecompressIndexes_C_Standalone(uint numIndexes, byte[] indexes);
+
+                public static List<int> ReadEdgeIndexGroup(BinaryReaderEx br, int indexCount)
+                {
+                    long start = br.Position;
+                    short memberCount = br.ReadInt16();
+                    br.ReadInt16();
+                    br.ReadInt32();
+                    br.AssertInt32(0);
+                    br.ReadInt32();
+
+                    var indices = new List<int>(indexCount);
+                    for (int i = 0; i < memberCount; i++)
+                    {
+                        int dataLength = br.ReadInt32();
+                        int dataOffset = br.ReadInt32();
+                        br.AssertInt32(0);
+                        br.AssertInt32(0);
+                        br.ReadInt16();
+                        br.ReadInt16();
+                        ushort baseIndex = br.ReadUInt16();
+                        br.ReadInt16();
+                        br.ReadInt32();
+                        br.ReadInt32();
+                        br.AssertInt32(0);
+                        br.AssertInt32(0);
+                        br.AssertInt32(0);
+                        br.AssertInt32(0);
+                        br.ReadInt16();
+                        br.ReadInt16();
+                        br.ReadInt16();
+                        br.ReadInt16();
+                        br.ReadInt16();
+                        ushort memberIndexCount = br.ReadUInt16();
+                        br.AssertInt32(-1);
+
+                        // I feel like one of those fields should be the required buffer size, but none I tried worked
+                        byte[] buffer = new byte[memberIndexCount * 32];
+                        br.GetBytes(start + dataOffset, buffer, 0, dataLength);
+                        DecompressIndexes_C_Standalone(memberIndexCount, buffer);
+                        var brBuffer = new BinaryReaderEx(true, buffer);
+                        for (int j = 0; j < memberIndexCount; j++)
+                            indices.Add(baseIndex + brBuffer.ReadUInt16());
+                    }
+                    return indices;
+                }
+            }
+        }
+    }
+}

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/FLVER2.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/FLVER2.cs
@@ -1,13 +1,8 @@
-﻿using SoulsFormats;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
-using System.Text;
-using System.Threading.Tasks;
 
-// FLVER implementation for Model Editor usage
-// Credit to The12thAvenger
 namespace SoulsFormats
 {
     /// <summary>
@@ -133,7 +128,7 @@ namespace SoulsFormats
             int vertexIndicesSize = br.AssertByte([0, 8, 16, 32]);
             Header.Unicode = br.ReadBoolean();
             Header.Unk4A = br.ReadBoolean();
-            Header.Unk4B = br.ReadBoolean();
+            br.AssertByte(0);
 
             Header.Unk4C = br.ReadInt32();
 
@@ -264,7 +259,7 @@ namespace SoulsFormats
             bw.WriteByte(vertexIndicesSize);
             bw.WriteBoolean(Header.Unicode);
             bw.WriteBoolean(Header.Unk4A);
-            bw.WriteBoolean(Header.Unk4B);
+            bw.WriteByte(0);
 
             bw.WriteInt32(Header.Unk4C);
 
@@ -475,11 +470,6 @@ namespace SoulsFormats
             public bool Unk4A { get; set; }
 
             /// <summary>
-            /// Unknown.
-            /// </summary>
-            public bool Unk4B { get; set; }
-
-            /// <summary>
             /// Unknown; I believe this is the primitive restart constant, but I'm not certain.
             /// </summary>
             public int Unk4C { get; set; }
@@ -498,7 +488,7 @@ namespace SoulsFormats
             /// Unknown.
             /// </summary>
             public short Unk68 { get; set; }
-
+            
             /// <summary>
             /// Used to denote Speedtree if -32768. Doesn't seem to be used for anything else currently.
             /// </summary>

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/FLVER2.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/FLVER2.cs
@@ -148,7 +148,8 @@ namespace SoulsFormats
 
             br.AssertInt32(0);
             br.AssertInt32(0);
-            Header.Unk68 = br.AssertInt32([0, 1, 2, 3, 4]);
+            Header.Unk68 = br.AssertInt16([0, 1, 2, 3, 4, 5]);
+            Header.SpecialModifier = br.AssertInt16([0, -32768]);
             br.AssertInt32(0);
             br.AssertInt32(0);
             Header.Unk74 = br.AssertInt32([0, 0x10]);
@@ -496,7 +497,12 @@ namespace SoulsFormats
             /// <summary>
             /// Unknown.
             /// </summary>
-            public int Unk68 { get; set; }
+            public short Unk68 { get; set; }
+
+            /// <summary>
+            /// Used to denote Speedtree if -32768. Doesn't seem to be used for anything else currently.
+            /// </summary>
+            public short SpecialModifier { get; set; }
 
             /// <summary>
             /// Unknown
@@ -517,6 +523,11 @@ namespace SoulsFormats
             {
                 return (FLVERHeader)MemberwiseClone();
             }
+        }
+
+        public bool IsSpeedtree()
+        {
+            return Header.SpecialModifier == -32768;
         }
     }
 }

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/FaceSet.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/FaceSet.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
-// FLVER implementation for Model Editor usage
-// Credit to The12thAvenger
 namespace SoulsFormats
 {
     public partial class FLVER2

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/GXList.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/GXList.cs
@@ -48,7 +48,12 @@ namespace SoulsFormats
 
                     TerminatorID = br.AssertInt32(id);
                     br.AssertInt32(100);
-                    TerminatorLength = br.ReadInt32() - 0xC;
+                    int lengthSubtraction = 0xC;
+                    if(header.Unk68 == 0x5)
+                    {
+                        lengthSubtraction = 0;
+                    }
+                    TerminatorLength = br.ReadInt32() - lengthSubtraction;
                     br.AssertPattern(TerminatorLength, 0x00);
                 }
             }

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/GXList.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/GXList.cs
@@ -1,12 +1,6 @@
-﻿using SoulsFormats;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-// FLVER implementation for Model Editor usage
-// Credit to The12thAvenger
 namespace SoulsFormats
 {
     public partial class FLVER2

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/Material.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/Material.cs
@@ -1,12 +1,6 @@
-﻿using SoulsFormats;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-// FLVER implementation for Model Editor usage
-// Credit to The12thAvenger
 namespace SoulsFormats
 {
     public partial class FLVER2
@@ -79,7 +73,7 @@ namespace SoulsFormats
                     numStringBytes += texture.Type.Length + 1;
                     numStringBytes += texture.Path.Length + 1;
                 }
-
+                
                 // 2-bytes per character
                 numStringBytes *= 2;
                 return numStringBytes;
@@ -125,7 +119,7 @@ namespace SoulsFormats
                     }
                     GXIndex = gxListIndices[gxOffset];
                 }
-
+                
             }
 
             internal void TakeTextures(Dictionary<int, Texture> textureDict)

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/Mesh.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/Mesh.cs
@@ -1,14 +1,8 @@
-﻿using SoulsFormats;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
-using System.Text;
-using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 
-// FLVER implementation for Model Editor usage
-// Credit to The12thAvenger
 namespace SoulsFormats
 {
     public partial class FLVER2
@@ -24,7 +18,7 @@ namespace SoulsFormats
             /// The mesh is assumed to not be in bind pose and the transform of the bound node is applied to each vertex.
             /// </summary>
             public bool UseBoneWeights { get; set; }
-
+            
             /// <inheritdoc cref="IFlverMesh.Dynamic"/>
             public byte Dynamic => (byte)(UseBoneWeights ? 1 : 0);
 
@@ -96,7 +90,7 @@ namespace SoulsFormats
                 int faceSetOffset = br.ReadInt32();
                 int vertexBufferCount = br.AssertInt32([0, 1, 2, 3]);
                 int vertexBufferOffset = br.ReadInt32();
-
+                
                 if (boundingBoxOffset != 0)
                 {
                     br.StepIn(boundingBoxOffset);
@@ -116,10 +110,10 @@ namespace SoulsFormats
                 FaceSets = new List<FaceSet>(faceSetIndices.Length);
                 foreach (int i in faceSetIndices)
                 {
-                    if (!faceSetDict.TryGetValue(i, out FaceSet value))
+                    if (!faceSetDict.ContainsKey(i))
                         throw new NotSupportedException("Face set not found or already taken: " + i);
 
-                    FaceSets.Add(value);
+                    FaceSets.Add(faceSetDict[i]);
                     faceSetDict.Remove(i);
                 }
                 faceSetIndices = null;
@@ -130,10 +124,10 @@ namespace SoulsFormats
                 VertexBuffers = new List<VertexBuffer>(vertexBufferIndices.Length);
                 foreach (int i in vertexBufferIndices)
                 {
-                    if (!vertexBufferDict.TryGetValue(i, out VertexBuffer value))
+                    if (!vertexBufferDict.ContainsKey(i))
                         throw new NotSupportedException("Vertex buffer not found or already taken: " + i);
 
-                    VertexBuffers.Add(value);
+                    VertexBuffers.Add(vertexBufferDict[i]);
                     vertexBufferDict.Remove(i);
                 }
                 vertexBufferIndices = null;
@@ -156,6 +150,14 @@ namespace SoulsFormats
                         }
                     }
                 }
+
+                for (int i = 0; i < VertexBuffers.Count; i++)
+                {
+                    VertexBuffer buffer = VertexBuffers[i];
+                    // This appears to be some kind of flag on edge-compressed vertex buffers
+                    if ((buffer.BufferIndex & ~0x60000000) != i)
+                        throw new FormatException("Unexpected vertex buffer index.");
+                }
             }
 
             internal void ReadVertices(BinaryReaderEx br, int dataOffset, List<BufferLayout> layouts, FLVERHeader header)
@@ -171,7 +173,7 @@ namespace SoulsFormats
                     Vertices.Add(new FLVER.Vertex(uvCap, tanCap, colorCap));
 
                 foreach (VertexBuffer buffer in VertexBuffers)
-                    buffer.ReadBuffer(br, layouts, Vertices, vertexCount, dataOffset, header);
+                    buffer.ReadBuffer(br, layouts, Vertices, dataOffset, header);
             }
 
             internal void Write(BinaryWriterEx bw, int index)

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/Mesh.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/Mesh.cs
@@ -94,7 +94,7 @@ namespace SoulsFormats
                 int boneOffset = br.ReadInt32();
                 int faceSetCount = br.ReadInt32();
                 int faceSetOffset = br.ReadInt32();
-                int vertexBufferCount = br.ReadInt32();
+                int vertexBufferCount = br.AssertInt32([0, 1, 2, 3]);
                 int vertexBufferOffset = br.ReadInt32();
 
                 if (boundingBoxOffset != 0)
@@ -165,16 +165,13 @@ namespace SoulsFormats
                 int tanCap = layoutMembers.Count(m => m.Semantic == FLVER.LayoutSemantic.Tangent);
                 int colorCap = layoutMembers.Count(m => m.Semantic == FLVER.LayoutSemantic.VertexColor);
 
-                if (VertexBuffers.Count > 0)
-                {
-                    int vertexCount = VertexBuffers[0].VertexCount;
-                    Vertices = new List<FLVER.Vertex>(vertexCount);
-                    for (int i = 0; i < vertexCount; i++)
-                        Vertices.Add(new FLVER.Vertex(uvCap, tanCap, colorCap));
+                int vertexCount = VertexBuffers.Count > 0 ? VertexBuffers[0].VertexCount : 0;
+                Vertices = new List<FLVER.Vertex>(vertexCount);
+                for (int i = 0; i < vertexCount; i++)
+                    Vertices.Add(new FLVER.Vertex(uvCap, tanCap, colorCap));
 
-                    foreach (VertexBuffer buffer in VertexBuffers)
-                        buffer.ReadBuffer(br, layouts, Vertices, vertexCount, dataOffset, header);
-                }
+                foreach (VertexBuffer buffer in VertexBuffers)
+                    buffer.ReadBuffer(br, layouts, Vertices, vertexCount, dataOffset, header);
             }
 
             internal void Write(BinaryWriterEx bw, int index)

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/SekiroUnkStruct.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/SekiroUnkStruct.cs
@@ -1,0 +1,207 @@
+﻿using System.Collections.Generic;
+
+namespace SoulsFormats
+{
+    public partial class FLVER2
+    {
+        /// <summary>
+        /// Unknown; only present in Sekiro.
+        /// </summary>
+        public class SekiroUnkStruct
+        {
+            /// <summary>
+            /// Unknown.
+            /// </summary>
+            public List<Member1> Members1 { get; set; }
+            
+            /// <summary>
+            /// Unknown.
+            /// </summary>
+            public List<Member2> Members2 { get; set; }
+
+            /// <summary>
+            /// Creates an empty SekiroUnkStruct.
+            /// </summary>
+            public SekiroUnkStruct()
+            {
+                Members1 = new List<Member1>();
+                Members2 = new List<Member2>();
+            }
+
+            internal SekiroUnkStruct(BinaryReaderEx br)
+            {
+                short count1 = br.ReadInt16();
+                short count2 = br.ReadInt16();
+                uint offset1 = br.ReadUInt32();
+                uint offset2 = br.ReadUInt32();
+                br.AssertInt32(0);
+                br.AssertInt32(0);
+                br.AssertInt32(0);
+                br.AssertInt32(0);
+                br.AssertInt32(0);
+
+                br.StepIn(offset1);
+                {
+                    Members1 = new List<Member1>(count1);
+                    for (int i = 0; i < count1; i++)
+                        Members1.Add(new Member1(br));
+                }
+                br.StepOut();
+
+                br.StepIn(offset2);
+                {
+                    Members2 = new List<Member2>(count2);
+                    for (int i = 0; i < count2; i++)
+                        Members2.Add(new Member2(br));
+                }
+                br.StepOut();
+            }
+
+            internal void Write(BinaryWriterEx bw)
+            {
+                bw.WriteInt16((short)Members1.Count);
+                bw.WriteInt16((short)Members2.Count);
+                bw.ReserveUInt32("SekiroUnkOffset1");
+                bw.ReserveUInt32("SekiroUnkOffset2");
+                bw.WriteInt32(0);
+                bw.WriteInt32(0);
+                bw.WriteInt32(0);
+                bw.WriteInt32(0);
+                bw.WriteInt32(0);
+
+                bw.FillUInt32("SekiroUnkOffset1", (uint)bw.Position);
+                foreach (Member1 member1 in Members1)
+                    member1.Write(bw);
+
+                bw.FillUInt32("SekiroUnkOffset2", (uint)bw.Position);
+                foreach (Member2 member2 in Members2)
+                    member2.Write(bw);
+            }
+
+            /// <summary>
+            /// Unknown.
+            /// References a bone index and perfectly matches its contained indices.
+            /// </summary>
+            public class Member1
+            {
+                /// <summary>
+                /// Index of the parent in this FLVER's bone collection, or -1 for none.
+                /// </summary>
+                public short ParentIndex { get; set; }
+
+                /// <summary>
+                /// Index of the first child in this FLVER's bone collection, or -1 for none.
+                /// </summary>
+                public short ChildIndex { get; set; }
+
+                /// <summary>
+                /// Index of the next child of this bone's parent, or -1 for none.
+                /// </summary>
+                public short NextSiblingIndex { get; set; }
+
+                /// <summary>
+                /// Index of the previous child of this bone's parent, or -1 for none.
+                /// </summary>
+                public short PreviousSiblingIndex { get; set; }
+
+                /// <summary>
+                /// Unknown; seems to just count up from 0.
+                /// </summary>
+                public int BoneIndex { get; set; }
+
+                /// <summary>
+                /// Creates a Member with default values.
+                /// </summary>
+                public Member1()
+                {
+                    ParentIndex = -1;
+                    ChildIndex = -1;
+                    NextSiblingIndex = -1;
+                    PreviousSiblingIndex = -1;
+                }
+
+                internal Member1(BinaryReaderEx br)
+                {
+                    ParentIndex = br.ReadInt16();
+                    ChildIndex = br.ReadInt16();
+                    NextSiblingIndex = br.ReadInt16();
+                    PreviousSiblingIndex = br.ReadInt16();
+                    BoneIndex = br.ReadInt32();
+                    br.AssertInt32(0);
+                }
+
+                internal void Write(BinaryWriterEx bw)
+                {
+                    bw.WriteInt16(ParentIndex);
+                    bw.WriteInt16(ChildIndex);
+                    bw.WriteInt16(NextSiblingIndex);
+                    bw.WriteInt16(PreviousSiblingIndex);
+                    bw.WriteInt32(BoneIndex);
+                    bw.WriteInt32(0);
+                }
+            }
+
+            /// <summary>
+            /// Unknown.
+            /// </summary>
+            public class Member2
+            {
+                /// <summary>
+                /// Index of the parent in this FLVER's bone collection, or -1 for none.
+                /// </summary>
+                public short Unk00 { get; set; }
+
+                /// <summary>
+                /// Index of the first child in this FLVER's bone collection, or -1 for none.
+                /// </summary>
+                public short Unk02 { get; set; }
+
+                /// <summary>
+                /// Index of the next child of this bone's parent, or -1 for none.
+                /// </summary>
+                public short Unk04 { get; set; }
+
+                /// <summary>
+                /// Index of the previous child of this bone's parent, or -1 for none.
+                /// </summary>
+                public short Unk06 { get; set; }
+
+                /// <summary>
+                /// Unknown; seems to just count up from 0.
+                /// </summary>
+                public int Index { get; set; }
+
+                /// <summary>
+                /// Creates a Member with default values.
+                /// </summary>
+                public Member2()
+                {
+                    Unk00 = -1;
+                    Unk02 = -1;
+                    Unk04 = -1;
+                    Unk06 = -1;
+                }
+
+                internal Member2(BinaryReaderEx br)
+                {
+                    Unk00 = br.ReadInt16();
+                    Unk02 = br.ReadInt16();
+                    Unk04 = br.ReadInt16();
+                    Unk06 = br.ReadInt16();
+                    Index = br.ReadInt32();
+                    br.AssertInt32(0);
+                }
+
+                internal void Write(BinaryWriterEx bw)
+                {
+                    bw.WriteInt16(Unk00);
+                    bw.WriteInt16(Unk02);
+                    bw.WriteInt16(Unk04);
+                    bw.WriteInt16(Unk06);
+                    bw.WriteInt32(Index);
+                    bw.WriteInt32(0);
+                }
+            }
+        }
+    }
+}

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/SkeletonSet.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/SkeletonSet.cs
@@ -1,12 +1,5 @@
-﻿using SoulsFormats;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
-// FLVER implementation for Model Editor usage
-// Credit to The12thAvenger
 namespace SoulsFormats
 {
     public partial class FLVER2
@@ -99,22 +92,22 @@ namespace SoulsFormats
                 /// Index of the parent bone, or -1 for none.
                 /// </summary>
                 public short ParentIndex { get; set; }
-
+                
                 /// <summary>
                 /// Index of the bone's first child, or -1 for none.
                 /// </summary>
                 public short FirstChildIndex { get; set; }
-
+                
                 /// <summary>
                 /// Index of the bone's next sibling, or -1 for none.
                 /// </summary>
                 public short NextSiblingIndex { get; set; }
-
+                
                 /// <summary>
                 /// Index of the bone's sibling, or -1 for none.
                 /// </summary>
                 public short PreviousSiblingIndex { get; set; }
-
+                
                 /// <summary>
                 /// Index of the node in the <see cref="FLVER2.Nodes"/> list
                 /// </summary>

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/Texture.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/Texture.cs
@@ -1,13 +1,5 @@
-﻿using SoulsFormats;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Numerics;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Numerics;
 
-// FLVER implementation for Model Editor usage
-// Credit to The12thAvenger
 namespace SoulsFormats
 {
     public partial class FLVER2

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/VertexBuffer.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/VertexBuffer.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
+﻿using System.Collections.Generic;
 using System.IO;
 
 namespace SoulsFormats
@@ -63,7 +61,7 @@ namespace SoulsFormats
                 BufferOffset = br.ReadInt32();
             }
 
-            internal void ReadBuffer(BinaryReaderEx br, List<BufferLayout> layouts, List<FLVER.Vertex> vertices, int count, int dataOffset, FLVERHeader header)
+            internal void ReadBuffer(BinaryReaderEx br, List<BufferLayout> layouts, List<FLVER.Vertex> vertices, int dataOffset, FLVERHeader header)
             {
                 BufferLayout layout = layouts[LayoutIndex];
                 if (VertexSize != layout.Size)
@@ -82,14 +80,13 @@ namespace SoulsFormats
                     }
                 }
 
-
                 br.StepIn(dataOffset + BufferOffset);
                 {
                     float uvFactor = 1024;
                     if (header.Version >= 0x2000F)
                         uvFactor = 2048;
 
-                    for (int i = 0; i < count; i++)
+                    for (int i = 0; i < vertices.Count; i++)
                         vertices[i].Read(br, layout, uvFactor);
                 }
                 br.StepOut();

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/IFlver.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/IFlver.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Generic;
 
-// FLVER implementation for Model Editor usage
-// Credit to The12thAvenger
 namespace SoulsFormats
 {
     /// <summary>

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/IFlver.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/IFlver.cs
@@ -28,6 +28,11 @@ namespace SoulsFormats
         /// Actual geometry of the model.
         /// </summary>
         IReadOnlyList<IFlverMesh> Meshes { get; }
+
+        /// <summary>
+        /// Checks if the model is a Speedtree model
+        /// </summary>
+        bool IsSpeedtree();
     }
 
     /// <summary>

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/LayoutMember.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/LayoutMember.cs
@@ -1,12 +1,5 @@
-﻿using SoulsFormats;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System;
 
-// FLVER implementation for Model Editor usage
-// Credit to The12thAvenger
 namespace SoulsFormats
 {
     public static partial class FLVER
@@ -19,7 +12,6 @@ namespace SoulsFormats
             /// <summary>
             /// Unknown; 0, 1, or 2.
             /// </summary>
-            ///
             public short Unk00 { get; set; }
 
             /// <summary>
@@ -58,7 +50,6 @@ namespace SoulsFormats
                         case LayoutType.Byte4B:
                         case LayoutType.Short2toFloat2:
                         case LayoutType.Byte4C:
-                        case LayoutType.Byte4D:
                         case LayoutType.UV:
                         case LayoutType.Byte4E:
                         case LayoutType.Short2ToFloat2B:
@@ -78,7 +69,7 @@ namespace SoulsFormats
                             return 16;
 
                         default:
-                            return -1;
+                            throw new NotImplementedException($"No size defined for buffer layout type: {Type}");
                     }
                 }
             }
@@ -117,6 +108,7 @@ namespace SoulsFormats
             {
                 bw.WriteInt16(Unk00);
                 bw.WriteInt16(SpecialModifier);
+                bw.WriteInt32(structOffset);
                 bw.WriteUInt32((uint)Type);
                 bw.WriteUInt32((uint)Semantic);
                 bw.WriteInt32(Index);
@@ -174,11 +166,6 @@ namespace SoulsFormats
             /// Four bytes.
             /// </summary>
             Byte4C = 0x13,
-
-            /// <summary>
-            /// Four bytes.
-            /// </summary>
-            Byte4D = 0x14,
 
             /// <summary>
             /// Two shorts.

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/LayoutMember.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/LayoutMember.cs
@@ -19,7 +19,13 @@ namespace SoulsFormats
             /// <summary>
             /// Unknown; 0, 1, or 2.
             /// </summary>
-            public int Unk00 { get; set; }
+            ///
+            public short Unk00 { get; set; }
+
+            /// <summary>
+            /// Value of -32768 denotes this member isn't stored with the vertex buffer due to Speedtree.
+            /// </summary>
+            public short SpecialModifier { get; set; }
 
             /// <summary>
             /// Format used to store this member.
@@ -55,7 +61,7 @@ namespace SoulsFormats
                         case LayoutType.Byte4D:
                         case LayoutType.UV:
                         case LayoutType.Byte4E:
-                        case LayoutType.Unknown:
+                        case LayoutType.Short2ToFloat2B:
                             return 4;
 
                         case LayoutType.Float2:
@@ -80,9 +86,10 @@ namespace SoulsFormats
             /// <summary>
             /// Creates a LayoutMember with the specified values.
             /// </summary>
-            public LayoutMember(LayoutType type, LayoutSemantic semantic, int index = 0, int unk00 = 0)
+            public LayoutMember(LayoutType type, LayoutSemantic semantic, int index = 0, short unk00 = 0, short specialModifier = 0)
             {
                 Unk00 = unk00;
+                SpecialModifier = specialModifier;
                 Type = type;
                 Semantic = semantic;
                 Index = index;
@@ -98,8 +105,9 @@ namespace SoulsFormats
 
             internal LayoutMember(BinaryReaderEx br, int structOffset)
             {
-                Unk00 = br.ReadInt32();
-                br.AssertInt32(structOffset);
+                Unk00 = br.ReadInt16();
+                SpecialModifier = br.ReadInt16();
+                br.ReadInt32();
                 Type = br.ReadEnum32<LayoutType>();
                 Semantic = br.ReadEnum32<LayoutSemantic>();
                 Index = br.ReadInt32();
@@ -107,8 +115,8 @@ namespace SoulsFormats
 
             internal void Write(BinaryWriterEx bw, int structOffset)
             {
-                bw.WriteInt32(Unk00);
-                bw.WriteInt32(structOffset);
+                bw.WriteInt16(Unk00);
+                bw.WriteInt16(SpecialModifier);
                 bw.WriteUInt32((uint)Type);
                 bw.WriteUInt32((uint)Semantic);
                 bw.WriteInt32(Index);
@@ -195,7 +203,7 @@ namespace SoulsFormats
             /// <summary>
             /// Unknown.
             /// </summary>
-            Unknown = 0x2D,
+            Short2ToFloat2B = 0x2D,
 
             /// <summary>
             /// Unknown.

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/Node.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/Node.cs
@@ -1,13 +1,6 @@
-﻿using SoulsFormats;
-using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System;
 using System.Numerics;
-using System.Text;
-using System.Threading.Tasks;
 
-// FLVER implementation for Model Editor usage
-// Credit to The12thAvenger
 namespace SoulsFormats
 {
     public partial class FLVER
@@ -40,7 +33,7 @@ namespace SoulsFormats
                 /// </summary>
                 Bone = 1 << 3
             }
-
+            
             /// <summary>
             /// The name of this node
             /// </summary>
@@ -69,7 +62,7 @@ namespace SoulsFormats
             /// <summary>
             /// Translation of this bone.
             /// </summary>
-            public Vector3 Position { get; set; }
+            public Vector3 Translation { get; set; }
 
             /// <summary>
             /// Rotation of this bone; euler radians in XZY order.
@@ -116,7 +109,7 @@ namespace SoulsFormats
                     * Matrix4x4.CreateRotationX(Rotation.X)
                     * Matrix4x4.CreateRotationZ(Rotation.Z)
                     * Matrix4x4.CreateRotationY(Rotation.Y)
-                    * Matrix4x4.CreateTranslation(Position);
+                    * Matrix4x4.CreateTranslation(Translation);
             }
 
             /// <summary>
@@ -126,7 +119,7 @@ namespace SoulsFormats
 
             internal Node(BinaryReaderEx br, bool unicode)
             {
-                Position = br.ReadVector3();
+                Translation = br.ReadVector3();
                 int nameOffset = br.ReadInt32();
                 Rotation = br.ReadVector3();
                 ParentIndex = br.ReadInt16();
@@ -147,7 +140,7 @@ namespace SoulsFormats
 
             internal void Write(BinaryWriterEx bw, int index)
             {
-                bw.WriteVector3(Position);
+                bw.WriteVector3(Translation);
                 bw.ReserveInt32($"BoneNameOffset{index}");
                 bw.WriteVector3(Rotation);
                 bw.WriteInt16(ParentIndex);

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/Vertex.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/Vertex.cs
@@ -138,6 +138,12 @@ namespace SoulsFormats
             {
                 foreach (LayoutMember member in layout)
                 {
+                    //Speedtree
+                    if (member.SpecialModifier == -32768)
+                    {
+                        continue;
+                    }
+
                     if (member.Semantic == LayoutSemantic.Position)
                     {
                         if (member.Type == LayoutType.Float3)
@@ -293,9 +299,13 @@ namespace SoulsFormats
                         else if (member.Type == LayoutType.Byte4C)
                         {
                             UVs.Add(new Vector3(br.ReadByte() / 255f, br.ReadByte() / 255f, br.ReadByte() / 255f));
-                            br.ReadByte();
+                            UVs.Add(new Vector3(br.ReadByte(), br.ReadByte(), 0) / 255f);
                         }
                         else if (member.Type == LayoutType.UV)
+                        {
+                            UVs.Add(new Vector3(br.ReadInt16(), br.ReadInt16(), 0) / uvFactor);
+                        }
+                        else if (member.Type == LayoutType.Short2ToFloat2B)
                         {
                             UVs.Add(new Vector3(br.ReadInt16(), br.ReadInt16(), 0) / uvFactor);
                         }
@@ -306,8 +316,8 @@ namespace SoulsFormats
                         }
                         else if (member.Type == LayoutType.Short4toFloat4B)
                         {
-                            UVs.Add(new Vector3(br.ReadInt16(), br.ReadInt16(), br.ReadInt16()) / uvFactor);
-                            br.ReadInt16();
+                            UVs.Add(new Vector3(br.ReadInt16(), br.ReadInt16(), 0) / uvFactor);
+                            UVs.Add(new Vector3(br.ReadInt16(), br.ReadInt16(), 0) / uvFactor);
                         }
                         else
                             throw new NotImplementedException($"Read not implemented for {member.Type} {member.Semantic}.");
@@ -612,10 +622,16 @@ namespace SoulsFormats
                         {
                             bw.WriteByte((byte)Math.Round(uv.X / uvFactor * 255f));
                             bw.WriteByte((byte)Math.Round(uv.Y / uvFactor * 255f));
-                            bw.WriteByte((byte)Math.Round(uv.Z / uvFactor * 255f));
-                            bw.WriteByte(0);
+                            uv = uvQueue.Dequeue() * uvFactor;
+                            bw.WriteByte((byte)Math.Round(uv.X / uvFactor * 255f));
+                            bw.WriteByte((byte)Math.Round(uv.Y / uvFactor * 255f));
                         }
                         else if (member.Type == LayoutType.UV)
+                        {
+                            bw.WriteInt16((short)Math.Round(uv.X));
+                            bw.WriteInt16((short)Math.Round(uv.Y));
+                        }
+                        else if (member.Type == LayoutType.Short2ToFloat2B)
                         {
                             bw.WriteInt16((short)Math.Round(uv.X));
                             bw.WriteInt16((short)Math.Round(uv.Y));
@@ -633,8 +649,9 @@ namespace SoulsFormats
                         {
                             bw.WriteInt16((short)Math.Round(uv.X));
                             bw.WriteInt16((short)Math.Round(uv.Y));
-                            bw.WriteInt16((short)Math.Round(uv.Z));
-                            bw.WriteInt16(0);
+                            uv = uvQueue.Dequeue() * uvFactor;
+                            bw.WriteInt16((short)Math.Round(uv.X));
+                            bw.WriteInt16((short)Math.Round(uv.Y));
                         }
                         else
                             throw new NotImplementedException($"Write not implemented for {member.Type} {member.Semantic}.");

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/VertexBoneIndices.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/VertexBoneIndices.cs
@@ -1,11 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-// FLVER implementation for Model Editor usage
-// Credit to The12thAvenger
 namespace SoulsFormats
 {
     public partial class FLVER

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/VertexBoneWeights.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/VertexBoneWeights.cs
@@ -1,11 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-// FLVER implementation for Model Editor usage
-// Credit to The12thAvenger
 namespace SoulsFormats
 {
     public partial class FLVER

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/VertexColor.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/FLVER/VertexColor.cs
@@ -1,12 +1,5 @@
-﻿using SoulsFormats;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System;
 
-// FLVER implementation for Model Editor usage
-// Credit to The12thAvenger
 namespace SoulsFormats
 {
     public static partial class FLVER

--- a/src/StudioCore/Editor/ModelContainer.cs
+++ b/src/StudioCore/Editor/ModelContainer.cs
@@ -129,12 +129,12 @@ public class ModelContainer : ObjectContainer
         //Smithbox.EditorHandler.ModelEditor.ViewportHandler.UpdateRepresentativeDummy(index, pos);
     }
 
-    public Vector3 RecursiveBoneOffset(Vector3 pos, FLVER.Node bone, FLVER2 flver)
+    public Vector3 RecursiveBoneOffset(Vector3 translation, FLVER.Node bone, FLVER2 flver)
     {
-        pos = RotateVector(pos, bone.Rotation) + bone.Position;
+        translation = RotateVector(translation, bone.Rotation) + bone.Translation;
         if (bone.ParentIndex >= 0)
-            return RecursiveBoneOffset(pos, flver.Nodes[bone.ParentIndex], flver);
-        return pos;
+            return RecursiveBoneOffset(translation, flver.Nodes[bone.ParentIndex], flver);
+        return translation;
     }
 
     // Rotation logic taken from cannon.js:

--- a/src/StudioCore/Editors/ModelEditor/Actions/FlverPropertyActions.cs
+++ b/src/StudioCore/Editors/ModelEditor/Actions/FlverPropertyActions.cs
@@ -1544,10 +1544,10 @@ public class UpdateProperty_FLVERMesh_BoundingBoxes_Unk : ViewportAction
 public class UpdateProperty_FLVERBufferLayout_LayoutMember_Unk00 : ViewportAction
 {
     private FLVER.LayoutMember Entry;
-    private int OldValue;
-    private int NewValue;
+    private short OldValue;
+    private short NewValue;
 
-    public UpdateProperty_FLVERBufferLayout_LayoutMember_Unk00(FLVER.LayoutMember entry, int oldValue, int newValue)
+    public UpdateProperty_FLVERBufferLayout_LayoutMember_Unk00(FLVER.LayoutMember entry, short oldValue, short newValue)
     {
         Entry = entry;
         OldValue = oldValue;

--- a/src/StudioCore/Editors/ModelEditor/Actions/FlverPropertyActions.cs
+++ b/src/StudioCore/Editors/ModelEditor/Actions/FlverPropertyActions.cs
@@ -1012,14 +1012,14 @@ public class UpdateProperty_FLVERNode_Translation : ViewportAction
 
     public override ActionEvent Execute(bool isRedo = false)
     {
-        Entry.Position = NewValue;
+        Entry.Translation = NewValue;
 
         return ActionEvent.NoEvent;
     }
 
     public override ActionEvent Undo()
     {
-        Entry.Position = OldValue;
+        Entry.Translation = OldValue;
 
         return ActionEvent.NoEvent;
     }

--- a/src/StudioCore/Editors/ModelEditor/Actions/Viewport/ChangeVisualNodeTransform.cs
+++ b/src/StudioCore/Editors/ModelEditor/Actions/Viewport/ChangeVisualNodeTransform.cs
@@ -13,20 +13,20 @@ namespace StudioCore.Editors.ModelEditor.Actions.Viewport;
 public class ChangeVisualNodeTransform : ViewportAction
 {
     private Entity Node;
-    private Vector3 OldPosition;
-    private Vector3 NewPosition;
+    private Vector3 OldTranslation;
+    private Vector3 NewTranslation;
     private Vector3 OldRotation;
     private Vector3 NewRotation;
     private Vector3 OldScale;
     private Vector3 NewScale;
     private FLVER.Node BoneNode;
 
-    public ChangeVisualNodeTransform(Entity node, Vector3 newPosition, Vector3 newRotation, Vector3 newScale)
+    public ChangeVisualNodeTransform(Entity node, Vector3 newTranslation, Vector3 newRotation, Vector3 newScale)
     {
         Node = node;
         BoneNode = (FLVER.Node)node.WrappedObject;
-        OldPosition = BoneNode.Position;
-        NewPosition = newPosition;
+        OldTranslation = BoneNode.Translation;
+        NewTranslation = newTranslation;
         OldRotation = BoneNode.Rotation;
         NewRotation = newRotation;
         OldScale = BoneNode.Scale;
@@ -35,7 +35,7 @@ public class ChangeVisualNodeTransform : ViewportAction
 
     public override ActionEvent Execute(bool isRedo = false)
     {
-        BoneNode.Position = NewPosition;
+        BoneNode.Translation = NewTranslation;
         BoneNode.Rotation = NewRotation;
         BoneNode.Scale = NewScale;
         Node.UpdateRenderModel();
@@ -45,7 +45,7 @@ public class ChangeVisualNodeTransform : ViewportAction
 
     public override ActionEvent Undo()
     {
-        BoneNode.Position = OldPosition;
+        BoneNode.Translation = OldTranslation;
         BoneNode.Rotation = OldRotation;
         BoneNode.Scale = OldScale;
         Node.UpdateRenderModel();

--- a/src/StudioCore/Editors/ModelEditor/Core/FlverBufferLayoutPropertyView.cs
+++ b/src/StudioCore/Editors/ModelEditor/Core/FlverBufferLayoutPropertyView.cs
@@ -94,10 +94,12 @@ public class FlverBufferLayoutPropertyView
         ImGui.NextColumn();
 
         ImGui.AlignTextToFramePadding();
-        ImGui.InputInt($"##Unk00##unk00{index}", ref unk00);
+        int unk00ref = 0;
+        ImGui.InputInt($"##Unk00##unk00{index}", ref unk00ref);
         if (ImGui.IsItemDeactivatedAfterEdit() || !ImGui.IsAnyItemActive())
         {
-            if (layout.Unk00 != unk00)
+            short unk00refconv = (short)unk00ref;
+            if (layout.Unk00 != unk00refconv)
                 Screen.EditorActionManager.ExecuteAction(
                 new UpdateProperty_FLVERBufferLayout_LayoutMember_Unk00(layout, layout.Unk00, unk00));
         }

--- a/src/StudioCore/Editors/ModelEditor/Core/FlverNodePropertyView.cs
+++ b/src/StudioCore/Editors/ModelEditor/Core/FlverNodePropertyView.cs
@@ -55,7 +55,7 @@ public class FlverNodePropertyView
         int firstChildIndex = entry.FirstChildIndex;
         int nextSiblingIndex = entry.NextSiblingIndex;
         int previousSiblingIndex = entry.PreviousSiblingIndex;
-        var translation = entry.Position;
+        var translation = entry.Translation;
         var rotation = entry.Rotation;
         var scale = entry.Scale;
         var bbMin = entry.BoundingBoxMin;
@@ -183,9 +183,9 @@ public class FlverNodePropertyView
         ImGui.InputFloat3($"##Translation", ref translation);
         if (ImGui.IsItemDeactivatedAfterEdit() || !ImGui.IsAnyItemActive())
         {
-            if (entry.Position != translation)
+            if (entry.Translation != translation)
                 Screen.EditorActionManager.ExecuteAction(
-                    new UpdateProperty_FLVERNode_Translation(entry, entry.Position, translation));
+                    new UpdateProperty_FLVERNode_Translation(entry, entry.Translation, translation));
         }
 
         ImGui.AlignTextToFramePadding();
@@ -237,10 +237,10 @@ public class FlverNodePropertyView
         ImGui.Columns(1);
 
         // Update representative selectable
-        if (Selection._trackedNodePosition != entry.Position)
+        if (Selection._trackedNodeTranslation != entry.Translation)
         {
-            Selection._trackedNodePosition = entry.Position;
-            Screen.ViewportManager.UpdateRepresentativeNode(index, entry.Position, entry.Rotation, entry.Scale);
+            Selection._trackedNodeTranslation = entry.Translation;
+            Screen.ViewportManager.UpdateRepresentativeNode(index, entry.Translation, entry.Rotation, entry.Scale);
         }
     }
 }

--- a/src/StudioCore/Editors/ModelEditor/Framework/ModelSelectionManager.cs
+++ b/src/StudioCore/Editors/ModelEditor/Framework/ModelSelectionManager.cs
@@ -46,7 +46,7 @@ public class ModelSelectionManager
     public int _subSelectedBufferLayoutMember = -1;
 
     public Vector3 _trackedDummyPosition = new Vector3();
-    public Vector3 _trackedNodePosition = new Vector3();
+    public Vector3 _trackedNodeTranslation = new Vector3();
 
     public bool FocusSelection = false;
     public bool SelectDummy = false;
@@ -260,7 +260,7 @@ public class ModelSelectionManager
         _selectedNode = index;
         _selectedFlverGroupType = GroupSelectionType.Node;
 
-        _trackedNodePosition = new Vector3();
+        _trackedNodeTranslation = new Vector3();
         ViewportManager.SelectRepresentativeNode(_selectedNode);
     }
 

--- a/src/StudioCore/Editors/ModelEditor/Framework/ModelViewportManager.cs
+++ b/src/StudioCore/Editors/ModelEditor/Framework/ModelViewportManager.cs
@@ -562,9 +562,9 @@ public class ModelViewportManager
         var bone = Screen.ResManager.GetCurrentFLVER().Nodes[Screen.Selection._selectedNode];
         var entBone = (FLVER.Node)transformEnt.WrappedObject;
 
-        if (bone.Position != entBone.Position)
+        if (bone.Translation != entBone.Translation)
         {
-            bone.Position = entBone.Position;
+            bone.Translation = entBone.Translation;
         }
     }
 

--- a/src/StudioCore/Editors/ModelEditor/Utils/FlverTools.cs
+++ b/src/StudioCore/Editors/ModelEditor/Utils/FlverTools.cs
@@ -63,7 +63,7 @@ public static class FlverTools
             * Matrix4x4.CreateRotationX(node.Rotation.X)
             * Matrix4x4.CreateRotationZ(node.Rotation.Z)
             * Matrix4x4.CreateRotationY(node.Rotation.Y)
-            * Matrix4x4.CreateTranslation(node.Position);
+            * Matrix4x4.CreateTranslation(node.Translation);
     }
     public static FLVER.Node GetParent(FLVER.Node node, IReadOnlyList<FLVER.Node> nodes)
     {

--- a/src/StudioCore/Havok/NewAnimSkeleton.cs
+++ b/src/StudioCore/Havok/NewAnimSkeleton.cs
@@ -187,8 +187,8 @@ public class NewAnimSkeleton
                     result *= Matrix4x4.CreateRotationX(parentBone.Rotation.X);
                     result *= Matrix4x4.CreateRotationZ(parentBone.Rotation.Z);
                     result *= Matrix4x4.CreateRotationY(parentBone.Rotation.Y);
-                    result *= Matrix4x4.CreateTranslation(parentBone.Position.X, parentBone.Position.Y,
-                        parentBone.Position.Z);
+                    result *= Matrix4x4.CreateTranslation(parentBone.Translation.X, parentBone.Translation.Y,
+                        parentBone.Translation.Z);
 
                     if (parentBone.ParentIndex >= 0)
                         parentBone = boneList[parentBone.ParentIndex];

--- a/src/StudioCore/Resource/Types/FlverResource.cs
+++ b/src/StudioCore/Resource/Types/FlverResource.cs
@@ -82,6 +82,8 @@ public class FlverResource : IResource, IDisposable
     private List<FlverBone> FBones { get; set; }
     private List<Matrix4x4> BoneTransforms { get; set; }
 
+    public bool IsSpeedtree = false;
+
     public GPUBufferAllocator.GPUBufferHandle StaticBoneBuffer { get; private set; }
 
     /// <summary>
@@ -861,7 +863,7 @@ public class FlverResource : IResource, IDisposable
             case FLVER.LayoutType.Byte4C:
             case FLVER.LayoutType.UV:
             case FLVER.LayoutType.Byte4E:
-            case FLVER.LayoutType.Unknown:
+            case FLVER.LayoutType.Short2ToFloat2B:
                 br.ReadUInt32();
                 break;
 
@@ -1952,6 +1954,7 @@ public class FlverResource : IResource, IDisposable
 
         if (al == AccessLevel.AccessFull || al == AccessLevel.AccessGPUOptimizedOnly)
         {
+            IsSpeedtree = Flver.IsSpeedtree();
             GPUMeshes = new FlverSubmesh[Flver.Meshes.Count()];
             GPUMaterials = new FlverMaterial[Flver.Materials.Count()];
             Bounds = new BoundingBox();
@@ -2049,8 +2052,9 @@ public class FlverResource : IResource, IDisposable
         br.AssertByte(0);
         br.AssertInt32(0);
         br.AssertInt32(0);
-        //br.AssertInt32(0, 1, 2, 3, 4);  // unknown
-        br.ReadInt32(); // unknown
+        br.AssertInt16([0, 1, 2, 3, 4, 5]);  // unknown
+        var specialModifier = br.AssertInt16([0, -32768]);
+        IsSpeedtree = specialModifier == -32768;
         br.AssertInt32(0);
         br.AssertInt32(0);
         br.AssertInt32([0x0, 0x10]);

--- a/src/StudioCore/Scene/DebugPrimitives/DbgPrimTree.cs
+++ b/src/StudioCore/Scene/DebugPrimitives/DbgPrimTree.cs
@@ -26,9 +26,12 @@ public class DbgPrimTree : DbgPrimSolid
             NameColor = trunkColor;
 
             // Solid Trunk (Box)
-            Vector3 trunkMin = new Vector3(-trunkWidth / 2, 0, -trunkWidth / 2);
-            Vector3 trunkMax = new Vector3(trunkWidth / 2, trunkHeight, trunkWidth / 2);
-            AddSolidBox(trunkMin, trunkMax, trunkColor);
+            if (trunkWidth > 0 && trunkHeight > 0)
+            {
+                Vector3 trunkMin = new Vector3(-trunkWidth / 2, 0, -trunkWidth / 2);
+                Vector3 trunkMax = new Vector3(trunkWidth / 2, trunkHeight, trunkWidth / 2);
+                AddSolidBox(trunkMin, trunkMax, trunkColor);
+            }
 
             // Cluster (Solid Sphere on top of trunk)
             Vector3 clusterPos = new Vector3(0, trunkHeight + clusterRadius, 0);

--- a/src/StudioCore/Scene/Framework/MeshRenderableProxy.cs
+++ b/src/StudioCore/Scene/Framework/MeshRenderableProxy.cs
@@ -215,6 +215,7 @@ public class MeshRenderableProxy : RenderableProxy, IMeshProviderEventListener
     {
         var needsPlaceholder = _placeholderType != ModelMarkerType.None;
         var useTreePlaceholder = false;
+        var useBushPlaceholder = false;
 
         for (var i = 0; i < _meshProvider.ChildCount; i++)
         {
@@ -254,10 +255,14 @@ public class MeshRenderableProxy : RenderableProxy, IMeshProviderEventListener
         if (_placeholderType != ModelMarkerType.None)
         {
             // Speed Tree asset
-            if(RenderableHelper.IsSpeedTreeAsset(_meshProvider))
+            var speedTreeType = RenderableHelper.IsSpeedTreeAsset(_meshProvider);
+            if (speedTreeType != RenderableHelper.SpeedTreeType.None)
             {
                 needsPlaceholder = true;
-                useTreePlaceholder = true;
+                if (speedTreeType == RenderableHelper.SpeedTreeType.Tree)
+                    useTreePlaceholder = true;
+                else
+                    useBushPlaceholder = true;
             }
 
             if (needsPlaceholder)
@@ -269,6 +274,12 @@ public class MeshRenderableProxy : RenderableProxy, IMeshProviderEventListener
                 {
                     _placeholderProxy =
                     RenderableHelper.GetTreeProxy(_renderablesSet);
+                    _placeholderProxy.DrawFilter = RenderFilter.SpeedTree;
+                }
+                else if (useBushPlaceholder)
+                {
+                    _placeholderProxy =
+                        RenderableHelper.GetBushProxy(_renderablesSet);
                     _placeholderProxy.DrawFilter = RenderFilter.SpeedTree;
                 }
                 else

--- a/src/StudioCore/Scene/Helpers/RenderableHelper.cs
+++ b/src/StudioCore/Scene/Helpers/RenderableHelper.cs
@@ -45,41 +45,37 @@ public static class RenderableHelper
     private static DbgPrimWireSphere? _jointSphere;
 
     private static DbgPrimTree? _modelMarkerTree;
+    private static DbgPrimTree? _modelMarkerBush;
 
-    /// <summary>
-    /// List of assets starting IDs that will always receive a tree marker.
-    /// Contains speedtree AEGs, which currently do not render in Smithbox.
-    /// Can be removed when speedtree rendering is functional.
-    /// </summary>
-    public static readonly HashSet<string> SpeedTree_Assets = new()
+    public static readonly HashSet<string> SpeedTree_Bushes = new()
     {
-        "AEG801",
-        "AEG805",
-        "AEG810",
-        "AEG811",
-        "AEG813",
-        "AEG814",
-        "AEG815",
-        "AEG816"
+        "AEG801_086",
     };
 
+    public enum SpeedTreeType
+    {
+        None,
+        Bush,
+        Tree
+    }
     /// <summary>
     /// Returns true if the passed mesh provider is a Speed Tree asset
     /// </summary>
-    public static bool IsSpeedTreeAsset(MeshProvider _meshProvider)
+    public static SpeedTreeType IsSpeedTreeAsset(MeshProvider _meshProvider)
     {
         if (_meshProvider is FlverMeshProvider fProvider)
         {
-            if (SpeedTree_Assets.FirstOrDefault(n => fProvider.MeshName.ToUpper().StartsWith(n)) != null)
+            if (fProvider.IsSpeedtree)
             {
-                if (fProvider.MeshName.ToUpper() != "AEG801_224")
+                if (SpeedTree_Bushes.Contains(fProvider.MeshName.ToUpper()))
                 {
-                    return true;
+                    return SpeedTreeType.Bush;
                 }
+                return SpeedTreeType.Tree;
             }
         }
 
-        return false;
+        return SpeedTreeType.None;
     }
 
     /// <summary>
@@ -199,6 +195,14 @@ public static class RenderableHelper
             6f,    // Trunk height
             0.5f,  // Trunk width
             3f,    // Cluster radius
+            Color.Brown,
+            Color.Green);
+
+        _modelMarkerBush = new DbgPrimTree(
+            Transform.Default,
+            0f,    // Trunk height
+            0f,  // Trunk width
+            1f,    // Cluster radius
             Color.Brown,
             Color.Green);
 
@@ -556,6 +560,22 @@ public static class RenderableHelper
         var transparency = 50.0f;
 
         DebugPrimitiveRenderableProxy r = new(renderables, _modelMarkerTree, false);
+
+        r.BaseColor = ColorHelper.GetTransparencyColor(baseColor, transparency);
+        r.HighlightedColor = ColorHelper.GetTransparencyColor(highlightColor, transparency);
+        //ColorHelper.ApplyColorVariance(r);
+
+        return r;
+    }
+
+    // Bush
+    public static DebugPrimitiveRenderableProxy GetBushProxy(MeshRenderables renderables)
+    {
+        var baseColor = CFG.Current.GFX_Renderable_Box_BaseColor;
+        var highlightColor = CFG.Current.GFX_Renderable_Box_HighlightColor;
+        var transparency = 50.0f;
+
+        DebugPrimitiveRenderableProxy r = new(renderables, _modelMarkerBush, false);
 
         r.BaseColor = ColorHelper.GetTransparencyColor(baseColor, transparency);
         r.HighlightedColor = ColorHelper.GetTransparencyColor(highlightColor, transparency);

--- a/src/StudioCore/Scene/Helpers/RenderableHelper.cs
+++ b/src/StudioCore/Scene/Helpers/RenderableHelper.cs
@@ -49,6 +49,7 @@ public static class RenderableHelper
 
     public static readonly HashSet<string> SpeedTree_Bushes = new()
     {
+        "AEG801_006",
         "AEG801_086",
     };
 

--- a/src/StudioCore/Scene/Meshes/FlverMeshProvider.cs
+++ b/src/StudioCore/Scene/Meshes/FlverMeshProvider.cs
@@ -72,6 +72,8 @@ public class FlverMeshProvider : MeshProvider, IResourceEventListener
 
     public string MeshName => Path.GetFileNameWithoutExtension(_resourceName);
 
+    public bool IsSpeedtree;
+
     public void OnResourceLoaded(IResourceHandle handle, int tag)
     {
         if (_resource != null)
@@ -162,6 +164,7 @@ public class FlverMeshProvider : MeshProvider, IResourceEventListener
     {
         _allSubmeshes = new List<FlverSubmeshProvider>();
         FlverResource res = _resource.Get();
+        IsSpeedtree = res.IsSpeedtree;
         _bounds = res.Bounds;
         for (var i = 0; i < res.GPUMeshes.Length; i++)
         {

--- a/src/StudioCore/Utilities/Utils.cs
+++ b/src/StudioCore/Utilities/Utils.cs
@@ -833,7 +833,7 @@ public static class Utils
         {
             var bone = bones[i];
             sb.AppendLine($"[{i}] {bone.Name}");
-            sb.AppendLine($"\tPosition: {bone.Position}");
+            sb.AppendLine($"\tTranslation: {bone.Translation}");
             sb.AppendLine($"\tRotation: {bone.Rotation}");
             sb.AppendLine($"\tScale: {bone.Scale}");
             sb.AppendLine($"\tParent Index: {bone.ParentIndex}");


### PR DESCRIPTION
Uses Shadowth117's Speedtree detection logic to tell whether an asset supports Speedtree, rather than going by AEG ID.

Still, added an AEG ID filter for bushes, to display a simple sphere as a bush placeholder rather than a tree placeholder.

That one would ideally need to be filled with bushes.

Untested outside of ELDEN RING, please test in other games if you can.