### PR TITLE
Fuzzy filter for map search

### DIFF
--- a/src/Smithbox.Program/Utilities/SearchFilters.cs
+++ b/src/Smithbox.Program/Utilities/SearchFilters.cs
@@ -14,71 +14,57 @@ public static class SearchFilters
     public static bool IsBasicMatch(string rawInput, string rawStr)
     {
         bool match = false;
-
         string input = rawInput.Trim().ToLower();
         string rawString = rawStr.ToLower();
-
         if (input.Equals(""))
         {
             match = true; // If input is empty, show all
             return match;
         }
-
         string[] inputParts = input.Split("+");
         bool[] partTruth = new bool[inputParts.Length];
-
         for (int i = 0; i < partTruth.Length; i++)
         {
             string entry = inputParts[i];
-
             if (entry == rawString)
                 partTruth[i] = true;
-
             if (rawString.Contains(entry))
                 partTruth[i] = true;
         }
-
         match = true;
-
         foreach (bool entry in partTruth)
         {
             if (!entry)
                 match = false;
         }
-
         return match;
     }
 
     /// <summary>
     /// Returns true is the input string (whole or part) matches a filename, reference name or tag.
     /// </summary>
-    public static bool IsSearchMatch(string rawInput, string rawRefId, string rawRefName, List<string> rawRefTags, 
+    public static bool IsSearchMatch(string rawInput, string rawRefId, string rawRefName, List<string> rawRefTags,
         bool matchAssetCategory = false, // Match AEG categories passed in input
         bool stripParticlePrefix = false, // Remove f and preceding zeroes from checked string against input
         bool splitWithDelimiter = false, // Split entry by passed delimiter and check against input
         string delimiter = "_" // Delimiter to split entry by
-        )
+    )
     {
         bool match = false;
-
         string input = rawInput.Trim().ToLower();
         string refId = rawRefId.ToLower();
         string refName = rawRefName.ToLower();
-
-        if(rawRefTags == null)
+        if (rawRefTags == null)
         {
             rawRefTags = new List<string>() { "" };
         }
-
         if (input.Equals(""))
         {
             match = true; // If input is empty, show all
             return match;
         }
-
         string[] inputParts = input.Split("+");
         bool[] partTruth = new bool[inputParts.Length];
-
         for (int i = 0; i < partTruth.Length; i++)
         {
             string entry = inputParts[i];
@@ -98,15 +84,13 @@ public static class SearchFilters
             // Match: Reference Name
             if (refName.Contains(entry))
                 partTruth[i] = true;
-
             if (splitWithDelimiter)
             {
                 var refParts = refName.Split(delimiter);
-                foreach(var refPart in refParts)
+                foreach (var refPart in refParts)
                 {
-                    if(entry == refPart)
+                    if (entry == refPart)
                         partTruth[i] = true;
-
                     if (refPart.Contains(entry))
                         partTruth[i] = true;
                 }
@@ -121,25 +105,18 @@ public static class SearchFilters
                 // Remove common brackets so the match ignores them
                 if (curString.Contains('('))
                     curString = curString.Replace("(", "");
-
                 if (curString.Contains(')'))
                     curString = curString.Replace(")", "");
-
                 if (curString.Contains('{'))
                     curString = curString.Replace("{", "");
-
                 if (curString.Contains('}'))
                     curString = curString.Replace("}", "");
-
                 if (curString.Contains('('))
                     curString = curString.Replace("(", "");
-
                 if (curString.Contains('['))
                     curString = curString.Replace("[", "");
-
                 if (curString.Contains(']'))
                     curString = curString.Replace("]", "");
-
                 if (entry == curString.Trim())
                     partTruth[i] = true;
             }
@@ -149,7 +126,6 @@ public static class SearchFilters
             {
                 if (entry == tagStr.ToLower())
                     partTruth[i] = true;
-
                 if (tagStr.ToLower().Contains(entry))
                     partTruth[i] = true;
             }
@@ -163,7 +139,6 @@ public static class SearchFilters
                     {
                         string[] parts = refId.Split("_");
                         string aegCategory = parts[0].Replace("aeg", "");
-
                         if (entry == aegCategory)
                         {
                             partTruth[i] = true;
@@ -172,40 +147,32 @@ public static class SearchFilters
                 }
             }
         }
-
         match = true;
-
-        foreach(bool entry in partTruth)
+        foreach (bool entry in partTruth)
         {
             if (!entry)
                 match = false;
         }
-
         return match;
     }
 
     public static bool IsAssetBrowserSearchMatch(string rawInput, string rawRefId, string rawRefName, List<string> rawRefTags)
     {
         bool match = false;
-
         string input = rawInput.Trim().ToLower();
         string refId = rawRefId.ToLower();
         string refName = rawRefName.ToLower();
-
         if (rawRefTags == null)
         {
             rawRefTags = new List<string>() { "" };
         }
-
         if (input.Equals(""))
         {
             match = true; // If input is empty, show all
             return match;
         }
-
         string[] inputParts = input.Split("+");
         bool[] partTruth = new bool[inputParts.Length];
-
         for (int i = 0; i < partTruth.Length; i++)
         {
             string entry = inputParts[i];
@@ -217,13 +184,11 @@ public static class SearchFilters
             // Contains: ID
             if (refId.Contains(entry))
                 partTruth[i] = true;
-
             var refIdParts = refId.Split("_");
             foreach (var refIdPart in refIdParts)
             {
                 if (entry == refIdPart)
                     partTruth[i] = true;
-
                 if (refIdPart.Contains(entry))
                     partTruth[i] = true;
             }
@@ -231,16 +196,13 @@ public static class SearchFilters
             // Match: Name
             if (entry == refName)
                 partTruth[i] = true;
-
             if (refName.Contains(entry))
                 partTruth[i] = true;
-
             var refParts = refName.Split("_");
             foreach (var refPart in refParts)
             {
                 if (entry == refPart)
                     partTruth[i] = true;
-
                 if (refPart.Contains(entry))
                     partTruth[i] = true;
             }
@@ -254,25 +216,18 @@ public static class SearchFilters
                 // Remove common brackets so the match ignores them
                 if (curString.Contains('('))
                     curString = curString.Replace("(", "");
-
                 if (curString.Contains(')'))
                     curString = curString.Replace(")", "");
-
                 if (curString.Contains('{'))
                     curString = curString.Replace("{", "");
-
                 if (curString.Contains('}'))
                     curString = curString.Replace("}", "");
-
                 if (curString.Contains('('))
                     curString = curString.Replace("(", "");
-
                 if (curString.Contains('['))
                     curString = curString.Replace("[", "");
-
                 if (curString.Contains(']'))
                     curString = curString.Replace("]", "");
-
                 if (entry == curString.Trim())
                     partTruth[i] = true;
             }
@@ -282,46 +237,36 @@ public static class SearchFilters
             {
                 if (tagStr.ToLower().Contains(entry))
                     partTruth[i] = true;
-
                 if (entry == tagStr.ToLower())
                     partTruth[i] = true;
             }
         }
-
         match = true;
-
         foreach (bool entry in partTruth)
         {
             if (!entry)
                 match = false;
         }
-
         return match;
     }
 
     public static bool IsEditorSearchMatch(string rawInput, string checkInput, string delimiter)
     {
         bool match = false;
-
         string cleanRawInput = rawInput.Trim().ToLower();
         string cleanCheckInput = checkInput.Trim().ToLower();
-
         if (cleanRawInput.Equals(""))
         {
             match = true; // If input is empty, show all
             return match;
         }
-
         string[] inputParts = cleanRawInput.Split("+");
         bool[] partTruth = new bool[inputParts.Length];
-
         for (int i = 0; i < partTruth.Length; i++)
         {
             string entry = inputParts[i];
-
             if (entry == cleanCheckInput)
                 partTruth[i] = true;
-
             var refParts = cleanCheckInput.Split($"{delimiter}");
             foreach (var refPart in refParts)
             {
@@ -331,41 +276,32 @@ public static class SearchFilters
                 }
             }
         }
-
         match = true;
-
         foreach (bool entry in partTruth)
         {
             if (!entry)
                 match = false;
         }
-
         return match;
     }
 
     public static bool IsSelectionSearchMatch(string rawInput, string checkInput, List<string> tags)
     {
         bool match = false;
-
         string cleanRawInput = rawInput.Trim().ToLower();
         string cleanCheckInput = checkInput.Trim().ToLower();
-
         if (cleanRawInput.Equals(""))
         {
             match = true; // If input is empty, show all
             return match;
         }
-
         string[] inputParts = cleanRawInput.Split("+");
         bool[] partTruth = new bool[inputParts.Length];
-
         for (int i = 0; i < partTruth.Length; i++)
         {
             string entry = inputParts[i];
-
             if (entry == cleanCheckInput)
                 partTruth[i] = true;
-
             var refParts = cleanCheckInput.Split($"_");
             foreach (var refPart in refParts)
             {
@@ -382,82 +318,78 @@ public static class SearchFilters
                     partTruth[i] = true;
             }
         }
-
         match = true;
-
         foreach (bool entry in partTruth)
         {
             if (!entry)
                 match = false;
         }
-
         return match;
     }
 
     public static bool IsIdSearchMatch(string rawInput, string checkInput)
     {
         bool match = false;
-
         int rawInputNum = -1;
         int.TryParse(rawInput, out rawInputNum);
-
         int checkInputNum = -1;
         int.TryParse(checkInput, out checkInputNum);
-
         string[] inputParts = rawInput.Split("+");
         bool[] partTruth = new bool[inputParts.Length];
-
         if (rawInput.Equals(""))
         {
             match = true; // If input is empty, show all
             return match;
         }
-
         for (int i = 0; i < partTruth.Length; i++)
         {
             int entry;
             int.TryParse(inputParts[i], out entry);
-
             if (entry == checkInputNum)
                 partTruth[i] = true;
         }
 
         // Act as OR
-        if(partTruth.Contains(true))
+        if (partTruth.Contains(true))
         {
             match = true;
         }
-
         return match;
     }
 
     public static bool IsMapSearchMatch(string rawInput, string mapId, string mapAlias, List<string> mapTags)
     {
         bool match = false;
-
         List<string> MapTags = mapTags;
         string input = rawInput.Trim().ToLower();
         string MapID = mapId.ToLower();
         string MapName = mapAlias.ToLower();
-
         if (input.Equals(""))
         {
             match = true; // If input is empty, show all
             return match;
         }
-
         string[] inputParts = input.Split("|");
-
         for (int i = 0; i < inputParts.Length; i++)
         {
             string entry = inputParts[i];
 
-            // Match: Map ID
+            string fuzzyEntry = ApplyFuzzyTransform(entry);
+
+            // Match: Map ID (original entry)
             if (entry == MapID)
                 match = true;
 
-            // Contains: Map ID
+            // Match: Map ID (fuzzy transformed entry)
+            if (fuzzyEntry != entry && fuzzyEntry == MapID)
+                match = true;
+
+            // Contains: Map ID (original entry)
             if (MapID.Contains(entry))
+                match = true;
+
+            // Contains: Map ID (fuzzy transformed entry)
+            if (fuzzyEntry != entry && MapID.Contains(fuzzyEntry))
                 match = true;
 
             // Match: Map ID parts
@@ -466,18 +398,27 @@ public static class SearchFilters
             {
                 var part = refPart.Replace("m", "");
 
+                // Original entry matching
                 if (entry == refPart)
                     match = true;
-
                 if (refPart.Contains(entry))
                     match = true;
+
+                // Fuzzy entry matching
+                if (fuzzyEntry != entry)
+                {
+                    if (fuzzyEntry == refPart)
+                        match = true;
+                    if (refPart.Contains(fuzzyEntry))
+                        match = true;
+                }
             }
 
-            // Match: Alias Name
+            // Match: Alias Name (original entry)
             if (entry == MapName)
                 match = true;
 
-            // Contains: Map ID
+            // Contains: Map Name (original entry)
             if (MapName.Contains(entry))
                 match = true;
 
@@ -487,7 +428,6 @@ public static class SearchFilters
             {
                 if (entry == refPart)
                     match = true;
-
                 if (refPart.Contains(entry))
                     match = true;
             }
@@ -499,13 +439,26 @@ public static class SearchFilters
                 {
                     if (tagStr.ToLower().Contains(entry))
                         match = true;
-
                     if (entry == tagStr.ToLower())
                         match = true;
                 }
             }
         }
-
         return match;
+    }
+
+    private static string ApplyFuzzyTransform(string input)
+    {
+        if (input.Length <= 2 || !input.All(char.IsDigit))
+            return input;
+
+        StringBuilder result = new StringBuilder();
+        for (int i = 0; i < input.Length; i++)
+        {
+            if (i > 0 && i % 2 == 0)
+                result.Append('_');
+            result.Append(input[i]);
+        }
+        return result.ToString();
     }
 }


### PR DESCRIPTION
This PR implements support for fuzzy search in the map searchbar. It makes it so you can, for example, type "2101" instead of "21_01" in order to find maps containing "21_01" in their name.