### PR TITLE
Fix DS1 & DeS CTD regression in GetModelMasks

### DIFF
--- a/src/Smithbox.Program/Editors/MapEditor/Framework/Entity.cs
+++ b/src/Smithbox.Program/Editors/MapEditor/Framework/Entity.cs
@@ -1842,7 +1842,7 @@ public class MsbEntity : Entity
 
                         if (npcParam.ContainsRow(npcParamId))
                         {
-                            return callback(npcParam[npcParamId]);
+                            return callback(npcParam[npcParamId], 16);
                         }
                         else
                         {
@@ -1858,7 +1858,7 @@ public class MsbEntity : Entity
 
                         if (npcParam.ContainsRow(npcParamId))
                         {
-                            return callback(npcParam[npcParamId]);
+                            return callback(npcParam[npcParamId], 16);
                         }
                         else
                         {


### PR DESCRIPTION
when `GetModelMasks` got reworked in d3103ce the inputs that limited DeS and DS1 model imports to 16 model masks was missed, which caused CTDs when loading maps.