### PR TITLE
fix: Map editor property name sync

### DIFF
--- a/src/Smithbox.Program/Editors/MapEditor/Core/MapPropertyView.cs
+++ b/src/Smithbox.Program/Editors/MapEditor/Core/MapPropertyView.cs
@@ -610,6 +610,7 @@ public class MapPropertyView
 
         if (input.Draw("##value", out string newValue))
         {
+            editName = (newValue, first);
             if (entities.Count() == 1)
             {
                 ContextActionManager.ExecuteAction(new RenameObjectsAction(


### PR DESCRIPTION
Force refresh small patch to fix the bug of displaying Name out of sync.
Thank you for your work.