### PR TITLE
Some NR Names, defs and meta

### DIFF
--- a/src/Smithbox.Data/Assets/PARAM/NR/Community Row Names/Bullet.json
+++ b/src/Smithbox.Data/Assets/PARAM/NR/Community Row Names/Bullet.json
@@ -4924,19 +4924,19 @@
     {
       "ID": 180105,
       "Entries": [
-        ""
+        "[Material] Restore HP"
       ]
     },
     {
       "ID": 180106,
       "Entries": [
-        ""
+        "[Material] Restore HP"
       ]
     },
     {
       "ID": 180107,
       "Entries": [
-        ""
+        "[Material] Restore HP"
       ]
     },
     {

--- a/src/Smithbox.Data/Assets/PARAM/NR/Community Row Names/SpEffectParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/NR/Community Row Names/SpEffectParam.json
@@ -9550,61 +9550,61 @@
     {
       "ID": 6900,
       "Entries": [
-        ""
+        "Successive Attacks AccumuVal: 2"
       ]
     },
     {
       "ID": 6901,
       "Entries": [
-        ""
+        "Successive Attacks AccumuVal: 4"
       ]
     },
     {
       "ID": 6902,
       "Entries": [
-        ""
+        "Successive Attacks AccumuVal: 6"
       ]
     },
     {
       "ID": 6903,
       "Entries": [
-        ""
+        "Successive Attacks AccumuVal: 8"
       ]
     },
     {
       "ID": 6904,
       "Entries": [
-        ""
+        "Successive Attacks AccumuVal: 10"
       ]
     },
     {
       "ID": 6905,
       "Entries": [
-        ""
+        "Successive Attacks AccumuVal: 12"
       ]
     },
     {
       "ID": 6906,
       "Entries": [
-        ""
+        "Successive Attacks AccumuVal: 14"
       ]
     },
     {
       "ID": 6907,
       "Entries": [
-        ""
+        "Successive Attacks AccumuVal: 16"
       ]
     },
     {
       "ID": 6908,
       "Entries": [
-        ""
+        "Successive Attacks AccumuVal: 18"
       ]
     },
     {
       "ID": 6909,
       "Entries": [
-        ""
+        "Successive Attacks AccumuVal: 20"
       ]
     },
     {
@@ -39370,7 +39370,7 @@
     {
       "ID": 42176,
       "Entries": [
-        ""
+        "[Adel] Poison Special Behavior - Damage"
       ]
     },
     {
@@ -42832,13 +42832,13 @@
     {
       "ID": 46306,
       "Entries": [
-        ""
+        "[Fulghor] Elemental Weakness Special Behavior - Damage"
       ]
     },
     {
       "ID": 46307,
       "Entries": [
-        ""
+        "[Fulghor] Elemental Weakness Special Behavior - Damage"
       ]
     },
     {
@@ -44716,7 +44716,7 @@
     {
       "ID": 49063,
       "Entries": [
-        ""
+        "[Libra] Madness Special Behavior - Buff"
       ]
     },
     {
@@ -45940,25 +45940,25 @@
     {
       "ID": 49500,
       "Entries": [
-        ""
+        "[Libra] The Condemned's Golden Buff"
       ]
     },
     {
       "ID": 49501,
       "Entries": [
-        ""
+        "[Libra] The Condemned's Golden Buff - 1st"
       ]
     },
     {
       "ID": 49502,
       "Entries": [
-        ""
+        "[Libra] The Condemned's Golden Buff - 2nd and later"
       ]
     },
     {
       "ID": 49503,
       "Entries": [
-        ""
+        "[Libra] The Condemned's HP Recovery"
       ]
     },
     {
@@ -47044,25 +47044,25 @@
     {
       "ID": 96010,
       "Entries": [
-        ""
+        "[Caligo] Elemental Weakness Special Behavior - Damage"
       ]
     },
     {
       "ID": 96011,
       "Entries": [
-        ""
+        "[Caligo] Elemental Weakness Special Behavior - Debuff"
       ]
     },
     {
       "ID": 96015,
       "Entries": [
-        ""
+        "[Caligo] Elemental Weakness Increased Resistance"
       ]
     },
     {
       "ID": 96016,
       "Entries": [
-        ""
+        "[Caligo] Elemental Weakness Increased Resistance 2"
       ]
     },
     {
@@ -47074,13 +47074,13 @@
     {
       "ID": 96101,
       "Entries": [
-        ""
+        "[Maris] Elemental Weakness Special Behavior - Damage"
       ]
     },
     {
       "ID": 96102,
       "Entries": [
-        ""
+        "[Maris] Elemental Weakness Special Behavior - Damage"
       ]
     },
     {
@@ -47104,49 +47104,49 @@
     {
       "ID": 96200,
       "Entries": [
-        ""
+        "[Gladius] Elemental Weakness Special Behavior - Damage"
       ]
     },
     {
       "ID": 96201,
       "Entries": [
-        ""
+        "[Gladius] Elemental Weakness Special Behavior - Debuff"
       ]
     },
     {
       "ID": 96205,
       "Entries": [
-        ""
+        "[Gladius] Elemental Weakness Increased Resistance"
       ]
     },
     {
       "ID": 96206,
       "Entries": [
-        ""
+        "[Gladius] Elemental Weakness Increased Resistance 2"
       ]
     },
     {
       "ID": 96210,
       "Entries": [
-        ""
+        "[Heolstor] Elemental Weakness Special Behavior - Damage"
       ]
     },
     {
       "ID": 96211,
       "Entries": [
-        ""
+        "[Heolstor] Elemental Weakness Special Behavior - Debuff"
       ]
     },
     {
       "ID": 96215,
       "Entries": [
-        ""
+        "[Heolstor] Elemental Weakness Increased Resistance"
       ]
     },
     {
       "ID": 96216,
       "Entries": [
-        ""
+        "[Heolstor] Elemental Weakness Increased Resistance 2"
       ]
     },
     {
@@ -47596,7 +47596,7 @@
     {
       "ID": 99515,
       "Entries": [
-        ""
+        "[Material] Rowa Fruit - Restore HP"
       ]
     },
     {
@@ -47614,55 +47614,55 @@
     {
       "ID": 99530,
       "Entries": [
-        ""
+        "[Material] Gold Firefly - Boost Rune Acquisition"
       ]
     },
     {
       "ID": 99540,
       "Entries": [
-        ""
+        "[Material] Nascent Butterfly - Cure Status Effects"
       ]
     },
     {
       "ID": 99541,
       "Entries": [
-        ""
+        "[Material] Nascent Butterfly - Improve Status Effects Resistance"
       ]
     },
     {
       "ID": 99555,
       "Entries": [
-        ""
+        "[Material] Grave Violet - Summon Foe-chasing Vengeful Spirits"
       ]
     },
     {
       "ID": 99565,
       "Entries": [
-        ""
+        "[Material] Smoldering Butterfly - Boost Physical and Fire Damage"
       ]
     },
     {
       "ID": 99570,
       "Entries": [
-        ""
+        "[Material] Sacramental Bud - Cure Rot and Restore HP"
       ]
     },
     {
       "ID": 99585,
       "Entries": [
-        ""
+        "[Material] Crystal Bud - Restore FP"
       ]
     },
     {
       "ID": 99590,
       "Entries": [
-        ""
+        "[Material] Silver Tear Husk - Boost Damage Negation"
       ]
     },
     {
       "ID": 99605,
       "Entries": [
-        ""
+        "[Material] Rimed Rowa - Restore HP"
       ]
     },
     {

--- a/src/Smithbox.Data/Assets/PARAM/NR/Defs/HeroParam.xml
+++ b/src/Smithbox.Data/Assets/PARAM/NR/Defs/HeroParam.xml
@@ -42,7 +42,7 @@
     <Field Def="s32 characterSkillDescriptionId"/>
     <Field Def="s32 ultimateArtDescriptionId"/>
     <Field Def="s32 passiveAbilityDescriptionId"/>
-    <Field Def="s32 unknown_38"/>
+    <Field Def="s32 defaultWeaponTypeDiscovery"/>
     <Field Def="s32 unknown_39"/>
   </Fields>
 </PARAMDEF>

--- a/src/Smithbox.Data/Assets/PARAM/NR/Defs/SpEffectParam.xml
+++ b/src/Smithbox.Data/Assets/PARAM/NR/Defs/SpEffectParam.xml
@@ -77,7 +77,7 @@
     <Field Def="f32 registDiseaseChangeRate"/>
     <Field Def="f32 registBloodChangeRate"/>
     <Field Def="f32 registCurseChangeRate"/>
-    <Field Def="s32 soulStealRate"/>
+    <Field Def="s32 secondaryIconId"/>
     <Field Def="f32 lifeReductionRate"/>
     <Field Def="f32 hpRecoverRate"/>
     <Field Def="s32 replaceSpEffectId"/>
@@ -256,7 +256,7 @@
     <Field Def="f32 unknown_146"/>
     <Field Def="f32 unknown_147"/>
     <Field Def="f32 unknown_148"/>
-    <Field Def="s32 secondaryIconId"/>
+    <Field Def="s32 tertiaryIconId"/>
     
     <Field Def="u8 madnessDamageRate"/>
     <Field Def="u8 isUseStatusAilmentAtkPowerCorrect:1"/>

--- a/src/Smithbox.Data/Assets/PARAM/NR/Meta/HeroParam.xml
+++ b/src/Smithbox.Data/Assets/PARAM/NR/Meta/HeroParam.xml
@@ -123,9 +123,24 @@
     AltName="Passive Ability Description ID"
     Wiki="The description of the passive ability for this character." 
     FmgRef="Modern_Menu_Text" />
+	
+	<defaultWeaponTypeDiscovery
+    AltName="Default Weapon Type Discovery"
+    Wiki="Default weaponTypeDiscovery for each character." 
+    Enum="WEP_TYPE" />
     
   </Field>
   
   <Enums>
+    <Enum Name="WEP_TYPE" type="u16">
+	  <Option Value="1100" Name="Wylder - Greatsword" />
+	  <Option Value="1200" Name="Guardian - Halberd" />
+	  <Option Value="1300" Name="Ironeye - Light Bow / Bow" />
+	  <Option Value="1400" Name="Duchess - Dagger" />
+	  <Option Value="1500" Name="Raider - Great Hammer / Greataxe / Colossal Weapon" />
+	  <Option Value="1600" Name="Revenant - Seal" />
+	  <Option Value="1700" Name="Recluse - Staff" />
+	  <Option Value="1800" Name="Executor - Katana" />
+	</Enum>
   </Enums>
 </PARAMMETA>

--- a/src/Smithbox.Data/Assets/PARAM/NR/Meta/ItemTableParam.xml
+++ b/src/Smithbox.Data/Assets/PARAM/NR/Meta/ItemTableParam.xml
@@ -48,7 +48,7 @@
 
     <weaponTypeDiscovery
     AltName="Weapon Type Discovery"
-    Wiki="Only roll this entry if the player has a SpEffect with matching weaponTypeDiscovery."
+    Wiki="Only roll this entry if the player has a matching weaponTypeDiscovery. Related relic SpEffect will overwrite the default one. "
     Enum="WEP_TYPE" />
   </Field>
   
@@ -77,6 +77,7 @@
     </Enum>
 
     <Enum Name="WEP_TYPE" type="u16">
+	  <Option Value="-1" Name="Matching Any weaponTypeDiscovery" />
       <Option Value="0" Name="None" />
       <Option Value="1" Name="Dagger" />
       <Option Value="3" Name="Straight Sword" />
@@ -126,6 +127,14 @@
       <Option Value="95" Name="Beast Claw" />
       <Option Value="256" Name="Weapons" />
       <Option Value="512" Name="Shields" />
+	  <Option Value="1100" Name="Wylder - Greatsword" />
+	  <Option Value="1200" Name="Guardian - Halberd" />
+	  <Option Value="1300" Name="Ironeye - Light Bow / Bow" />
+	  <Option Value="1400" Name="Duchess - Dagger" />
+	  <Option Value="1500" Name="Raider - Great Hammer / Greataxe / Colossal Weapon" />
+	  <Option Value="1600" Name="Revenant - Seal" />
+	  <Option Value="1700" Name="Recluse - Staff" />
+	  <Option Value="1800" Name="Executor - Katana" />
     </Enum>
   </Enums>
 </PARAMMETA>

--- a/src/Smithbox.Data/Assets/PARAM/NR/Meta/SpEffectParam.xml
+++ b/src/Smithbox.Data/Assets/PARAM/NR/Meta/SpEffectParam.xml
@@ -358,9 +358,10 @@
     Wiki="Multiply the spell resistance value by the set multiplier" 
     DefaultValue="1" />
     
-    <soulStealRate 
-    AltName="Soul Steal %" 
-    Wiki="Defense against HP robbed by NPCs in Soul Steel" 
+    <secondaryIconId 
+    AltName="Secondary Icon ID" 
+    Wiki="Icon ID (When -1, no icon is required)" 
+	IconConfig="Status" 
     DefaultValue="-1" />
     
     <lifeReductionRate 
@@ -1391,8 +1392,8 @@
     Wiki="Correction value used only for point damage and% damage of state change type [madness]" 
     DefaultValue="100" />
     
-    <secondaryIconId 
-    AltName="Secondary Icon ID" 
+    <tertiaryIconId 
+    AltName="Tertiary Icon ID" 
     Wiki="Icon ID (When -1, no icon is required)" 
     IconConfig="Status" 
     DefaultValue="-1" />


### PR DESCRIPTION
soulStealRate in SpEffectParam should be secondaryIconId, and the original secondary has been changed to tertiary. For example, 1730 Golden Vow Buff in SpEffect.