### PR TITLE
fix: FMG lookup fix attempt

### DIFF
--- a/src/Smithbox.Program/Editors/TextEditor/Data/TextData.cs
+++ b/src/Smithbox.Program/Editors/TextEditor/Data/TextData.cs
@@ -35,6 +35,12 @@ public class TextData
             .Where(e => e.Extension == "msgbnd")
             .ToList();
 
+
+        if (Project.ProjectType == ProjectType.ER)
+        {
+            msgbndDictionary.Entries = msgbndDictionary.Entries.OrderBy(e => e.Folder).ThenBy(e => e.Filename.Contains("dlc02")).ThenBy(e => e.Filename.Contains("dlc01")).ThenBy(e => e.Filename).ToList();
+        }
+
         var fmgDictionary = new FileDictionary();
         fmgDictionary.Entries = new List<FileDictionaryEntry>();
 


### PR DESCRIPTION
* Sort MSGBND entries as they come in, sorting dlc02 > dlc01 > basegame
* Resolve issues with the command entries lookup where it would keep iterating over entries even after it already found the fitting one
* Make the command entries lookup look for _dlc02 and _dlc01 variants of `containerName`