### PR TITLE
MSB-NR

### DIFF
--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/MSB/MSB-NR/EventParam.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/MSB/MSB-NR/EventParam.cs
@@ -262,7 +262,7 @@ namespace SoulsFormats
             /// <summary>
             /// Unknown.
             /// </summary>
-            public int MapID { get; set; }
+            public sbyte[] MapID { get; set; } = new sbyte[4];
 
             /// <summary>
             /// Unknown.
@@ -346,7 +346,7 @@ namespace SoulsFormats
 
                 // Unk3
                 br.Position = start + unk3Offset;
-                MapID = br.ReadInt32();
+                MapID = br.ReadSBytes(4);
                 UnkS04 = br.ReadInt32();
                 UnkS08 = br.ReadInt32();
                 UnkS0C = br.ReadInt32();
@@ -408,7 +408,7 @@ namespace SoulsFormats
                 }
 
                 bw.FillInt64("Unk3Offset", bw.Position - start);
-                bw.WriteInt32(MapID);
+                bw.WriteSBytes(MapID);
                 bw.WriteInt32(UnkS04);
                 bw.WriteInt32(UnkS08);
                 bw.WriteInt32(UnkS0C);
@@ -1366,7 +1366,7 @@ namespace SoulsFormats
 
 
             /// <summary>
-            /// Unknown.
+            /// The structure is very similar to Sekiro.
             /// </summary>
             public class ConversationInformation : Event
             {
@@ -1380,112 +1380,48 @@ namespace SoulsFormats
 
                 internal ConversationInformation(BinaryReaderEx br) : base(br) { }
 
-                public int Unk00 { get; set; }
-                public int Unk04 { get; set; }
-                public int Unk08 { get; set; }
-                public int Unk0C { get; set; }
-                public int Unk10 { get; set; }
-                public int Unk14 { get; set; }
-                public int Unk18 { get; set; }
-                public int Unk1C { get; set; }
-                public int Unk20 { get; set; }
-                public int Unk24 { get; set; }
-                public int Unk28 { get; set; }
-                public int Unk2C { get; set; }
-                public int Unk30 { get; set; }
-                public int Unk34 { get; set; }
-                public int Unk38 { get; set; }
-                public int Unk3C { get; set; }
-                public int Unk40 { get; set; }
-                public int Unk44 { get; set; }
-                public int Unk48 { get; set; }
-                public int Unk4C { get; set; }
-                public int Unk50 { get; set; }
-                public int Unk54 { get; set; }
-                public int Unk58 { get; set; }
-                public int Unk5C { get; set; }
-                public int Unk60 { get; set; }
-                public int Unk64 { get; set; }
-                public int Unk68 { get; set; }
-                public int Unk6C { get; set; }
-                public int Unk70 { get; set; }
-                public int Unk74 { get; set; }
-                public int Unk78 { get; set; }
-                public int Unk7C { get; set; }
-                public int Unk80 { get; set; }
+                /// <summary>
+                /// Unknown.
+                /// </summary>
+                [MSBReference(ReferenceType = typeof(Part.EnemyBase))]
+                public string[] Talk_EnemyNames { get; private set; }
+                public int[] Talk_EnemyIndices;
+
+                public int[] Talk_TalkIDs { get; set; }
+                public byte Talk_Unk44 { get; set; }
+                public byte Talk_Unk45 { get; set; }
 
                 private protected override void ReadTypeData(BinaryReaderEx br)
                 {
-                    Unk00 = br.ReadInt32();
-                    Unk04 = br.ReadInt32();
-                    Unk08 = br.ReadInt32();
-                    Unk0C = br.ReadInt32();
-                    Unk10 = br.ReadInt32();
-                    Unk14 = br.ReadInt32();
-                    Unk18 = br.ReadInt32();
-                    Unk1C = br.ReadInt32();
-                    Unk20 = br.ReadInt32();
-                    Unk24 = br.ReadInt32();
-                    Unk28 = br.ReadInt32();
-                    Unk2C = br.ReadInt32();
-                    Unk30 = br.ReadInt32();
-                    Unk34 = br.ReadInt32();
-                    Unk38 = br.ReadInt32();
-                    Unk3C = br.ReadInt32();
-                    Unk40 = br.ReadInt32();
-                    Unk44 = br.ReadInt32();
-                    Unk48 = br.ReadInt32();
-                    Unk4C = br.ReadInt32();
-                    Unk50 = br.ReadInt32();
-                    Unk54 = br.ReadInt32();
-                    Unk58 = br.ReadInt32();
-                    Unk5C = br.ReadInt32();
-                    Unk60 = br.ReadInt32();
-                    Unk64 = br.ReadInt32();
-                    Unk68 = br.ReadInt32();
-                    Unk6C = br.ReadInt32();
-                    Unk70 = br.ReadInt32();
-                    Unk74 = br.ReadInt32();
-                    Unk78 = br.ReadInt32();
-                    Unk7C = br.ReadInt32();
-                    Unk80 = br.ReadInt32();
+                    Talk_EnemyIndices = br.ReadInt32s(4);
+                    br.AssertPattern(0x14, 0xFF);
+                    Talk_TalkIDs = br.ReadInt32s(3);
+                    br.AssertPattern(0x14, 0x00);
+                    Talk_Unk44 = br.ReadByte();
+                    Talk_Unk45 = br.ReadByte();
+                    br.AssertPattern(0x3A, 0x00);
                 }
 
                 private protected override void WriteTypeData(BinaryWriterEx bw)
                 {
-                    bw.WriteInt32(Unk00);
-                    bw.WriteInt32(Unk04);
-                    bw.WriteInt32(Unk08);
-                    bw.WriteInt32(Unk0C);
-                    bw.WriteInt32(Unk10);
-                    bw.WriteInt32(Unk14);
-                    bw.WriteInt32(Unk18);
-                    bw.WriteInt32(Unk1C);
-                    bw.WriteInt32(Unk20);
-                    bw.WriteInt32(Unk24);
-                    bw.WriteInt32(Unk28);
-                    bw.WriteInt32(Unk2C);
-                    bw.WriteInt32(Unk30);
-                    bw.WriteInt32(Unk34);
-                    bw.WriteInt32(Unk38);
-                    bw.WriteInt32(Unk3C);
-                    bw.WriteInt32(Unk40);
-                    bw.WriteInt32(Unk44);
-                    bw.WriteInt32(Unk48);
-                    bw.WriteInt32(Unk4C);
-                    bw.WriteInt32(Unk50);
-                    bw.WriteInt32(Unk54);
-                    bw.WriteInt32(Unk58);
-                    bw.WriteInt32(Unk5C);
-                    bw.WriteInt32(Unk60);
-                    bw.WriteInt32(Unk64);
-                    bw.WriteInt32(Unk68);
-                    bw.WriteInt32(Unk6C);
-                    bw.WriteInt32(Unk70);
-                    bw.WriteInt32(Unk74);
-                    bw.WriteInt32(Unk78);
-                    bw.WriteInt32(Unk7C);
-                    bw.WriteInt32(Unk80);
+                    bw.WriteInt32s(Talk_EnemyIndices);
+                    bw.WritePattern(0x14, 0xFF);
+                    bw.WriteInt32s(Talk_TalkIDs);
+                    bw.WritePattern(0x14, 0x00);
+                    bw.WriteByte(Talk_Unk44);
+                    bw.WriteByte(Talk_Unk45);
+                    bw.WritePattern(0x3A, 0x00);
+                }
+                internal override void GetNames(MSB_NR msb, Entries entries)
+                {
+                    base.GetNames(msb, entries);
+                    Talk_EnemyNames = MSB.FindNames(msb.Parts.Enemies, Talk_EnemyIndices);
+                }
+
+                internal override void GetIndices(MSB_NR msb, Entries entries)
+                {
+                    base.GetIndices(msb, entries);
+                    Talk_EnemyIndices = MSB.FindIndices(this, msb.Parts.Enemies, Talk_EnemyNames);
                 }
             }
 

--- a/src/Andre/SoulsFormats/SoulsFormats/Formats/MSB/MSB-NR/PointParam.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Formats/MSB/MSB-NR/PointParam.cs
@@ -618,7 +618,7 @@ namespace SoulsFormats
             /// <summary>
             /// Unknown.
             /// </summary>
-            public int MapID { get; set; }
+            public sbyte[] MapID { get; set; } = new sbyte[4];
 
             /// <summary>
             /// Unknown.
@@ -744,7 +744,7 @@ namespace SoulsFormats
 
                 // Unk4
                 br.Position = start + unkOffset4;
-                MapID = br.ReadInt32();
+                MapID = br.ReadReversedSBytesButLastIsHex(4);
                 UnkS04 = br.ReadInt32();
                 br.AssertInt32(0);
                 UnkS0C = br.ReadInt32();
@@ -830,7 +830,7 @@ namespace SoulsFormats
                 }
 
                 bw.FillInt64("Unk4Offset", bw.Position - start);
-                bw.WriteInt32(MapID);
+                bw.WriteReversedSBytesButLastIsHex(MapID);
                 bw.WriteInt32(UnkS04);
                 bw.WriteInt32(0);
                 bw.WriteInt32(UnkS0C);
@@ -2575,14 +2575,6 @@ namespace SoulsFormats
                 private protected override RegionType Type => RegionType.SmallBaseAttachPoint;
                 private protected override bool HasTypeData => true;
 
-                public int TUnk00 { get; set; }
-
-                public int TUnk04 { get; set; }
-
-                public int TUnk08 { get; set; }
-
-                public int TUnk0C { get; set; }
-
                 /// <summary>
                 /// Creates a LockedMountJump with default values.
                 /// </summary>
@@ -2592,18 +2584,14 @@ namespace SoulsFormats
 
                 private protected override void ReadTypeData(BinaryReaderEx br)
                 {
-                    TUnk00 = br.ReadInt32();
-                    TUnk04 = br.ReadInt32();
-                    TUnk08 = br.ReadInt32();
-                    TUnk0C = br.ReadInt32();
+                    br.AssertInt32(0);
+                    br.AssertInt32(0);
                 }
 
                 private protected override void WriteTypeData(BinaryWriterEx bw)
                 {
-                    bw.WriteSingle(TUnk00);
-                    bw.WriteInt32(TUnk04);
-                    bw.WriteInt32(TUnk08);
-                    bw.WriteInt32(TUnk0C);
+                    bw.WriteInt32(0);
+                    bw.WriteInt32(0);
                 }
             }
 

--- a/src/Andre/SoulsFormats/SoulsFormats/Util/BinaryReaderEx.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Util/BinaryReaderEx.cs
@@ -96,6 +96,25 @@ namespace SoulsFormats
         }
 
         /// <summary>
+        /// Reads length sbytes, makes the last returned element a BCD-decoded value if valid.
+        /// </summary>
+        public sbyte[] ReadReversedSBytesButLastIsHex(int length)
+        {
+            sbyte[] sbytes = ReadSBytes(length);
+            if (length > 0)
+            {
+                byte b0 = unchecked((byte)sbytes[0]);
+                int hi = (b0 >> 4) & 0xF;
+                int lo = b0 & 0xF;
+                if (hi <= 9 && lo <= 9)
+                    sbytes[0] = (sbyte)(hi * 10 + lo);
+            }
+
+            Array.Reverse(sbytes);
+            return sbytes;
+        }
+
+        /// <summary>
         /// Reads a value from the specified offset using the given function, returning the stream to its original position afterwards.
         /// </summary>
         private T GetValue<T>(Func<T> readValue, long offset)

--- a/src/Andre/SoulsFormats/SoulsFormats/Util/BinaryWriterEx.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Util/BinaryWriterEx.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Numerics;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace SoulsFormats
@@ -71,6 +72,27 @@ namespace SoulsFormats
         {
             Array.Reverse(bytes);
             bw.Write(bytes);
+        }
+
+        public void WriteReversedSBytesButLastIsHex(sbyte[] sbytes)
+        {
+            if (sbytes == null) throw new ArgumentNullException(nameof(sbytes));
+
+            var tmp = (sbyte[])sbytes.Clone();
+
+            if (tmp.Length > 0)
+            {
+                int last = tmp[^1];
+
+                if (last >= 0 && last <= 99)
+                {
+                    byte bcd = (byte)(((last / 10) << 4) | (last % 10));
+                    tmp[^1] = unchecked((sbyte)bcd);
+                }
+            }
+
+            Array.Reverse(tmp);
+            bw.Write(MemoryMarshal.AsBytes(tmp.AsSpan()));
         }
 
         private void Reserve(string name, string typeName, int length)

--- a/src/Smithbox.Data/Assets/MSB/NR/Meta/Event/ConversationInformation.xml
+++ b/src/Smithbox.Data/Assets/MSB/NR/Meta/Event/ConversationInformation.xml
@@ -1,10 +1,32 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <MSBMETA XmlVersion="0">
   <Self 
-  Wiki="" />
+  Wiki="This map object represents a Talk ESD setup within the map." />
   
   <Field>
-  
+    <Talk_EnemyNames
+    AltName="Enemy Name"
+    Wiki="The name of the enemy associated with this setup slot." 
+    MapRef="Part-Enemy"
+    ArrayProperty="" />
+    
+    <Talk_EnemyIndices
+    IndexProperty="" />
+
+    <Talk_TalkIDs
+    AltName="Talk ID"
+    Wiki="The talk ID to associated with the enemy that corresponds to this slot." 
+    TalkAlias="" />
+
+    <Talk_Unk44
+    AltName="Unknown: 0x44"
+    Wiki=""
+    IsBool="" />
+
+    <Talk_Unk45
+    AltName="Unknown: 0x45"
+    Wiki=""
+    IsBool="" />
   </Field>
   
   <Enums>


### PR DESCRIPTION
- Fixed SmallBaseAttachPoint reading the contents of the next MapTypeEntity.
- The MapID in PointParam should be four signed bytes in little-endian order, with the last digit read in hexadecimal. Reference: https://discord.com/channels/529802828278005773/919966283397730394/1380993912407330956. I did some crap code for that.
- ConversationInformation is very similar to Sekiro's Talk, but since only m10 has ConversationInformation, I can't guarantee it's 
100% correct.
Thanks for your work.