### PR TITLE
Make name import by ID gracefully handle duplicates

### DIFF
--- a/src/Smithbox.Program/Editors/ParamEditor/Data/ParamData.cs
+++ b/src/Smithbox.Program/Editors/ParamEditor/Data/ParamData.cs
@@ -118,7 +118,7 @@ public class ParamData
             var dialog = PlatformUtils.Instance.MessageBox("Do you wish to import row names?", "Automatic Row Naming", MessageBoxButtons.OKCancel, MessageBoxIcon.Information);
             if (dialog is DialogResult.OK)
             {
-                PrimaryBank.ImportRowNames(ImportRowNameType.AutoImport, ImportRowNameSourceType.Community);
+                PrimaryBank.ImportRowNames(ImportRowNameType.ID, ImportRowNameSourceType.Community);
             }
 
             Project.ImportedParamRowNames = true;


### PR DESCRIPTION
When importing param names by ID, this now uses the relative position of multiple names to disambiguate rows that use the same ID. This makes by-ID imports work even for params where order matters, and makes Smithbox generally more flexible in handling new rows that are added in between existing ones.

Beacuse by-ID name imports now work fine even params where order matters, this removes the "automatic" import mode and replaces it with by-ID.

Closes #245