### PR TITLE
feat: Attempt filtering some invalid project files

### DIFF
--- a/src/Smithbox.Program/Core/ProjectEntry.cs
+++ b/src/Smithbox.Program/Core/ProjectEntry.cs
@@ -1173,7 +1173,7 @@ public class ProjectEntry
         }
 
         // Create merged dictionary, including unique entries present in the project directory only.
-        var projectFileDictionary = ProjectUtils.BuildFromSource(ProjectPath, FileDictionary);
+        var projectFileDictionary = ProjectUtils.BuildFromSource(ProjectPath, FileDictionary, ProjectType);
         FileDictionary = ProjectUtils.MergeFileDictionaries(FileDictionary, projectFileDictionary);
 
         return true;

--- a/src/Smithbox.Program/Editors/MapEditor/Data/MapData.cs
+++ b/src/Smithbox.Program/Editors/MapEditor/Data/MapData.cs
@@ -84,41 +84,35 @@ public class MapData
         MapFiles.Entries = Project.FileDictionary.Entries
             .Where(e => e.Folder.StartsWith("/map"))
             .Where(e => e.Extension == "msb")
-            .OrderBy(e => e.Filename)
             .ToList();
 
         // BTL
         LightFiles.Entries = Project.FileDictionary.Entries
             .Where(e => e.Folder.StartsWith("/map"))
             .Where(e => e.Extension == "btl")
-            .OrderBy(e => e.Filename)
             .ToList();
 
         DS2_LightFiles.Entries = Project.FileDictionary.Entries
             .Where(e => e.Folder.StartsWith("/map"))
             .Where(e => e.Extension == "gibhd")
-            .OrderBy(e => e.Filename)
             .ToList();
 
         // NVA
         NavmeshFiles.Entries = Project.FileDictionary.Entries
             .Where(e => e.Folder.StartsWith("/map"))
             .Where(e => e.Extension == "nva")
-            .OrderBy(e => e.Filename)
             .ToList();
 
         // BTAB
         LightAtlasFiles.Entries = Project.FileDictionary.Entries
             .Where(e => e.Folder.StartsWith("/map"))
             .Where(e => e.Extension == "btab")
-            .OrderBy(e => e.Filename)
             .ToList();
 
         // Collision
         CollisionFiles.Entries = Project.FileDictionary.Entries
             .Where(e => e.Folder.StartsWith("/map"))
             .Where(e => e.Extension == "hkxbhd")
-            .OrderBy(e => e.Filename)
             .ToList();
     }
 


### PR DESCRIPTION
You need to look this one over.

I attempted to filter out noise from the project file list by removing any files contained in a subdirectory of a Witchy-unpacked folder, as those would likely not be part of the project.

I also removed some common cases in ER projects.

I don't know what kind of performance/time impact these changes might have on a project, or any unforeseen results of the Witchy filter on non-ER projects.