### PR TITLE
chore: Project list tweak, DS3 crash fix

### DIFF
--- a/src/Smithbox.Program/Core/ProjectManager.cs
+++ b/src/Smithbox.Program/Core/ProjectManager.cs
@@ -117,24 +117,24 @@ public class ProjectManager
 
     private void DisplayProjectListGroup(ProjectType projectType)
     {
+        var projectList = Projects.Where(e => e.ProjectType == projectType).ToList();
+        if (!projectList.Any()) return;
         // When filtering the list, don't use the collapsible sections since it makes it harder to see the filtered results
         if (CFG.Current.DisplayCollapsibleProjectCategories && ProjectListFilter == "")
         {
             if(ImGui.CollapsingHeader($"{projectType}##collapsibleSection_{projectType}", ImGuiTreeNodeFlags.DefaultOpen))
             {
-                DisplayProjectListOfType(projectType);
+                DisplayProjectList(projectList);
             }
         }
         else
         {
-            DisplayProjectListOfType(projectType);
+            DisplayProjectList(projectList);
         }
     }
 
-    private void DisplayProjectListOfType(ProjectType projectType)
+    private void DisplayProjectList(List<ProjectEntry> projectList)
     {
-        var projectList = Projects.Where(e => e.ProjectType == projectType).ToList();
-
         if (projectList.Count > 0)
         {
             foreach (var project in projectList)

--- a/src/Smithbox.Program/Editors/ParamEditor/Tools/ItemGib.cs
+++ b/src/Smithbox.Program/Editors/ParamEditor/Tools/ItemGib.cs
@@ -122,7 +122,8 @@ public class ItemGib
 
         var activeParam = Editor._activeView.Selection.GetActiveParam();
 
-        if (string.IsNullOrEmpty(activeParam) || !GetGameOffsets().Bases.Any(item => item.itemIDCategories.ContainsKey(activeParam)))
+        var gameOffsets = GetGameOffsets();
+        if (string.IsNullOrEmpty(activeParam) || gameOffsets == null || !gameOffsets.Bases.Any(item => item.itemIDCategories.ContainsKey(activeParam)))
         {
             return;
         }

--- a/src/Smithbox.Program/Memory/GameOffsetsEntry.cs
+++ b/src/Smithbox.Program/Memory/GameOffsetsEntry.cs
@@ -56,8 +56,8 @@ public class GameOffsetBaseEntry
     public int? ERItemGiveFuncOffset = null;
     public int? ERMapItemManOffset = null;
 
-    public Dictionary<string, int> paramOffsets;
-    public Dictionary<string, int> itemIDCategories;
+    public Dictionary<string, int> paramOffsets = new();
+    public Dictionary<string, int> itemIDCategories = new();
 
     public GameOffsetBaseEntry() { }
 

--- a/src/Smithbox.Program/Resource/Types/HavokCollisionResource.cs
+++ b/src/Smithbox.Program/Resource/Types/HavokCollisionResource.cs
@@ -126,14 +126,7 @@ public class HavokCollisionResource : IResource, IDisposable
                     // HKX for ER is loaded directly in HavokCollisionManager
                     // This is required since the parallel nature of the
                     // Resource Manager doesn't work with the HavokBinarySerializer
-                    if (curProject.MapEditor.CollisionManager.HavokContainers.ContainsKey(filename))
-                    {
-                        ER_HKX = curProject.MapEditor.CollisionManager.HavokContainers[filename];
-                    }
-                    else
-                    {
-                        return false;
-                    }
+                    return curProject.MapEditor.CollisionManager.HavokContainers.TryGetValue(filename, out ER_HKX);
                 }
                 // Fallback for map collision
                 else


### PR DESCRIPTION
- Don't show categories for games that don't have any projects
- Fix crash when opening EquipParamWeapon in DS3 (causes error spam instead)