### PR TITLE
Fix SetParamNamesLegacy for overlapping IDs

### DIFF
--- a/src/Smithbox.Program/Configuration/CFG.cs
+++ b/src/Smithbox.Program/Configuration/CFG.cs
@@ -451,11 +451,6 @@ public class CFG
     public bool RepackLooseDS2Params = false;
 
     /// <summary>
-    /// If true, then row name restore will use index matching. If false, it will use ID matching.
-    /// </summary>
-    public bool UseIndexMatchForRowNameRestore = true;
-
-    /// <summary>
     /// The delimiter character to use when exporting param data.
     /// </summary>
     public string Param_Export_Delimiter

--- a/src/Smithbox.Program/Configuration/Settings/EditorSettings.cs
+++ b/src/Smithbox.Program/Configuration/Settings/EditorSettings.cs
@@ -700,9 +700,6 @@ public class ParamEditorTab
 
             if (ImGui.CollapsingHeader("Regulation Data", ImGuiTreeNodeFlags.DefaultOpen))
             {
-                ImGui.Checkbox("Use index matching for row name restore", ref CFG.Current.UseIndexMatchForRowNameRestore);
-                UIHelper.Tooltip("If enabled, when row names are restored, they will be matched based on the row index, rather than ID. If disabled, row ID will be used.");
-
                 switch (curProject.ProjectType)
                 {
                     case ProjectType.DES:

--- a/src/Smithbox.Program/Editors/ParamEditor/Data/ParamBank.cs
+++ b/src/Smithbox.Program/Editors/ParamEditor/Data/ParamBank.cs
@@ -2503,27 +2503,14 @@ public class ParamBank
     }
     private static void SetParamNamesLegacy(Param param, RowNameParamLegacy rowNames)
     {
-        var rowNameDict = rowNames.Entries.ToDictionary(e => e.Index);
+        var rowsByID = param.Rows.ToLookup(e => e.ID);
+        var rowNamesByID = rowNames.Entries.ToLookup(e => e.ID);
 
-        for (var i = 0; i < param.Rows.Count; i++)
+        foreach (var entry in rowsByID)
         {
-            if (CFG.Current.UseIndexMatchForRowNameRestore)
+            foreach (var (row, nameEntry) in entry.Zip(rowNamesByID[entry.Key]))
             {
-                if (rowNameDict.ContainsKey(i))
-                {
-                    param.Rows[i].Name = rowNameDict[i].Name;
-                }
-            }
-            else
-            {
-                // ID may not be unique, so we will manually loop here
-                foreach (var entry in rowNames.Entries)
-                {
-                    if (entry.ID == param.Rows[i].ID)
-                    {
-                        param.Rows[i].Name = entry.Name;
-                    }
-                }
+                row.Name = nameEntry.Name;
             }
         }
     }


### PR DESCRIPTION
The old ToDictionary call would crash if `rowNames` had multiple rows with the same index value. This instead matches the new row name behavior elsewhere and always imports first by ID, then within each ID by the order the names appear.

Because this works for both rows with both unique and non-unique IDs, I've also removed the `UseIndexMatchForRowNameRestore` configuration since it should no longer be necessary.