### PR TITLE
Update some NR annotations, defs and meta

### DIFF
--- a/Documentation/NR/map_names.txt
+++ b/Documentation/NR/map_names.txt
@@ -43,7 +43,7 @@ m34_30_00_00:Ruins - Beastmen of Farum Azula
 m35_90_00_00:Ruins - Tutorial and Revenant Encounter
 m37_90_00_00:Township
 m38_00_00_00:Great Church - Oracle Envoys; Guardian Golem
-m38_10_00_00:Great Church - Oracle Envoys; Guardian Golem
+m38_10_00_00:Great Church - Mausoleum Knight; Fire Monk
 m40_00_00_00:Sorcerer's Rise - Normal
 m40_90_00_00:Sorcerer's Rise - Ruined
 m41_00_00_00:Church - Dogs

--- a/src/Smithbox.Data/Assets/Aliases/NR/MapNames.json
+++ b/src/Smithbox.Data/Assets/Aliases/NR/MapNames.json
@@ -226,7 +226,7 @@
   },
   {
     "ID": "m38_10_00_00",
-    "Name": "Great Church - Oracle Envoys; Guardian Golem",
+    "Name": "Great Church - Mausoleum Knight; Fire Monk",
     "Tags": []
   },
   {

--- a/src/Smithbox.Data/Assets/PARAM/NR/Community Row Names/ItemLotParam_enemy.json
+++ b/src/Smithbox.Data/Assets/PARAM/NR/Community Row Names/ItemLotParam_enemy.json
@@ -364,19 +364,19 @@
     {
       "ID": 5310000,
       "Entries": [
-        ""
+        "[Coffin]"
       ]
     },
     {
       "ID": 5310001,
       "Entries": [
-        ""
+        "[Coffin]"
       ]
     },
     {
       "ID": 5310002,
       "Entries": [
-        "Cord End"
+        "[Coffin] Cord End"
       ]
     },
     {
@@ -2008,19 +2008,19 @@
     {
       "ID": 6123000,
       "Entries": [
-        "[Unused Crater Boss]"
+        "[Unused Rotted Woods Boss]"
       ]
     },
     {
       "ID": 6123001,
       "Entries": [
-        "[Unused Crater Boss]"
+        "[Unused Rotted Woods Boss]"
       ]
     },
     {
       "ID": 6123002,
       "Entries": [
-        "[Unused Crater Boss] Power Table 8 / Wending Grace"
+        "[Unused Rotted Woods Boss] Power Table 8 / Wending Grace"
       ]
     },
     {
@@ -2044,13 +2044,13 @@
     {
       "ID": 6123100,
       "Entries": [
-        "[Lordsworn Knight (Crater?)]"
+        "[Lordsworn Knight (Rotted Woods)]"
       ]
     },
     {
       "ID": 6123101,
       "Entries": [
-        "[Lordsworn Knight (Crater?)]"
+        "[Lordsworn Knight (Rotted Woods)]"
       ]
     },
     {
@@ -2362,37 +2362,37 @@
     {
       "ID": 6300000,
       "Entries": [
-        "[Unused Boss Drop]"
+        "[Flame of Frenzy (Random Encounter)]"
       ]
     },
     {
       "ID": 6300001,
       "Entries": [
-        "[Unused Boss Drop]"
+        "[Flame of Frenzy (Random Encounter)]"
       ]
     },
     {
       "ID": 6300002,
       "Entries": [
-        "[Unused Boss Drop]"
+        "[Flame of Frenzy (Random Encounter)]"
       ]
     },
     {
       "ID": 6300100,
       "Entries": [
-        "[Unused Boss Drop]"
+        "[Flame of Frenzy (Random Encounter)]"
       ]
     },
     {
       "ID": 6300101,
       "Entries": [
-        "[Unused Boss Drop]"
+        "[Flame of Frenzy (Random Encounter)]"
       ]
     },
     {
       "ID": 6300102,
       "Entries": [
-        "[Unused Boss Drop]"
+        "[Flame of Frenzy (Random Encounter)]"
       ]
     },
     {

--- a/src/Smithbox.Data/Assets/PARAM/NR/Community Row Names/NpcParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/NR/Community Row Names/NpcParam.json
@@ -142,19 +142,19 @@
     {
       "ID": 10000400,
       "Entries": [
-        ""
+        "Flame of Frenzy (Random Encounter)"
       ]
     },
     {
       "ID": 10000410,
       "Entries": [
-        ""
+        "Flame of Frenzy (Random Encounter)"
       ]
     },
     {
       "ID": 10000500,
       "Entries": [
-        ""
+        "Coffin"
       ]
     },
     {

--- a/src/Smithbox.Data/Assets/PARAM/NR/Community Row Names/SpEffectParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/NR/Community Row Names/SpEffectParam.json
@@ -41476,25 +41476,25 @@
     {
       "ID": 45890,
       "Entries": [
-        ""
+        "[Libra] Tempered Gold Chip (Small)"
       ]
     },
     {
       "ID": 45891,
       "Entries": [
-        ""
+        "[Libra] Tempered Gold Chip (Small)"
       ]
     },
     {
       "ID": 45892,
       "Entries": [
-        ""
+        "[Libra] Tempered Gold Chip (Small)"
       ]
     },
     {
       "ID": 45893,
       "Entries": [
-        ""
+        "[Libra] Tempered Gold Chip (Small)"
       ]
     },
     {
@@ -45124,19 +45124,19 @@
     {
       "ID": 49170,
       "Entries": [
-        ""
+        "[Libra] Tempered Gold Chip (Big)"
       ]
     },
     {
       "ID": 49171,
       "Entries": [
-        ""
+        "[Libra] Tempered Gold Chip (Big)"
       ]
     },
     {
       "ID": 49172,
       "Entries": [
-        ""
+        "[Libra] Tempered Gold Chip (Big)"
       ]
     },
     {
@@ -46114,19 +46114,19 @@
     {
       "ID": 49720,
       "Entries": [
-        ""
+        "[Libra] Demon's Eye"
       ]
     },
     {
       "ID": 49721,
       "Entries": [
-        ""
+        "[Libra] Demon's Eye"
       ]
     },
     {
       "ID": 49722,
       "Entries": [
-        ""
+        "[Libra] Demon's Eye"
       ]
     },
     {
@@ -46144,13 +46144,13 @@
     {
       "ID": 49730,
       "Entries": [
-        ""
+        "[Libra] Fruitless Trial"
       ]
     },
     {
       "ID": 49731,
       "Entries": [
-        ""
+        "[Libra] Fruitless Trial"
       ]
     },
     {
@@ -46180,25 +46180,25 @@
     {
       "ID": 49741,
       "Entries": [
-        ""
+        "[Libra] Demon's Madness"
       ]
     },
     {
       "ID": 49742,
       "Entries": [
-        ""
+        "[Libra] Demon's Madness"
       ]
     },
     {
       "ID": 49743,
       "Entries": [
-        ""
+        "[Libra] Demon's Madness"
       ]
     },
     {
       "ID": 49744,
       "Entries": [
-        ""
+        "[Libra] Demon's Madness"
       ]
     },
     {
@@ -47158,7 +47158,7 @@
     {
       "ID": 99110,
       "Entries": [
-        ""
+        "Mountaintop Ice Dragon Environmental Frostbite"
       ]
     },
     {
@@ -47170,7 +47170,7 @@
     {
       "ID": 99130,
       "Entries": [
-        ""
+        "Rotted Woods Environmental Scarlet Rot"
       ]
     },
     {
@@ -47194,7 +47194,7 @@
     {
       "ID": 99150,
       "Entries": [
-        ""
+        "[Evergaol Day 1 Scaling] 0.55x HP, 0.53x damage"
       ]
     },
     {
@@ -47206,7 +47206,7 @@
     {
       "ID": 99152,
       "Entries": [
-        ""
+        "[Evergaol Day 2 Scaling] 0.75x HP, 0.8x damage"
       ]
     },
     {
@@ -47728,13 +47728,13 @@
     {
       "ID": 99810,
       "Entries": [
-        "Night Rain Circle: Damage"
+        "Night Rain Circle: Damage (1st Shrinking)"
       ]
     },
     {
       "ID": 99811,
       "Entries": [
-        "Night Rain Circle: Damage"
+        "Night Rain Circle: Damage (2nd Shrinking)"
       ]
     },
     {
@@ -47896,49 +47896,49 @@
     {
       "ID": 99871,
       "Entries": [
-        ""
+        "Night Rain Circle: Increased Damage (1st Shrinking)"
       ]
     },
     {
       "ID": 99872,
       "Entries": [
-        ""
+        "Night Rain Circle: Instant Death (1st Shrinking)"
       ]
     },
     {
       "ID": 99873,
       "Entries": [
-        ""
+        "Night Rain Circle (1st Shrinking)"
       ]
     },
     {
       "ID": 99874,
       "Entries": [
-        ""
+        "Night Rain Circle (1st Shrinking)"
       ]
     },
     {
       "ID": 99876,
       "Entries": [
-        ""
+        "Night Rain Circle: Increased Damage (2nd Shrinking)"
       ]
     },
     {
       "ID": 99877,
       "Entries": [
-        ""
+        "Night Rain Circle: Instant Death (2nd Shrinking)"
       ]
     },
     {
       "ID": 99878,
       "Entries": [
-        ""
+        "Night Rain Circle (2nd Shrinking)"
       ]
     },
     {
       "ID": 99879,
       "Entries": [
-        ""
+        "Night Rain Circle (2nd Shrinking)"
       ]
     },
     {
@@ -52798,421 +52798,421 @@
     {
       "ID": 540001,
       "Entries": [
-        ""
+        "Poison Resistance (Neutralizing Boluses)"
       ]
     },
     {
       "ID": 540002,
       "Entries": [
-        ""
+        "Poison Resistance +1 (Neutralizing Boluses)"
       ]
     },
     {
       "ID": 540003,
       "Entries": [
-        ""
+        "Poison Resistance +2 (Neutralizing Boluses)"
       ]
     },
     {
       "ID": 540004,
       "Entries": [
-        ""
+        "Poison Resistance +3 (Neutralizing Boluses)"
       ]
     },
     {
       "ID": 540005,
       "Entries": [
-        ""
+        "Poison Resistance +4 (Neutralizing Boluses)"
       ]
     },
     {
       "ID": 540006,
       "Entries": [
-        ""
+        "Poison Resistance +5 (Neutralizing Boluses)"
       ]
     },
     {
       "ID": 540007,
       "Entries": [
-        ""
+        "Poison Resistance +6 (Neutralizing Boluses)"
       ]
     },
     {
       "ID": 540008,
       "Entries": [
-        ""
+        "Poison Resistance +7 (Neutralizing Boluses)"
       ]
     },
     {
       "ID": 540009,
       "Entries": [
-        ""
+        "Poison Resistance +8 (Neutralizing Boluses)"
       ]
     },
     {
       "ID": 540010,
       "Entries": [
-        ""
+        "Poison Resistance +9 (Neutralizing Boluses)"
       ]
     },
     {
       "ID": 540021,
       "Entries": [
-        ""
+        "Rot Resistance (Stanching Boluses)"
       ]
     },
     {
       "ID": 540022,
       "Entries": [
-        ""
+        "Rot Resistance +1 (Preserving Boluses)"
       ]
     },
     {
       "ID": 540023,
       "Entries": [
-        ""
+        "Rot Resistance +2 (Preserving Boluses)"
       ]
     },
     {
       "ID": 540024,
       "Entries": [
-        ""
+        "Rot Resistance +3 (Preserving Boluses)"
       ]
     },
     {
       "ID": 540025,
       "Entries": [
-        ""
+        "Rot Resistance +4 (Preserving Boluses)"
       ]
     },
     {
       "ID": 540026,
       "Entries": [
-        ""
+        "Rot Resistance +5 (Preserving Boluses)"
       ]
     },
     {
       "ID": 540027,
       "Entries": [
-        ""
+        "Rot Resistance +6 (Preserving Boluses)"
       ]
     },
     {
       "ID": 540028,
       "Entries": [
-        ""
+        "Rot Resistance +7 (Preserving Boluses)"
       ]
     },
     {
       "ID": 540029,
       "Entries": [
-        ""
+        "Rot Resistance +8 (Preserving Boluses)"
       ]
     },
     {
       "ID": 540030,
       "Entries": [
-        ""
+        "Rot Resistance +9 (Preserving Boluses)"
       ]
     },
     {
       "ID": 540041,
       "Entries": [
-        ""
+        "Blood Loss Resistance (Stanching Boluses)"
       ]
     },
     {
       "ID": 540042,
       "Entries": [
-        ""
+        "Blood Loss Resistance +1 (Stanching Boluses)"
       ]
     },
     {
       "ID": 540043,
       "Entries": [
-        ""
+        "Blood Loss Resistance +2 (Stanching Boluses)"
       ]
     },
     {
       "ID": 540044,
       "Entries": [
-        ""
+        "Blood Loss Resistance +3 (Stanching Boluses)"
       ]
     },
     {
       "ID": 540045,
       "Entries": [
-        ""
+        "Blood Loss Resistance +4 (Stanching Boluses)"
       ]
     },
     {
       "ID": 540046,
       "Entries": [
-        ""
+        "Blood Loss Resistance +5 (Stanching Boluses)"
       ]
     },
     {
       "ID": 540047,
       "Entries": [
-        ""
+        "Blood Loss Resistance +6 (Stanching Boluses)"
       ]
     },
     {
       "ID": 540048,
       "Entries": [
-        ""
+        "Blood Loss Resistance +7 (Stanching Boluses)"
       ]
     },
     {
       "ID": 540049,
       "Entries": [
-        ""
+        "Blood Loss Resistance +8 (Stanching Boluses)"
       ]
     },
     {
       "ID": 540050,
       "Entries": [
-        ""
+        "Blood Loss Resistance +9 (Stanching Boluses)"
       ]
     },
     {
       "ID": 540061,
       "Entries": [
-        ""
+        "Death Blight Resistance (Rejuvenating Boluses)"
       ]
     },
     {
       "ID": 540062,
       "Entries": [
-        ""
+        "Death Blight Resistance +1 (Rejuvenating Boluses)"
       ]
     },
     {
       "ID": 540063,
       "Entries": [
-        ""
+        "Death Blight Resistance +2 (Rejuvenating Boluses)"
       ]
     },
     {
       "ID": 540064,
       "Entries": [
-        ""
+        "Death Blight Resistance +3 (Rejuvenating Boluses)"
       ]
     },
     {
       "ID": 540065,
       "Entries": [
-        ""
+        "Death Blight Resistance +4 (Rejuvenating Boluses)"
       ]
     },
     {
       "ID": 540066,
       "Entries": [
-        ""
+        "Death Blight Resistance +5 (Rejuvenating Boluses)"
       ]
     },
     {
       "ID": 540067,
       "Entries": [
-        ""
+        "Death Blight Resistance +6 (Rejuvenating Boluses)"
       ]
     },
     {
       "ID": 540068,
       "Entries": [
-        ""
+        "Death Blight Resistance +7 (Rejuvenating Boluses)"
       ]
     },
     {
       "ID": 540069,
       "Entries": [
-        ""
+        "Death Blight Resistance +8 (Rejuvenating Boluses)"
       ]
     },
     {
       "ID": 540070,
       "Entries": [
-        ""
+        "Death Blight Resistance +9 (Rejuvenating Boluses)"
       ]
     },
     {
       "ID": 540081,
       "Entries": [
-        ""
+        "Frost Resistance (Thawfrost Boluses)"
       ]
     },
     {
       "ID": 540082,
       "Entries": [
-        ""
+        "Frost Resistance +1 (Thawfrost Boluses)"
       ]
     },
     {
       "ID": 540083,
       "Entries": [
-        ""
+        "Frost Resistance +2 (Thawfrost Boluses)"
       ]
     },
     {
       "ID": 540084,
       "Entries": [
-        ""
+        "Frost Resistance +3 (Thawfrost Boluses)"
       ]
     },
     {
       "ID": 540085,
       "Entries": [
-        ""
+        "Frost Resistance +4 (Thawfrost Boluses)"
       ]
     },
     {
       "ID": 540086,
       "Entries": [
-        ""
+        "Frost Resistance +5 (Thawfrost Boluses)"
       ]
     },
     {
       "ID": 540087,
       "Entries": [
-        ""
+        "Frost Resistance +6 (Thawfrost Boluses)"
       ]
     },
     {
       "ID": 540088,
       "Entries": [
-        ""
+        "Frost Resistance +7 (Thawfrost Boluses)"
       ]
     },
     {
       "ID": 540089,
       "Entries": [
-        ""
+        "Frost Resistance +8 (Thawfrost Boluses)"
       ]
     },
     {
       "ID": 540090,
       "Entries": [
-        ""
+        "Frost Resistance +9 (Thawfrost Boluses)"
       ]
     },
     {
       "ID": 540101,
       "Entries": [
-        ""
+        "Sleep Resistance (Stimulating Boluses)"
       ]
     },
     {
       "ID": 540102,
       "Entries": [
-        ""
+        "Sleep Resistance +1 (Stimulating Boluses)"
       ]
     },
     {
       "ID": 540103,
       "Entries": [
-        ""
+        "Sleep Resistance +2 (Stimulating Boluses)"
       ]
     },
     {
       "ID": 540104,
       "Entries": [
-        ""
+        "Sleep Resistance +3 (Stimulating Boluses)"
       ]
     },
     {
       "ID": 540105,
       "Entries": [
-        ""
+        "Sleep Resistance +4 (Stimulating Boluses)"
       ]
     },
     {
       "ID": 540106,
       "Entries": [
-        ""
+        "Sleep Resistance +5 (Stimulating Boluses)"
       ]
     },
     {
       "ID": 540107,
       "Entries": [
-        ""
+        "Sleep Resistance +6 (Stimulating Boluses)"
       ]
     },
     {
       "ID": 540108,
       "Entries": [
-        ""
+        "Sleep Resistance +7 (Stimulating Boluses)"
       ]
     },
     {
       "ID": 540109,
       "Entries": [
-        ""
+        "Sleep Resistance +8 (Stimulating Boluses)"
       ]
     },
     {
       "ID": 540110,
       "Entries": [
-        ""
+        "Sleep Resistance +9 (Stimulating Boluses)"
       ]
     },
     {
       "ID": 540121,
       "Entries": [
-        ""
+        "Madness Resistance (Clarifying Boluses)"
       ]
     },
     {
       "ID": 540122,
       "Entries": [
-        ""
+        "Madness Resistance +1 (Clarifying Boluses)"
       ]
     },
     {
       "ID": 540123,
       "Entries": [
-        ""
+        "Madness Resistance +2 (Clarifying Boluses)"
       ]
     },
     {
       "ID": 540124,
       "Entries": [
-        ""
+        "Madness Resistance +3 (Clarifying Boluses)"
       ]
     },
     {
       "ID": 540125,
       "Entries": [
-        ""
+        "Madness Resistance +4 (Clarifying Boluses)"
       ]
     },
     {
       "ID": 540126,
       "Entries": [
-        ""
+        "Madness Resistance +5 (Clarifying Boluses)"
       ]
     },
     {
       "ID": 540127,
       "Entries": [
-        ""
+        "Madness Resistance +6 (Clarifying Boluses)"
       ]
     },
     {
       "ID": 540128,
       "Entries": [
-        ""
+        "Madness Resistance +7 (Clarifying Boluses)"
       ]
     },
     {
       "ID": 540129,
       "Entries": [
-        ""
+        "Madness Resistance +8 (Clarifying Boluses)"
       ]
     },
     {
       "ID": 540130,
       "Entries": [
-        ""
+        "Madness Resistance +9 (Clarifying Boluses)"
       ]
     },
     {
@@ -56686,67 +56686,67 @@
     {
       "ID": 6999000,
       "Entries": [
-        ""
+        "Favor of the Night"
       ]
     },
     {
       "ID": 6999100,
       "Entries": [
-        ""
+        "Favor of Noklateo"
       ]
     },
     {
       "ID": 6999101,
       "Entries": [
-        ""
+        "Favor of Noklateo"
       ]
     },
     {
       "ID": 6999104,
       "Entries": [
-        ""
+        "Favor of Noklateo (Revival Buff)"
       ]
     },
     {
       "ID": 6999105,
       "Entries": [
-        ""
+        "Favor of Noklateo (Revival Buff)"
       ]
     },
     {
       "ID": 6999106,
       "Entries": [
-        ""
+        "Favor of Noklateo (Revival Buff)"
       ]
     },
     {
       "ID": 6999107,
       "Entries": [
-        ""
+        "Favor of Noklateo (Revival Buff)"
       ]
     },
     {
       "ID": 6999200,
       "Entries": [
-        ""
+        "Favor of the Rotted Woods"
       ]
     },
     {
       "ID": 6999300,
       "Entries": [
-        ""
+        "Favor of the Mountaintop"
       ]
     },
     {
       "ID": 6999310,
       "Entries": [
-        ""
+        "Improved Frost Resistance"
       ]
     },
     {
       "ID": 6999320,
       "Entries": [
-        ""
+        "Attacks Possess Anti-Dragon Effect"
       ]
     },
     {
@@ -56764,43 +56764,43 @@
     {
       "ID": 6999332,
       "Entries": [
-        ""
+        "Favor of the Mountaintop"
       ]
     },
     {
       "ID": 6999333,
       "Entries": [
-        ""
+        "Favor of the Mountaintop"
       ]
     },
     {
       "ID": 6999400,
       "Entries": [
-        ""
+        "Unhealed Wound Carved by the Night"
       ]
     },
     {
       "ID": 6999500,
       "Entries": [
-        ""
+        "Automatic Revival Upon Defeat (Solo)"
       ]
     },
     {
       "ID": 6999501,
       "Entries": [
-        ""
+        "Automatic Revival Upon Defeat (Solo)"
       ]
     },
     {
       "ID": 6999505,
       "Entries": [
-        ""
+        "Automatic Revival Upon Defeat (Solo)"
       ]
     },
     {
       "ID": 6999506,
       "Entries": [
-        ""
+        "Automatic Revival Upon Defeat (Solo)"
       ]
     },
     {
@@ -57430,49 +57430,49 @@
     {
       "ID": 7010220,
       "Entries": [
-        "RELIC: Flask Also Heals Allies"
+        "RELIC: Flask Also Heals Allies (Self)"
       ]
     },
     {
       "ID": 7010221,
       "Entries": [
-        "RELIC: Flask Also Heals Allies"
+        "RELIC: Flask Also Heals Allies (Ally)"
       ]
     },
     {
       "ID": 7010230,
       "Entries": [
-        "RELIC: Flask Also Heals Allies"
+        "POW: Gradual Restoration by Flask (Unused)"
       ]
     },
     {
       "ID": 7010231,
       "Entries": [
-        "RELIC: Flask Also Heals Allies"
+        "POW: Gradual Restoration by Flask / RELIC: Ally Flask + POW: Gradual Flask (Self)"
       ]
     },
     {
       "ID": 7010240,
       "Entries": [
-        "RELIC: Flask Also Heals Allies"
+        "RELIC: Ally Flask + POW: Gradual Flask (Flat For Allies)"
       ]
     },
     {
       "ID": 7010241,
       "Entries": [
-        "RELIC: Flask Also Heals Allies"
+        "RELIC: Ally Flask + POW: Gradual Flask (Overtime For Allies)"
       ]
     },
     {
       "ID": 7010250,
       "Entries": [
-        "RELIC: Flask Also Heals Allies"
+        "RELIC: Ally Flask + POW: Unifying Fate (Self)"
       ]
     },
     {
       "ID": 7010260,
       "Entries": [
-        "RELIC: Flask Also Heals Allies"
+        "RELIC: Ally Flask + POW: Unifying Fate (Ally)"
       ]
     },
     {
@@ -58738,13 +58738,13 @@
     {
       "ID": 7050101,
       "Entries": [
-        "RELIC: Items confer effect to all nearby allies"
+        "RELIC: Items confer effect to all nearby allies (Starlight Shards)"
       ]
     },
     {
       "ID": 7050102,
       "Entries": [
-        "RELIC: Items confer effect to all nearby allies"
+        "RELIC: Items confer effect to all nearby allies (Starlight Shards)"
       ]
     },
     {
@@ -58756,121 +58756,121 @@
     {
       "ID": 7050201,
       "Entries": [
-        "RELIC: Items confer effect to all nearby allies"
+        "RELIC: Items confer effect to all nearby allies (Neutralizing Boluses)"
       ]
     },
     {
       "ID": 7050202,
       "Entries": [
-        "RELIC: Items confer effect to all nearby allies"
+        "RELIC: Items confer effect to all nearby allies (Neutralizing Boluses)"
       ]
     },
     {
       "ID": 7050203,
       "Entries": [
-        "RELIC: Items confer effect to all nearby allies"
+        "RELIC: Items confer effect to all nearby allies (Neutralizing Boluses)"
       ]
     },
     {
       "ID": 7050204,
       "Entries": [
-        "RELIC: Items confer effect to all nearby allies"
+        "RELIC: Items confer effect to all nearby allies (Stanching Boluses)"
       ]
     },
     {
       "ID": 7050205,
       "Entries": [
-        "RELIC: Items confer effect to all nearby allies"
+        "RELIC: Items confer effect to all nearby allies (Stanching Boluses)"
       ]
     },
     {
       "ID": 7050206,
       "Entries": [
-        "RELIC: Items confer effect to all nearby allies"
+        "RELIC: Items confer effect to all nearby allies (Stanching Boluses)"
       ]
     },
     {
       "ID": 7050207,
       "Entries": [
-        "RELIC: Items confer effect to all nearby allies"
+        "RELIC: Items confer effect to all nearby allies (Thawfrost Boluses)"
       ]
     },
     {
       "ID": 7050208,
       "Entries": [
-        "RELIC: Items confer effect to all nearby allies"
+        "RELIC: Items confer effect to all nearby allies (Thawfrost Boluses)"
       ]
     },
     {
       "ID": 7050209,
       "Entries": [
-        "RELIC: Items confer effect to all nearby allies"
+        "RELIC: Items confer effect to all nearby allies (Thawfrost Boluses)"
       ]
     },
     {
       "ID": 7050210,
       "Entries": [
-        "RELIC: Items confer effect to all nearby allies"
+        "RELIC: Items confer effect to all nearby allies (Stimulating Boluses)"
       ]
     },
     {
       "ID": 7050211,
       "Entries": [
-        "RELIC: Items confer effect to all nearby allies"
+        "RELIC: Items confer effect to all nearby allies (Stimulating Boluses)"
       ]
     },
     {
       "ID": 7050212,
       "Entries": [
-        "RELIC: Items confer effect to all nearby allies"
+        "RELIC: Items confer effect to all nearby allies (Stimulating Boluses)"
       ]
     },
     {
       "ID": 7050213,
       "Entries": [
-        "RELIC: Items confer effect to all nearby allies"
+        "RELIC: Items confer effect to all nearby allies (Preserving Boluses)"
       ]
     },
     {
       "ID": 7050214,
       "Entries": [
-        "RELIC: Items confer effect to all nearby allies"
+        "RELIC: Items confer effect to all nearby allies (Preserving Boluses)"
       ]
     },
     {
       "ID": 7050215,
       "Entries": [
-        "RELIC: Items confer effect to all nearby allies"
+        "RELIC: Items confer effect to all nearby allies (Preserving Boluses)"
       ]
     },
     {
       "ID": 7050216,
       "Entries": [
-        "RELIC: Items confer effect to all nearby allies"
+        "RELIC: Items confer effect to all nearby allies (Rejuvenating Boluses)"
       ]
     },
     {
       "ID": 7050217,
       "Entries": [
-        "RELIC: Items confer effect to all nearby allies"
+        "RELIC: Items confer effect to all nearby allies (Rejuvenating Boluses)"
       ]
     },
     {
       "ID": 7050218,
       "Entries": [
-        "RELIC: Items confer effect to all nearby allies"
+        "RELIC: Items confer effect to all nearby allies (Clarifying Boluses)"
       ]
     },
     {
       "ID": 7050219,
       "Entries": [
-        "RELIC: Items confer effect to all nearby allies"
+        "RELIC: Items confer effect to all nearby allies (Clarifying Boluses)"
       ]
     },
     {
       "ID": 7050220,
       "Entries": [
-        "RELIC: Items confer effect to all nearby allies"
+        "RELIC: Items confer effect to all nearby allies (Clarifying Boluses)"
       ]
     },
     {
@@ -58882,37 +58882,37 @@
     {
       "ID": 7050301,
       "Entries": [
-        "RELIC: Items confer effect to all nearby allies"
+        "RELIC: Items confer effect to all nearby allies (Exalted Flesh)"
       ]
     },
     {
       "ID": 7050302,
       "Entries": [
-        "RELIC: Items confer effect to all nearby allies"
+        "RELIC: Items confer effect to all nearby allies (Pickled Turtle Neck)"
       ]
     },
     {
       "ID": 7050303,
       "Entries": [
-        "RELIC: Items confer effect to all nearby allies"
+        "RELIC: Items confer effect to all nearby allies (Silver-Pickled Fowl Foot)"
       ]
     },
     {
       "ID": 7050304,
       "Entries": [
-        "RELIC: Items confer effect to all nearby allies"
+        "RELIC: Items confer effect to all nearby allies (Gold-Pickled Fowl Foot)"
       ]
     },
     {
       "ID": 7050305,
       "Entries": [
-        "RELIC: Items confer effect to all nearby allies"
+        "RELIC: Items confer effect to all nearby allies (Boiled Crab)"
       ]
     },
     {
       "ID": 7050306,
       "Entries": [
-        "RELIC: Items confer effect to all nearby allies"
+        "RELIC: Items confer effect to all nearby allies (Boiled Prawn)"
       ]
     },
     {

--- a/src/Smithbox.Data/Assets/PARAM/NR/Defs/AntiqueStandParam.xml
+++ b/src/Smithbox.Data/Assets/PARAM/NR/Defs/AntiqueStandParam.xml
@@ -20,9 +20,9 @@
     <Field Def="s32 unlockFlag"/>
     <Field Def="s32 goodsId"/>
     
-    <Field Def="u8 unkColor_01" FirstVersion="10200000"/>
-    <Field Def="u8 unkColor_02" FirstVersion="10200000"/>
-    <Field Def="u8 unkColor_03" FirstVersion="10200000"/>
+    <Field Def="u8 deepRelicSlot1" FirstVersion="10200000"/>
+    <Field Def="u8 deepRelicSlot2" FirstVersion="10200000"/>
+    <Field Def="u8 deepRelicSlot3" FirstVersion="10200000"/>
     
     <Field Def="dummy8 endPadding[1]" FirstVersion="10200000"/>
   </Fields>

--- a/src/Smithbox.Data/Assets/PARAM/NR/Defs/ChaosMatchingRankControlParam.xml
+++ b/src/Smithbox.Data/Assets/PARAM/NR/Defs/ChaosMatchingRankControlParam.xml
@@ -7,14 +7,14 @@
   <FormatVersion>0</FormatVersion>
   <!-- FirstVersion="10200000" -->
   <Fields>
+    <Field Def="u8 cursedUncommonRate"/>
+    <Field Def="u8 cursedRareRate"/>
     <Field Def="u8 mapChallengeWeight_Map"/>
     <Field Def="u8 mapChallengeWeight_Nightlord"/>
     <Field Def="u8 mapChallengeWeight_None"/>
     <Field Def="u8 cataclysmWeight_0"/>
     <Field Def="u8 cataclysmWeight_1"/>
     <Field Def="u8 cataclysmWeight_2"/>
-    <Field Def="u8 cursedUncommonRate"/>
-    <Field Def="u8 cursedRareRate"/>
     
     <Field Def="dummy8 endPadding[4]"/>
   </Fields>

--- a/src/Smithbox.Data/Assets/PARAM/NR/Defs/NpcParam.xml
+++ b/src/Smithbox.Data/Assets/PARAM/NR/Defs/NpcParam.xml
@@ -2218,8 +2218,8 @@
     
     <Field Def="s32 chaosMatchingCorrectParamId" FirstVersion="10200000"/>
     <Field Def="s32 chaosMatchingSpEffectSetParamId" FirstVersion="10200000"/>
+    <Field Def="s32 chaosMatchingRewardLotId" FirstVersion="10200000"/>
     <Field Def="s32 chaosMatchingItemLotId" FirstVersion="10200000"/>
-    <Field Def="s32 chaosMatchingMutationTableId" FirstVersion="10200000"/>
     <Field Def="s32 chaosMatchingUnk" FirstVersion="10200000"/>
     
     <Field Def="dummy8 endPadding[12]" FirstVersion="10200000"/>

--- a/src/Smithbox.Data/Assets/PARAM/NR/Meta/AntiqueStandParam.xml
+++ b/src/Smithbox.Data/Assets/PARAM/NR/Meta/AntiqueStandParam.xml
@@ -50,19 +50,19 @@
     Wiki="The linked goods item for this relic vessel." 
     Refs="EquipParamGoods" />
     
-    <unkColor_01
-    AltName="Unknown - Color: 1"
-    Wiki=""
+    <deepRelicSlot1
+    AltName="Depths Relic Slot Color: 1"
+    Wiki="The color for the first depths relic slot."
     Enum="SLOT_COLOR" />
     
-    <unkColor_02
-    AltName="Unknown - Color: 3"
-    Wiki=""
+    <deepRelicSlot2
+    AltName="Depths Relic Slot Color: 2"
+    Wiki="The color for the second depths relic slot."
     Enum="SLOT_COLOR" />
     
-    <unkColor_03
-    AltName="Unknown - Color: 4"
-    Wiki=""
+    <deepRelicSlot3
+    AltName="Depths Relic Slot Color: 3"
+    Wiki="The color for the third depths relic slot."
     Enum="SLOT_COLOR" />
     
     <endPadding

--- a/src/Smithbox.Data/Assets/PARAM/NR/Meta/NpcParam.xml
+++ b/src/Smithbox.Data/Assets/PARAM/NR/Meta/NpcParam.xml
@@ -648,23 +648,23 @@
     
     <chaosMatchingCorrectParamId
     AltName="Chaos Matching: Correction ID"
-    Wiki=""
+    Wiki="Speffect sets that determine enemy scaling for each depth."
     Refs="ChaosMatchingCorrectParam" />
     
     <chaosMatchingSpEffectSetParamId
     AltName="Chaos Matching: SpEffect Set ID"
-    Wiki=""
+    Wiki="Applies when an enemy is mutated."
     Refs="SpEffectSetParam" />
     
-    <chaosMatchingItemLotId
-    AltName="Chaos Matching: Item Lot ID"
-    Wiki=""
+    <chaosMatchingRewardLotId
+    AltName="Chaos Matching: Reward ItemLot ID"
+    Wiki="The item lot id that replaces the normal reward itemlot id when an enemy is mutated. Includes the Dormant Power roll."
     Refs="ItemLotParam_enemy" />
     
-    <chaosMatchingMutationTableId
-    AltName="Chaos Matching: Mutation Table ID"
-    Wiki=""
-    Refs="ChaosMatchingMutationEnemyTableParam" />
+    <chaosMatchingItemLotId
+    AltName="Chaos Matching: Enemy Itemlot ID"
+    Wiki="The item lot id that replaces the normal enemy itemlot id when an enemy is mutated."
+    Refs="ItemLotParam_enemy" />
 
     <Day2SpEffectParamID
     AltName="Day 2 SpEffect ID"


### PR DESCRIPTION
Including a NR map name correction.
The chaosMatchingMutationTableId param in NpcParam is changed by me. I tested it many times, and it should refer to ItemLotParam_enemy. I attempted to modify it and obtained the expected enemy drops.
Thanks for your work.