### PR TITLE
Fix CTD with empty string in row name editing

### DIFF
--- a/src/Smithbox.Program/Editors/ParamEditor/Tools/ParamRowOperations.cs
+++ b/src/Smithbox.Program/Editors/ParamEditor/Tools/ParamRowOperations.cs
@@ -420,12 +420,12 @@ public partial class ParamTools
     #region Adjust Row Name
     public void AdjustRowName(string adjustment, RowNameAdjustType type)
     {
-        if (adjustment == null)
+        if (string.IsNullOrEmpty(adjustment))
             return;
 
-        var curParamKey = Editor._activeView.Selection.GetActiveParam();
+        string curParamKey = Editor._activeView.Selection.GetActiveParam();
 
-        if (curParamKey == null)
+        if (string.IsNullOrEmpty(curParamKey))
             return;
 
         Param baseParam = Editor.Project.ParamData.PrimaryBank.Params[curParamKey];
@@ -441,7 +441,7 @@ public partial class ParamTools
 
         foreach (Param.Row row in rows)
         {
-            if(type is RowNameAdjustType.Prepend)
+            if (type is RowNameAdjustType.Prepend)
             {
                 row.Name = $"{adjustment}{row.Name}";
             }


### PR DESCRIPTION
Experienced this CTD when trying to experiment with mass renaming via these buttons.
the `Replace()` function used for removing strings from row names throws an error if the "old" input string is null or empty, so I've adjusted the early outs in `ParamTools.AdjustRowName()` to use `IsNullOrEmpty()` instead of simply checking if it is null.

I don't think its possible for `curParamKey` to ever be an empty string, but I figure its better to change it now in case behavior ever changes and it becomes possible for it to be an empty string.
There may also be other places in the code where strings should use this check, but I have not looked.