### PR TITLE
DS1/DS1R General Param Community Name Overhaul (V2)

### DIFF
--- a/src/Smithbox.Data/Assets/PARAM/DS1R/Community Row Names/CalcCorrectGraph.json
+++ b/src/Smithbox.Data/Assets/PARAM/DS1R/Community Row Names/CalcCorrectGraph.json
@@ -16,55 +16,55 @@
     {
       "ID": 2,
       "Entries": [
-        "Unused"
+        "[UNUSED] Weapons (DeS Sharp Stone)"
       ]
     },
     {
       "ID": 3,
       "Entries": [
-        "Unused"
+        "[UNUSED] Weapons (DeS Clearstone)"
       ]
     },
     {
       "ID": 4,
       "Entries": [
-        "Unused"
+        "[UNUSED] Weapons (DeS Greystone)"
       ]
     },
     {
       "ID": 5,
       "Entries": [
-        "Unused"
+        "[UNUSED] Weapons (DeS Bladestone)"
       ]
     },
     {
       "ID": 6,
       "Entries": [
-        "Unused"
+        "[UNUSED] Weapons (DeS Spiderstone)"
       ]
     },
     {
       "ID": 7,
       "Entries": [
-        "Unused"
+        "[UNUSED] Weapons (DeS Mercurystone)"
       ]
     },
     {
       "ID": 8,
       "Entries": [
-        "Unused"
+        "[UNUSED] Weapons (DeS Dragonstone)"
       ]
     },
     {
       "ID": 9,
       "Entries": [
-        "Unused"
+        "[UNUSED] Weapons (DeS Suckerstone)"
       ]
     },
     {
       "ID": 10,
       "Entries": [
-        "Unused"
+        "[UNUSED] Weapons (DeS Marrowstone)"
       ]
     },
     {
@@ -112,13 +112,13 @@
     {
       "ID": 101,
       "Entries": [
-        "Unused"
+        "Unused - Max MP"
       ]
     },
     {
       "ID": 102,
       "Entries": [
-        "Natural Defence (Soul Level)"
+        "Natural Defense (Soul Level)"
       ]
     },
     {
@@ -155,6 +155,84 @@
       "ID": 200,
       "Entries": [
         "Level up cost"
+      ]
+    },
+    {
+      "ID": 300,
+      "Entries": [
+        "Level Sync: HP"
+      ]
+    },
+    {
+      "ID": 302,
+      "Entries": [
+        "Level Sync: Stamina"
+      ]
+    },
+    {
+      "ID": 303,
+      "Entries": [
+        "Level Sync: Natural Defense"
+      ]
+    },
+    {
+      "ID": 304,
+      "Entries": [
+        "Level Sync: Resistance"
+      ]
+    },
+    {
+      "ID": 310,
+      "Entries": [
+        "Level Sync: Sword"
+      ]
+    },
+    {
+      "ID": 320,
+      "Entries": [
+        "Level Sync: Dagger"
+      ]
+    },
+    {
+      "ID": 330,
+      "Entries": [
+        "Level Sync: Greatsword"
+      ]
+    },
+    {
+      "ID": 340,
+      "Entries": [
+        "Level Sync: Bow"
+      ]
+    },
+    {
+      "ID": 341,
+      "Entries": [
+        "Level Sync: Greatbow"
+      ]
+    },
+    {
+      "ID": 342,
+      "Entries": [
+        "Level Sync: Crossbow"
+      ]
+    },
+    {
+      "ID": 350,
+      "Entries": [
+        "Level Sync: Catalyst"
+      ]
+    },
+    {
+      "ID": 351,
+      "Entries": [
+        "Level Sync: Talisman"
+      ]
+    },
+    {
+      "ID": 352,
+      "Entries": [
+        "Level Sync: Pyromancy Flame"
       ]
     }
   ]

--- a/src/Smithbox.Data/Assets/PARAM/DS1R/Community Row Names/CharaInitParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/DS1R/Community Row Names/CharaInitParam.json
@@ -4,79 +4,79 @@
     {
       "ID": 1,
       "Entries": [
-        "LEVELUP presentation version_Knight"
+        "LEVELUP presentation Version - Knight"
       ]
     },
     {
       "ID": 2,
       "Entries": [
-        "IGNITE Demo Play Version_Knight"
+        "IGNITE Demo Play Version - Knight"
       ]
     },
     {
       "ID": 3,
       "Entries": [
-        "For SCE online check (no pledge)"
+        "For SCE online check (No Covenant)"
       ]
     },
     {
       "ID": 4,
       "Entries": [
-        "For SCE online check (Hakukyo)"
+        "For SCE online check (Way of White)"
       ]
     },
     {
       "ID": 5,
       "Entries": [
-        "SCE online check (princess protection)"
+        "For SCE online check (Princess Guard)"
       ]
     },
     {
       "ID": 6,
       "Entries": [
-        "For SCE online check (solar warrior)"
+        "For SCE online check (Warrior of Sunlight)"
       ]
     },
     {
       "ID": 7,
       "Entries": [
-        "For SCE Online Check (Dark Reis)"
+        "For SCE Online Check (Darkwraith)"
       ]
     },
     {
       "ID": 8,
       "Entries": [
-        "SCE Online Check (Road to Old Dragon)"
+        "For SCE Online Check (Path of the Dragon)"
       ]
     },
     {
       "ID": 9,
       "Entries": [
-        "For SCE online check (subordinate of Grave King)"
+        "For SCE online check (Gravelord Servant)"
       ]
     },
     {
       "ID": 10,
       "Entries": [
-        "SCE Online Check (Forest Hunter)"
+        "For SCE Online Check (Forest Hunter)"
       ]
     },
     {
       "ID": 11,
       "Entries": [
-        "SCE Online Check (Dark Moon Sword)"
+        "For SCE Online Check (Blade of the Darkmoon)"
       ]
     },
     {
       "ID": 12,
       "Entries": [
-        "For SCE online check (servant of chaos)"
+        "For SCE online check (Chaos Servant)"
       ]
     },
     {
       "ID": 100,
       "Entries": [
-        "[PC version] for GGD_Artorius"
+        "[PC version] for GGD_Artorias"
       ]
     },
     {
@@ -88,229 +88,229 @@
     {
       "ID": 1000,
       "Entries": [
-        "Proto version_Knight"
+        "Prototype Version - Knight"
       ]
     },
     {
       "ID": 1001,
       "Entries": [
-        "Prototype_Magician"
+        "Prototype Version - Sorcerer"
       ]
     },
     {
       "ID": 1002,
       "Entries": [
-        "Proto_Onion Knight"
+        "Prototype Version - Catarina Knight"
       ]
     },
     {
       "ID": 1003,
       "Entries": [
-        "Proto version_NPC transformed into a pot"
+        "Prototype Version - NPC transformed into a pot"
       ]
     },
     {
       "ID": 1010,
       "Entries": [
-        "December 2009 version_knight"
+        "December 2009 Version - Knight"
       ]
     },
     {
       "ID": 1011,
       "Entries": [
-        "December 2009 edition_priest"
+        "December 2009 Version - Cleric"
       ]
     },
     {
       "ID": 1012,
       "Entries": [
-        "December 2009 version_Magician"
+        "December 2009 Version - Sorcerer"
       ]
     },
     {
       "ID": 1030,
       "Entries": [
-        "April 2010 edition_bandit"
+        "April 2010 Version - Thief"
       ]
     },
     {
       "ID": 1031,
       "Entries": [
-        "April 2010 version_Ninja"
+        "April 2010 Version - Ninja"
       ]
     },
     {
       "ID": 1032,
       "Entries": [
-        "April 2010 edition_Black Knight"
+        "April 2010 Version - Black Knight"
       ]
     },
     {
       "ID": 1040,
       "Entries": [
-        "January 2011_Warrior"
+        "January 2011 Version - Warrior"
       ]
     },
     {
       "ID": 1041,
       "Entries": [
-        "January 2011_Hunter"
+        "January 2011 Version - Hunter"
       ]
     },
     {
       "ID": 1042,
       "Entries": [
-        "January 2011_Sorcerer"
+        "January 2011 Version - Sorcerer"
       ]
     },
     {
       "ID": 1043,
       "Entries": [
-        "January 2011 version_Knight"
+        "January 2011 Version - Knight"
       ]
     },
     {
       "ID": 1050,
       "Entries": [
-        "April 2011 edition_Warrior"
+        "April 2011 Version - Warrior"
       ]
     },
     {
       "ID": 1051,
       "Entries": [
-        "April 2011_Knight"
+        "April 2011 Version - Knight"
       ]
     },
     {
       "ID": 1052,
       "Entries": [
-        "April 2011 version_Magician"
+        "April 2011 Version - Sorcerer"
       ]
     },
     {
       "ID": 1053,
       "Entries": [
-        "April 2011 version_Sorcerer"
+        "April 2011 Version - Pyromancer"
       ]
     },
     {
       "ID": 1054,
       "Entries": [
-        "April 2011 version_warrior"
+        "April 2011 Version - Warrior 2"
       ]
     },
     {
       "ID": 1055,
       "Entries": [
-        "April 2011 version_Knight"
+        "April 2011 Version - Knight 2"
       ]
     },
     {
       "ID": 1056,
       "Entries": [
-        "April 2011 version_Magician"
+        "April 2011 Version - Sorcerer 2"
       ]
     },
     {
       "ID": 1057,
       "Entries": [
-        "April 2011, Magician"
+        "April 2011 Version - Pyromancer 2"
       ]
     },
     {
       "ID": 2000,
       "Entries": [
-        "Early Character_Warrior"
+        "Early Character - Warrior"
       ]
     },
     {
       "ID": 2001,
       "Entries": [
-        "Early Character_Knight"
+        "Early Character - Knight"
       ]
     },
     {
       "ID": 2002,
       "Entries": [
-        "Early Character_Wanderer"
+        "Early Character - Wanderer"
       ]
     },
     {
       "ID": 2003,
       "Entries": [
-        "Early Character_ Thief"
+        "Early Character - Thief"
       ]
     },
     {
       "ID": 2004,
       "Entries": [
-        "Early Character_Bandit"
+        "Early Character - Bandit"
       ]
     },
     {
       "ID": 2005,
       "Entries": [
-        "Early Character_Hunter"
+        "Early Character - Hunter"
       ]
     },
     {
       "ID": 2006,
       "Entries": [
-        "Early Character_Sorcerer"
+        "Early Character - Sorcerer"
       ]
     },
     {
       "ID": 2007,
       "Entries": [
-        "Early Character_Sorcerer"
+        "Early Character - Pyromancer"
       ]
     },
     {
       "ID": 2008,
       "Entries": [
-        "Early Character_Monk"
+        "Early Character - Cleric"
       ]
     },
     {
       "ID": 2009,
       "Entries": [
-        "Early Character"
+        "Early Character - Deprived"
       ]
     },
     {
       "ID": 2020,
       "Entries": [
-        "Title Selection_Warrior"
+        "Title Selection - Warrior"
       ]
     },
     {
       "ID": 2021,
       "Entries": [
-        "Title selection_Knight + Miracle"
+        "Title Selection - Knight + Miracle"
       ]
     },
     {
       "ID": 2022,
       "Entries": [
-        "Title selection_Magician"
+        "Title Selection - Sorcerer"
       ]
     },
     {
       "ID": 2023,
       "Entries": [
-        "Title selection_Sorcerer"
+        "Title Selection - Pyromancer"
       ]
     },
     {
       "ID": 2024,
       "Entries": [
-        "Title selection_Sun Knight"
+        "Title Selection - Sun Knight"
       ]
     },
     {
       "ID": 2025,
       "Entries": [
-        "Title selection_Black Knight"
+        "Title Selection - Black Knight"
       ]
     },
     {
@@ -658,49 +658,49 @@
     {
       "ID": 6000,
       "Entries": [
-        "Knight Solaire - Undead Burg"
+        "Solaire of Astora - Undead Burg"
       ]
     },
     {
       "ID": 6002,
       "Entries": [
-        "Knight Solaire - Anor Londo"
+        "Solaire of Astora - Anor Londo"
       ]
     },
     {
       "ID": 6003,
       "Entries": [
-        "Knight Solaire"
+        "Solaire of Astora - Demon Ruins"
       ]
     },
     {
       "ID": 6004,
       "Entries": [
-        "Knight Solaire - Demon Ruins"
+        "Solaire of Astora - Demon Ruins (Hostile)"
       ]
     },
     {
       "ID": 6010,
       "Entries": [
-        "Lady of the Darkling"
+        "Darkmoon Knightess"
       ]
     },
     {
       "ID": 6020,
       "Entries": [
-        "Oscar, Knight of Astora"
+        "Oscar of Astora"
       ]
     },
     {
       "ID": 6021,
       "Entries": [
-        "Oscar, Knight of Astora (Hostile)"
+        "Oscar of Astora (Hostile)"
       ]
     },
     {
       "ID": 6030,
       "Entries": [
-        "Big Hat Logan - Sen's Fortress"
+        "Big Hat Logan - Sen's Fortress/Firelink Shrine"
       ]
     },
     {
@@ -718,7 +718,7 @@
     {
       "ID": 6040,
       "Entries": [
-        "Griggs of Vinheim - Undead Burg"
+        "Griggs of Vinheim - Lower Undead Burg/Firelink Shrine"
       ]
     },
     {
@@ -808,7 +808,7 @@
     {
       "ID": 6220,
       "Entries": [
-        "Blacksmith Rickert"
+        "Rickert of Vinheim"
       ]
     },
     {
@@ -838,7 +838,7 @@
     {
       "ID": 6280,
       "Entries": [
-        "Siegmeyer of Catarina - Sen's Fortress"
+        "Siegmeyer of Catarina - Sen's Fortress/Ash Lake"
       ]
     },
     {
@@ -856,37 +856,37 @@
     {
       "ID": 6283,
       "Entries": [
-        "Siegmeyer of Catarina"
+        "Siegmeyer of Catarina - Blighttown"
       ]
     },
     {
       "ID": 6284,
       "Entries": [
-        "Siegmeyer of Catarina"
+        "Siegmeyer of Catarina - Lost Izalith"
       ]
     },
     {
       "ID": 6290,
       "Entries": [
-        "Sieglinde of Catarina - Duke's Archives"
+        "Sieglinde of Catarina - Duke's Archives/Firelink Shrine"
       ]
     },
     {
       "ID": 6291,
       "Entries": [
-        "Sieglinde of Catarina - Great Hollow"
+        "Sieglinde of Catarina - Ash Lake"
       ]
     },
     {
       "ID": 6300,
       "Entries": [
-        "Knight Lautrec - Undead Burg"
+        "Knight Lautrec of Carim - Undead Parish/Firelink Shrine"
       ]
     },
     {
       "ID": 6301,
       "Entries": [
-        "Knight Lautrec - Anor Londo"
+        "Knight Lautrec of Carim - Anor Londo"
       ]
     },
     {
@@ -898,13 +898,13 @@
     {
       "ID": 6320,
       "Entries": [
-        "Patches - Catacombs"
+        "Trusty Patches - Catacombs"
       ]
     },
     {
       "ID": 6321,
       "Entries": [
-        "Patches - Firelink Shrine"
+        "Trusty Patches - Tomb of the Giants/Firelink Shrine"
       ]
     },
     {
@@ -916,7 +916,7 @@
     {
       "ID": 6390,
       "Entries": [
-        "Black Knight Tarkus"
+        "[UNUSED] Black Iron Tarkus"
       ]
     },
     {
@@ -940,25 +940,25 @@
     {
       "ID": 6510,
       "Entries": [
-        "Iron Tarkus (Summon) - Sen's Fortress"
+        "Black Iron Tarkus (Summon) - Sen's Fortress"
       ]
     },
     {
       "ID": 6511,
       "Entries": [
-        "Iron Tarkus (Summon)"
+        "[UNUSED] Black Iron Tarkus (Summon)"
       ]
     },
     {
       "ID": 6520,
       "Entries": [
-        "Witch Beatrice (Summon)"
+        "Witch Beatrice (Summon) - Darkroot Garden"
       ]
     },
     {
       "ID": 6521,
       "Entries": [
-        "Witch Beatrice (Summon)"
+        "Witch Beatrice (Summon) - New Londo Ruins"
       ]
     },
     {
@@ -976,31 +976,31 @@
     {
       "ID": 6540,
       "Entries": [
-        "Knight Solaire (Summon) - Undead Burg"
+        "Solaire of Astora (Summon) - Undead Parish"
       ]
     },
     {
       "ID": 6541,
       "Entries": [
-        "Knight Solaire (Summon) - The Depths"
+        "Solaire of Astora (Summon) - The Depths"
       ]
     },
     {
       "ID": 6542,
       "Entries": [
-        "Knight Solaire (Summon) - Anor Londo"
+        "Solaire of Astora (Summon) - Anor Londo"
       ]
     },
     {
       "ID": 6543,
       "Entries": [
-        "Knight Solaire (Summon) - Demon Ruins"
+        "Solaire of Astora (Summon) - Demon Ruins"
       ]
     },
     {
       "ID": 6544,
       "Entries": [
-        "Knight Solaire (Summon) - Tomb of the Giants"
+        "Solaire of Astora (Summon) - Kiln of the First Flame"
       ]
     },
     {
@@ -1018,25 +1018,25 @@
     {
       "ID": 6560,
       "Entries": [
-        "Knight Kirk (Invader) - The Depths"
+        "Kirk, Knight of Thorns (Invader) - The Depths"
       ]
     },
     {
       "ID": 6561,
       "Entries": [
-        "Knight Kirk (Invader) - Demon Ruins"
+        "Kirk, Knight of Thorns (Invader) - Demon Ruins"
       ]
     },
     {
       "ID": 6562,
       "Entries": [
-        "Knight Kirk (Invader) - Lost Izalith"
+        "Kirk, Knight of Thorns (Invader) - Lost Izalith"
       ]
     },
     {
       "ID": 6570,
       "Entries": [
-        "Xanthous King, Jeremiah (Invader)"
+        "Xanthous King Jeremiah (Invader)"
       ]
     },
     {
@@ -1048,43 +1048,43 @@
     {
       "ID": 6590,
       "Entries": [
-        "Knight Lautrec (Summon)"
+        "Knight Lautrec of Carim (Summon)"
       ]
     },
     {
       "ID": 6591,
       "Entries": [
-        "Knight Lautrec (Summon)"
+        "Knight Lautrec of Carim (Summon)"
       ]
     },
     {
       "ID": 6600,
       "Entries": [
-        "Prince Ricard"
+        "Undead Prince Ricard"
       ]
     },
     {
       "ID": 6610,
       "Entries": [
-        "Crystal Knight"
+        "Hollow Crystal Knight"
       ]
     },
     {
       "ID": 6620,
       "Entries": [
-        "Daughter of Chaos"
+        "Quelana of Izalith"
       ]
     },
     {
       "ID": 6640,
       "Entries": [
-        "Dark Moon Sword (Heavy Knight)"
+        "Darkmoon Soldier (Sword)"
       ]
     },
     {
       "ID": 6650,
       "Entries": [
-        "Dark Moon Sword (Light Knight)"
+        "Darkmoon Soldier (Greatsword)"
       ]
     },
     {
@@ -1138,505 +1138,505 @@
     {
       "ID": 7100,
       "Entries": [
-        "Castle 2_Vagrant NPC_Warrior"
+        "Depths - Vagrant NPC - Warrior"
       ]
     },
     {
       "ID": 7110,
       "Entries": [
-        "Castle 1 ・ First half_Vagrant NPC_Voyeur"
+        "Undead Burg/Parish 1st half - Vagrant NPC - Thief"
       ]
     },
     {
       "ID": 7111,
       "Entries": [
-        "Castle 1st & 2nd half_Vagrant NPC_Voyeur"
+        "Undead Burg/Parish 2nd half - Vagrant NPC - Thief"
       ]
     },
     {
       "ID": 7120,
       "Entries": [
-        "Painting world_Vagrant NPC_Wanderer"
+        "Painted World - Vagrant NPC - Wanderer"
       ]
     },
     {
       "ID": 7130,
       "Entries": [
-        "Moriwaba, first half_Vagrant NPC_Hunter"
+        "Darkroot Garden/Basin 1st half - Vagrant NPC - Hunter"
       ]
     },
     {
       "ID": 7131,
       "Entries": [
-        "Moriwaba, latter half_Vagrant NPC_Hunter"
+        "Darkroot Garden/Basin 2nd half - Vagrant NPC - Hunter"
       ]
     },
     {
       "ID": 7140,
       "Entries": [
-        "Cemetery 1_Vagrant NPC_Cleric"
+        "Catacombs - Vagrant NPC - Cleric"
       ]
     },
     {
       "ID": 7150,
       "Entries": [
-        "Cemetery 2_Vagrant NPC_Cleric"
+        "Tomb of the Giants - Vagrant NPC - Cleric"
       ]
     },
     {
       "ID": 7160,
       "Entries": [
-        "Underground Lake_Vagrant NPC_Dragon Newt"
+        "Ash Lake - Vagrant NPC - Dragon Newt"
       ]
     },
     {
       "ID": 7170,
       "Entries": [
-        "Kagemachi_Vagrant NPC_Wanderer"
+        "Blighttown - Vagrant NPC - Wanderer"
       ]
     },
     {
       "ID": 7180,
       "Entries": [
-        "Closed city_Vagrant NPC_Sorcerer"
+        "Demon Ruins/Lost Izalith - Vagrant NPC - Pyromancer"
       ]
     },
     {
       "ID": 7190,
       "Entries": [
-        "Royal Castle 1_Vagrant NPC_Warrior"
+        "Sen's Fortress - Vagrant NPC - Warrior"
       ]
     },
     {
       "ID": 7200,
       "Entries": [
-        "Royal Castle 2_Vagrant NPC_Knight"
+        "Anor Londo - Vagrant NPC - Knight"
       ]
     },
     {
       "ID": 7210,
       "Entries": [
-        "Abyss_Vagrant NPC_Bandit"
+        "New Londo Ruins - Vagrant NPC - Bandit"
       ]
     },
     {
       "ID": 7220,
       "Entries": [
-        "Crystal Tower_Vagrant NPC_Sorcerer"
+        "Duke's Archives/Crystal Cave - Vagrant NPC - Sorcerer"
       ]
     },
     {
       "ID": 7230,
       "Entries": [
-        "Great tomb_Vagrant NPC_Not possessed"
+        "Kiln of the First Flame - Vagrant NPC - Deprived"
       ]
     },
     {
       "ID": 7240,
       "Entries": [
-        "Tutorial_Vagrant NPC_What You Don't Have"
+        "Undead Asylum - Vagrant NPC - Deprived"
       ]
     },
     {
       "ID": 8000,
       "Entries": [
-        "for PV_warrior equipment (hero)"
+        "For PV - Warrior equipment (hero)"
       ]
     },
     {
       "ID": 8001,
       "Entries": [
-        "PV_Sorcerer"
+        "For PV - Pyromancer"
       ]
     },
     {
       "ID": 8002,
       "Entries": [
-        "For PV_Red clothing head not equipped"
+        "For PV - Crimson Set"
       ]
     },
     {
       "ID": 8003,
       "Entries": [
-        "PV for _ Chain Mail Woman (Phantom)"
+        "For PV - Chain Set Woman (Phantom)"
       ]
     },
     {
       "ID": 8004,
       "Entries": [
-        "PV_Hunter head not equipped (Phantom)"
+        "For PV - Hunter Set (no hat) (Phantom)"
       ]
     },
     {
       "ID": 8005,
       "Entries": [
-        "PV for onion (phantom)"
+        "For PV - Catarina Set (Phantom)"
       ]
     },
     {
       "ID": 8006,
       "Entries": [
-        "PV for _ gray saint"
+        "For PV - Gray Saint"
       ]
     },
     {
       "ID": 8007,
       "Entries": [
-        "PV_Knight"
+        "For PV - Knight"
       ]
     },
     {
       "ID": 8008,
       "Entries": [
-        "PV_Black Knight"
+        "For PV - Black Knight"
       ]
     },
     {
       "ID": 8500,
       "Entries": [
-        "Test Player (Warrior / Sword, Ax Spear, Shield)"
+        "Test Player (Warrior / Sword, Halberd, Shield)"
       ]
     },
     {
       "ID": 8501,
       "Entries": [
-        "Test player (hunter / ax, bow, shield)"
+        "Test Player (Hunter / Axe, Bow, Shield)"
       ]
     },
     {
       "ID": 8502,
       "Entries": [
-        "Test player (mage / catalyst, straight sword, small shield, projection flame)"
+        "Test Player (Pyromancer / Catalyst, Straight Sword, Small Shield, Flame Projectile)"
       ]
     },
     {
       "ID": 8600,
       "Entries": [
-        "Test Player_Warrior (Tutorial Clear)"
+        "Test Player - Warrior (Tutorial Clear)"
       ]
     },
     {
       "ID": 8601,
       "Entries": [
-        "Test Player_Knight (Tutorial Clear)"
+        "Test Player - Knight (Tutorial Clear)"
       ]
     },
     {
       "ID": 8602,
       "Entries": [
-        "test player_magician (clear tutorial)"
+        "Test Player - Sorcerer (Tutorial Clear)"
       ]
     },
     {
       "ID": 8603,
       "Entries": [
-        "test player_magician (tutorial clear)"
+        "Test Player - Pyromancer (Tutorial Clear)"
       ]
     },
     {
       "ID": 8604,
       "Entries": [
-        "Test player_Monk (clear tutorial)"
+        "Test Player - Cleric (Tutorial Clear)"
       ]
     },
     {
       "ID": 8610,
       "Entries": [
-        "test player_warrior (gargoyle clear)"
+        "Test Player - Warrior (Gargoyle Clear)"
       ]
     },
     {
       "ID": 8611,
       "Entries": [
-        "test player_knight (gargoyle clear)"
+        "Test Player - Knight (Gargoyle Clear)"
       ]
     },
     {
       "ID": 8612,
       "Entries": [
-        "Test player_Magician (gargoyle clear)"
+        "Test Player - Sorcerer (Gargoyle Clear)"
       ]
     },
     {
       "ID": 8613,
       "Entries": [
-        "Test player_Sorcerer (gargoyle clear)"
+        "Test Player - Pyromancer (Gargoyle Clear)"
       ]
     },
     {
       "ID": 8614,
       "Entries": [
-        "Test player_Monk (gargoyle clear)"
+        "Test Player - Cleric (Gargoyle Clear)"
       ]
     },
     {
       "ID": 8620,
       "Entries": [
-        "Test player_Warrior (Journey 2 search only)"
+        "Test Player - Warrior (Only Explored The Depths)"
       ]
     },
     {
       "ID": 8621,
       "Entries": [
-        "Test player_Knight (only search 2 castles)"
+        "Test Player - Knight (Only Explored The Depths)"
       ]
     },
     {
       "ID": 8622,
       "Entries": [
-        "Test player_Magician (Journey 2 search only)"
+        "Test Player - Sorcerer (Only Explored The Depths)"
       ]
     },
     {
       "ID": 8623,
       "Entries": [
-        "Test player_Sorcerer (only search 2 castles)"
+        "Test Player - Pyromancer (Only Explored The Depths)"
       ]
     },
     {
       "ID": 8624,
       "Entries": [
-        "Test player_Monk (only search for castle 2)"
+        "Test player - Cleric (Only Explored The Depths)"
       ]
     },
     {
       "ID": 8630,
       "Entries": [
-        "test player_warrior (castle clear 2 / devour clear)"
+        "Test Player - Warrior (Gaping Dragon Clear)"
       ]
     },
     {
       "ID": 8631,
       "Entries": [
-        "test player_knight (castle 2 clear / phagocy clear)"
+        "Test Player - Knight (Gaping Dragon Clear)"
       ]
     },
     {
       "ID": 8632,
       "Entries": [
-        "Test player_Magician (Castle 2 clear / phagocytic clear)"
+        "Test Player - Sorcerer (Gaping Dragon Clear)"
       ]
     },
     {
       "ID": 8633,
       "Entries": [
-        "test player_magician (castle 2 clear / phagocy clear)"
+        "Test Player - Pyromancy (Gaping Dragon Clear)"
       ]
     },
     {
       "ID": 8634,
       "Entries": [
-        "test player_ monk (castle clear 2 / devour clear)"
+        "Test Player - Cleric (Gaping Dragon Clear)"
       ]
     },
     {
       "ID": 8640,
       "Entries": [
-        "test player_warrior (Kagemachi clear)"
+        "Test Player - Warrior (Blighttown Clear)"
       ]
     },
     {
       "ID": 8641,
       "Entries": [
-        "Test Player_Knight (Kagecho Clear)"
+        "Test Player - Knight (Blighttown Clear)"
       ]
     },
     {
       "ID": 8642,
       "Entries": [
-        "Test Player_Magician (Kagemachi Clear)"
+        "Test Player - Sorcerer (Blighttown Clear)"
       ]
     },
     {
       "ID": 8643,
       "Entries": [
-        "Test player_Sorcerer (Kagemachi clear)"
+        "Test player - Pyromancer (Blighttown Clear)"
       ]
     },
     {
       "ID": 8644,
       "Entries": [
-        "Test player_Monk (Kagemachi clear)"
+        "Test Player - Cleric (Blighttown Clear)"
       ]
     },
     {
       "ID": 8650,
       "Entries": [
-        "test player_warrior (Ojo 1 clear)"
+        "Test Player - Warrior (Sen's Fortress Clear)"
       ]
     },
     {
       "ID": 8651,
       "Entries": [
-        "Test player_Knight (Ojo 1 clear)"
+        "Test Player - Knight (Sen's Fortress Clear)"
       ]
     },
     {
       "ID": 8652,
       "Entries": [
-        "test player_magician (Ojo 1 clear)"
+        "Test Player - Sorcerer (Sen's Fortress Clear)"
       ]
     },
     {
       "ID": 8653,
       "Entries": [
-        "Test player_Sorcerer (Ojo 1 clear)"
+        "Test Player - Pyromancer (Sen's Fortress Clear)"
       ]
     },
     {
       "ID": 8654,
       "Entries": [
-        "test player _ monk (Ojo 1 clear)"
+        "Test Player - Cleric (Sen's Fortress Clear)"
       ]
     },
     {
       "ID": 8660,
       "Entries": [
-        "test player_warrior (Ojo 2 clear)"
+        "Test Player - Warrior (Anor Londo Clear)"
       ]
     },
     {
       "ID": 8661,
       "Entries": [
-        "test player_knight (Ojo 2 clear)"
+        "Test Player - Knight (Anor Londo Clear)"
       ]
     },
     {
       "ID": 8662,
       "Entries": [
-        "test player_magician (Ojo 2 clear)"
+        "Test Player - Sorcerer (Anor Londo Clear)"
       ]
     },
     {
       "ID": 8663,
       "Entries": [
-        "Test Player_Sorcerer (Ojo 2 Clear)"
+        "Test Player - Pyromancer (Anor Londo Clear)"
       ]
     },
     {
       "ID": 8664,
       "Entries": [
-        "Test player_Monk (Ojo 2 clear)"
+        "Test Player - Cleric (Anor Londo Clear)"
       ]
     },
     {
       "ID": 8670,
       "Entries": [
-        "Test Player_Warrior (Abyss Clear)"
+        "Test Player - Warrior (New Londo Ruins Clear)"
       ]
     },
     {
       "ID": 8671,
       "Entries": [
-        "Test Player_Knight (Abyss Clear)"
+        "Test Player - Knight (New Londo Ruins Clear)"
       ]
     },
     {
       "ID": 8672,
       "Entries": [
-        "test player_magician (abyss clear)"
+        "Test Player - Sorcerer (New Londo Ruins Clear)"
       ]
     },
     {
       "ID": 8673,
       "Entries": [
-        "Test Player_Mage (Abyss Clear)"
+        "Test Player - Pyromancer (New Londo Ruins Clear)"
       ]
     },
     {
       "ID": 8674,
       "Entries": [
-        "Test Player_Monk (Abyss Clear)"
+        "Test Player - Cleric (New Londo Ruins Clear)"
       ]
     },
     {
       "ID": 8680,
       "Entries": [
-        "test player_warrior (crystal tower clear)"
+        "Test Player - Warrior (Crystal Cave Clear)"
       ]
     },
     {
       "ID": 8681,
       "Entries": [
-        "Test player_Knight (crystal tower clear)"
+        "Test Player - Knight (Crystal Cave Clear)"
       ]
     },
     {
       "ID": 8682,
       "Entries": [
-        "test player_magician (crystal tower clear)"
+        "Test Player - Sorcerer (Crystal Cave Clear)"
       ]
     },
     {
       "ID": 8683,
       "Entries": [
-        "test player_magician (crystal tower clear)"
+        "Test Player - Pyromancer (Crystal Cave Clear)"
       ]
     },
     {
       "ID": 8684,
       "Entries": [
-        "Test player_Monk (crystal tower clear)"
+        "Test Player - Cleric (Crystal Cave Clear)"
       ]
     },
     {
       "ID": 8690,
       "Entries": [
-        "Test Player_Warrior (Clear city)"
+        "Test Player - Warrior (Lost Izalith Clear)"
       ]
     },
     {
       "ID": 8691,
       "Entries": [
-        "Test Player_Knight (Clear city)"
+        "Test Player - Knight (Lost Izalith Clear)"
       ]
     },
     {
       "ID": 8692,
       "Entries": [
-        "test player_magician (closed city clear)"
+        "Test Player - Sorcerer (Lost Izalith Clear)"
       ]
     },
     {
       "ID": 8693,
       "Entries": [
-        "Test Player_Sorcerer (Clear city)"
+        "Test Player - Pyromancer (Lost Izalith Clear)"
       ]
     },
     {
       "ID": 8694,
       "Entries": [
-        "test player_ monk (closed city clear)"
+        "Test Player - Cleric (Lost Izalith Clear)"
       ]
     },
     {
       "ID": 9000,
       "Entries": [
-        "debug player (memory verification)"
+        "Debug Player (memory verification)"
       ]
     },
     {
       "ID": 9001,
       "Entries": [
-        "Debug player (general-purpose man)"
+        "Debug Player (general-purpose man)"
       ]
     },
     {
       "ID": 9002,
       "Entries": [
-        "Debug player (general-purpose woman)"
+        "Debug Player (general-purpose woman)"
       ]
     },
     {
       "ID": 9005,
       "Entries": [
-        "Debug player (with lantern)"
+        "Debug Player (with lantern)"
       ]
     },
     {
       "ID": 9006,
       "Entries": [
-        "Debug player (for network check)"
+        "Debug Player (for network check)"
       ]
     },
     {
@@ -1648,7 +1648,7 @@
     {
       "ID": 9008,
       "Entries": [
-        "Debug player with bow"
+        "Debug Player (with bow)"
       ]
     },
     {
@@ -1690,181 +1690,193 @@
     {
       "ID": 9016,
       "Entries": [
-        "Debug player (poison + fire weapon)"
+        "Debug Player (poison + fire weapon)"
       ]
     },
     {
       "ID": 9017,
       "Entries": [
-        "Debug player (light dress)"
+        "Debug Player (light dress)"
       ]
     },
     {
       "ID": 9018,
       "Entries": [
-        "Debug player (dragon makeover)"
+        "Debug Player (dragon makeover)"
+      ]
+    },
+    {
+      "ID": 9019,
+      "Entries": [
+        "Debug Player (Spell: EN bullet A-C2)"
       ]
     },
     {
       "ID": 9100,
       "Entries": [
-        "Debug player (magic: EN bullets A to C2)"
+        "Debug Player (Spell: EN bullet A-C2)"
       ]
     },
     {
       "ID": 9101,
       "Entries": [
-        "Debug player (magic: EN bullet D-D2 / weapon enhancement 1-3 / shield enhancement 1-2)"
+        "Debug Player (Spell: EN bullet D-D2 / Magic Weapon 1-3 / Magic Shield 1-2)"
       ]
     },
     {
       "ID": 9102,
       "Entries": [
-        "Debug player (magic: invisible W / B / light / silence / sound / repair)"
+        "Debug Player (Spell: Hidden Weapon/Body / Cast Light / Hush / Aural Decoy / Repair)"
       ]
     },
     {
       "ID": 9103,
       "Entries": [
-        "Debug player (magic: F control / mimicry / curse / curative / crystal beam)"
+        "Debug Player (Spell: Fall control / Chameleon / Resist Curse / Remedy / White Dragon Breath)"
       ]
     },
     {
       "ID": 9104,
       "Entries": [
-        "Debug player (magic: F ball 1-3 / F storm 1-2 / flame emission / flame whip)"
+        "Debug Player (Pyromancy: Fireball 1-3 / Firestorm 1-2 / Fire Surge / Fire Whip)"
       ]
     },
     {
       "ID": 9105,
       "Entries": [
-        "Debug player (magic: melee flame 1-2 / poison mist / poison mist / acid mist)"
+        "Debug Player (Pyromancy: Combustion 1-2 / Poison Mist / Toxic mist / Acid Surge)"
       ]
     },
     {
       "ID": 9106,
       "Entries": [
-        "Debug Player (Spells: Iron Body / Veil of Water / Copper Body / Enchanted / Crazy Power)"
+        "Debug Player (Pyromancy: Iron Flesh / Flash Sweat / Undead Rapport / Power Within)"
       ]
     },
     {
       "ID": 9107,
       "Entries": [
-        "Debug player (Spell: C_Fireball / C_Firestorm / C_Fire Whip)"
+        "Debug Player (Pyromancy: Great Chaos Fireball / Chaos Storm / Chaos Fire Whip)"
       ]
     },
     {
       "ID": 9108,
       "Entries": [
-        "Debug player (miracle: recovery 1-4 / regen / great regen)"
+        "Debug Player (Miracle: Heal 1-4 / Replenishment / Bountiful Sunlight)"
       ]
     },
     {
       "ID": 9109,
       "Entries": [
-        "Debug player (miracle: Summon 1-2 / one-time resurrection / return / force 1-3)"
+        "Debug Player (Miracle: Gravelord Sword Dance 1-2 / Escape Death / Homeward / Force 1-3)"
       ]
     },
     {
       "ID": 9110,
       "Entries": [
-        "Debug player (miracle: hint / lightning 1-3 / magic protection 1-2)"
+        "Debug Player (Miracle: Seek Guidance / Lightning Spear 1-3 / Magic Barrier 1-2)"
       ]
     },
     {
       "ID": 9111,
       "Entries": [
-        "Debug player (miracle: causal reward / causal reward _ bullet / gravity / anti-magic / sun sword / moonlight sword)"
+        "Debug Player (Miracle: Karmic Justice / Tranquil Walk / Vow of Silence / Sunlight Blade / Darkmoon Blade)"
       ]
     },
     {
       "ID": 9112,
       "Entries": [
-        "Debug Player ([DLC] Dark Ball / Dark Splash / Dark Mist / Followers / Black Flame)"
+        "Debug Player ([DLC] Dark Orb / Dark Bead / Dark Fog / Pursuers / Black Flame)"
+      ]
+    },
+    {
+      "ID": 9119,
+      "Entries": [
+        "Debug Player (Unique Weapon: Moonlight Greatsword / Dragon Greatsword)"
       ]
     },
     {
       "ID": 9120,
       "Entries": [
-        "Debug player (Magic weapon: Straight sword of ancient dragon / Sword of stone)"
+        "Debug Player (Unique Weapon: Drake Sword / Stone Greatsword)"
       ]
     },
     {
       "ID": 9121,
       "Entries": [
-        "Debug player (magic weapon: moonlight / old dragon sword)"
+        "Debug Player (Unique Weapon: Moonlight Greatsword / Dragon Greatsword)"
       ]
     },
     {
       "ID": 9122,
       "Entries": [
-        "Debug Player (Magic Weapon: Iron Ax / Dragon King's Ax)"
+        "Debug Player (Unique Weapon: Golem Axe / Dragon King Greataxe)"
       ]
     },
     {
       "ID": 9123,
       "Entries": [
-        "Debug Player (Magic Weapon: Hammer of Law Judgment / Dark Hand)"
+        "Debug Player (Unique Weapon: Grant / Dark Hand)"
       ]
     },
     {
       "ID": 9124,
       "Entries": [
-        "Debug player (magic weapon: 6th magic spear / dragon hunting spear)"
+        "Debug Player (Unique weapon: Channeler's Trident / Dragonslayer Spear)"
       ]
     },
     {
       "ID": 9125,
       "Entries": [
-        "Debug Player (Magic Weapon: Quartz Ring Shield / Rock Shield)"
+        "Debug Player (Magic Weapon: Crystal Ring Shield / Havel's Greatshield)"
       ]
     },
     {
       "ID": 9130,
       "Entries": [
-        "Beat value / beat value check _ warrior (LV5 castle 1 hammer)"
+        "Beat Value/Beat Value Check - Warrior (LV5 Undead Asylum to Undead Burg)"
       ]
     },
     {
       "ID": 9131,
       "Entries": [
-        "Beat value / beat value check _ warrior (until LV15 castle 2 search)"
+        "Beat Value/Beat Value Check - Warrior (LV15 The Depths)"
       ]
     },
     {
       "ID": 9132,
       "Entries": [
-        "Beat value / beat value check _ warrior (LV25 castle 2 devour)"
+        "Beat Value/Beat Value Check - Warrior (LV25 The Depths to Gaping Dragon)"
       ]
     },
     {
       "ID": 9133,
       "Entries": [
-        "Beat value / beat value check _ warrior (to LV35 Kagemachi)"
+        "Beat Value/Beat Value Check - Warrior (LV35 Blighttown)"
       ]
     },
     {
       "ID": 9134,
       "Entries": [
-        "Beat value / beat value check_warrior (LV45 Ojo 1)"
+        "Beat Value/Beat Value Check - Warrior (LV45 Sen's Fortress)"
       ]
     },
     {
       "ID": 9135,
       "Entries": [
-        "Beat value / beat value check_warrior (LV55 to Moriwaba)"
+        "Beat Value/Beat Value Check - Warrior (LV55 Darkroot Garden)"
       ]
     },
     {
       "ID": 9136,
       "Entries": [
-        "Beat value / beat value check_Warrior (up to LV65 Cemetery 2)"
+        "Beat Value/Beat Value Check - Warrior (LV65 Tomb of the Giants)"
       ]
     },
     {
       "ID": 9137,
       "Entries": [
-        "Beat value / beat value check_Warrior (up to LV75 last)"
+        "Beat Value/Beat Value Check - Warrior (LV75 last)"
       ]
     },
     {

--- a/src/Smithbox.Data/Assets/PARAM/DS1R/Community Row Names/EquipMtrlSetParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/DS1R/Community Row Names/EquipMtrlSetParam.json
@@ -736,73 +736,73 @@
     {
       "ID": 1700,
       "Entries": [
-        "Demon Titanite +0 [Soul of Moonlight Buttefly]"
+        "Demon Titanite +0 [Soul of the Moonlight Butterfly]"
       ]
     },
     {
       "ID": 1701,
       "Entries": [
-        "Demon Titanite +1 [Soul of Moonlight Buttefly]"
+        "Demon Titanite +1 [Soul of the Moonlight Butterfly]"
       ]
     },
     {
       "ID": 1702,
       "Entries": [
-        "Demon Titanite +2 [Soul of Moonlight Buttefly]"
+        "Demon Titanite +2 [Soul of the Moonlight Butterfly]"
       ]
     },
     {
       "ID": 1703,
       "Entries": [
-        "Demon Titanite +3 [Soul of Moonlight Buttefly]"
+        "Demon Titanite +3 [Soul of the Moonlight Butterfly]"
       ]
     },
     {
       "ID": 1704,
       "Entries": [
-        "Demon Titanite +4 [Soul of Moonlight Buttefly]"
+        "Demon Titanite +4 [Soul of the Moonlight Butterfly]"
       ]
     },
     {
       "ID": 1705,
       "Entries": [
-        "Demon Titanite +5 [Soul of Moonlight Buttefly]"
+        "Demon Titanite +5 [Soul of the Moonlight Butterfly]"
       ]
     },
     {
       "ID": 1800,
       "Entries": [
-        "Demon Titanite +0 [Core of Iron Golem]"
+        "Demon Titanite +0 [Core of an Iron Golem]"
       ]
     },
     {
       "ID": 1801,
       "Entries": [
-        "Demon Titanite +1 [Core of Iron Golem]"
+        "Demon Titanite +1 [Core of an Iron Golem]"
       ]
     },
     {
       "ID": 1802,
       "Entries": [
-        "Demon Titanite +2 [Core of Iron Golem]"
+        "Demon Titanite +2 [Core of an Iron Golem]"
       ]
     },
     {
       "ID": 1803,
       "Entries": [
-        "Demon Titanite +3 [Core of Iron Golem]"
+        "Demon Titanite +3 [Core of an Iron Golem]"
       ]
     },
     {
       "ID": 1804,
       "Entries": [
-        "Demon Titanite +4 [Core of Iron Golem]"
+        "Demon Titanite +4 [Core of an Iron Golem]"
       ]
     },
     {
       "ID": 1805,
       "Entries": [
-        "Demon Titanite +5 [Core of Iron Golem]"
+        "Demon Titanite +5 [Core of an Iron Golem]"
       ]
     },
     {
@@ -916,73 +916,73 @@
     {
       "ID": 2200,
       "Entries": [
-        "Dragon Scale +0 [Core of Iron Golem]"
+        "Dragon Scale +0 [Core of an Iron Golem]"
       ]
     },
     {
       "ID": 2201,
       "Entries": [
-        "Dragon Scale +1 [Core of Iron Golem]"
+        "Dragon Scale +1 [Core of an Iron Golem]"
       ]
     },
     {
       "ID": 2202,
       "Entries": [
-        "Dragon Scale +2 [Core of Iron Golem]"
+        "Dragon Scale +2 [Core of an Iron Golem]"
       ]
     },
     {
       "ID": 2203,
       "Entries": [
-        "Dragon Scale +3 [Core of Iron Golem]"
+        "Dragon Scale +3 [Core of an Iron Golem]"
       ]
     },
     {
       "ID": 2204,
       "Entries": [
-        "Dragon Scale +4 [Core of Iron Golem]"
+        "Dragon Scale +4 [Core of an Iron Golem]"
       ]
     },
     {
       "ID": 2205,
       "Entries": [
-        "Dragon Scale +5 [Core of Iron Golem]"
+        "Dragon Scale +5 [Core of an Iron Golem]"
       ]
     },
     {
       "ID": 2300,
       "Entries": [
-        "Demon Titanite +0"
+        "Demon Titanite +0 [UNUSED]"
       ]
     },
     {
       "ID": 2301,
       "Entries": [
-        "Demon Titanite +1"
+        "Demon Titanite +1 [UNUSED]"
       ]
     },
     {
       "ID": 2302,
       "Entries": [
-        "Demon Titanite +2"
+        "Demon Titanite +2 [UNUSED]"
       ]
     },
     {
       "ID": 2303,
       "Entries": [
-        "Demon Titanite +3"
+        "Demon Titanite +3 [UNUSED]"
       ]
     },
     {
       "ID": 2304,
       "Entries": [
-        "Demon Titanite +4"
+        "Demon Titanite +4 [UNUSED]"
       ]
     },
     {
       "ID": 2305,
       "Entries": [
-        "Demon Titanite +5"
+        "Demon Titanite +5 [UNUSED]"
       ]
     },
     {

--- a/src/Smithbox.Data/Assets/PARAM/DS1R/Community Row Names/EquipParamGoods.json
+++ b/src/Smithbox.Data/Assets/PARAM/DS1R/Community Row Names/EquipParamGoods.json
@@ -70,13 +70,13 @@
     {
       "ID": 115,
       "Entries": [
-        "Black Eye Orb -"
+        "Black Eye Orb - Lautrec Invasion"
       ]
     },
     {
       "ID": 116,
       "Entries": [
-        "Black Eye Orb -"
+        "[UNUSED] Black Eye Orb - Shiva Invasion"
       ]
     },
     {
@@ -92,99 +92,195 @@
       ]
     },
     {
-      "ID": 200,
+      "ID": 130,
       "Entries": [
-        "Estus Flask"
+        "None"
       ]
     },
     {
-      "ID": 201,
+      "ID": 131,
+      "Entries": [
+        "Way of White"
+      ]
+    },
+    {
+      "ID": 132,
+      "Entries": [
+        "Princess's Guard"
+      ]
+    },
+    {
+      "ID": 133,
+      "Entries": [
+        "Warrior of Sunlight"
+      ]
+    },
+    {
+      "ID": 134,
+      "Entries": [
+        "Darkwraith"
+      ]
+    },
+    {
+      "ID": 135,
+      "Entries": [
+        "Path of the Dragon"
+      ]
+    },
+    {
+      "ID": 136,
+      "Entries": [
+        "Gravelord Servant"
+      ]
+    },
+    {
+      "ID": 137,
+      "Entries": [
+        "Forest Hunter"
+      ]
+    },
+    {
+      "ID": 138,
+      "Entries": [
+        "Darkmoon Blade"
+      ]
+    },
+    {
+      "ID": 139,
+      "Entries": [
+        "Chaos Servant"
+      ]
+    },
+    {
+      "ID": 140,
+      "Entries": [
+        "dummy10"
+      ]
+    },
+    {
+      "ID": 141,
+      "Entries": [
+        "dummy11"
+      ]
+    },
+    {
+      "ID": 142,
+      "Entries": [
+        "dummy12"
+      ]
+    },
+    {
+      "ID": 143,
+      "Entries": [
+        "dummy13"
+      ]
+    },
+    {
+      "ID": 144,
+      "Entries": [
+        "dummy14"
+      ]
+    },
+    {
+      "ID": 145,
+      "Entries": [
+        "dummy15"
+      ]
+    },
+    {
+      "ID": 200,
       "Entries": [
         "Estus Flask - Drained"
       ]
     },
     {
-      "ID": 202,
+      "ID": 201,
       "Entries": [
-        "Estus Flask +1"
+        "Estus Flask"
       ]
     },
     {
-      "ID": 203,
+      "ID": 202,
       "Entries": [
         "Estus Flask +1 - Drained"
       ]
     },
     {
-      "ID": 204,
+      "ID": 203,
       "Entries": [
-        "Estus Flask +2"
+        "Estus Flask +1"
       ]
     },
     {
-      "ID": 205,
+      "ID": 204,
       "Entries": [
         "Estus Flask +2 - Drained"
       ]
     },
     {
-      "ID": 206,
+      "ID": 205,
       "Entries": [
-        "Estus Flask +3"
+        "Estus Flask +2"
       ]
     },
     {
-      "ID": 207,
+      "ID": 206,
       "Entries": [
         "Estus Flask +3 - Drained"
       ]
     },
     {
-      "ID": 208,
+      "ID": 207,
       "Entries": [
-        "Estus Flask +4"
+        "Estus Flask +3"
       ]
     },
     {
-      "ID": 209,
+      "ID": 208,
       "Entries": [
         "Estus Flask +4 - Drained"
       ]
     },
     {
-      "ID": 210,
+      "ID": 209,
       "Entries": [
-        "Estus Flask +5"
+        "Estus Flask +4"
       ]
     },
     {
-      "ID": 211,
+      "ID": 210,
       "Entries": [
         "Estus Flask +5 - Drained"
       ]
     },
     {
-      "ID": 212,
+      "ID": 211,
       "Entries": [
-        "Estus Flask +6"
+        "Estus Flask +5"
       ]
     },
     {
-      "ID": 213,
+      "ID": 212,
       "Entries": [
         "Estus Flask +6 - Drained"
       ]
     },
     {
+      "ID": 213,
+      "Entries": [
+        "Estus Flask +6"
+      ]
+    },
+    {
       "ID": 214,
       "Entries": [
-        "Estus Flask +7"
+        "Estus Flask +7 - Drained"
       ]
     },
     {
       "ID": 215,
       "Entries": [
-        "Estus Flask +7 - Drained"
+        "Estus Flask +7"
       ]
     },
     {
@@ -412,43 +508,43 @@
     {
       "ID": 390,
       "Entries": [
-        "Fire Keeper Soul"
+        "Fire Keeper Soul (Anastacia of Astora)"
       ]
     },
     {
       "ID": 391,
       "Entries": [
-        "Fire Keeper Soul"
+        "Fire Keeper Soul (Darkmoon Knightess)"
       ]
     },
     {
       "ID": 392,
       "Entries": [
-        "Fire Keeper Soul"
+        "Fire Keeper Soul (The Fair Lady)"
       ]
     },
     {
       "ID": 393,
       "Entries": [
-        "Fire Keeper Soul"
+        "Fire Keeper Soul (New Londo Ruins)"
       ]
     },
     {
       "ID": 394,
       "Entries": [
-        "Fire Keeper Soul"
+        "Fire Keeper Soul (Blighttown)"
       ]
     },
     {
       "ID": 395,
       "Entries": [
-        "Fire Keeper Soul"
+        "Fire Keeper Soul (Duke's Archives)"
       ]
     },
     {
       "ID": 396,
       "Entries": [
-        "Fire Keeper Soul"
+        "Fire Keeper Soul (Undead Parish)"
       ]
     },
     {
@@ -910,37 +1006,37 @@
     {
       "ID": 2200,
       "Entries": [
-        "[Unused] Blacksmith's favorite"
+        "[UNUSED] Blacksmith's favorite"
       ]
     },
     {
       "ID": 2500,
       "Entries": [
-        "Lord Soul"
+        "Lord Soul (Gravelord Nito)"
       ]
     },
     {
       "ID": 2501,
       "Entries": [
-        "Lord Soul"
+        "Lord Soul (Bed of Chaos)"
       ]
     },
     {
       "ID": 2502,
       "Entries": [
-        "Bequeathed Lord Soul Shard"
+        "Bequeathed Lord Soul Shard (Four Kings)"
       ]
     },
     {
       "ID": 2503,
       "Entries": [
-        "Bequeathed Lord Soul Shard"
+        "Bequeathed Lord Soul Shard (Seath the Scaleless)"
       ]
     },
     {
       "ID": 2504,
       "Entries": [
-        "[Unused] Demon Fire 5"
+        "[UNUSED] Lord Soul 5"
       ]
     },
     {
@@ -976,25 +1072,25 @@
     {
       "ID": 2603,
       "Entries": [
-        "[Unused] Magic Equipment Menu Unlock"
+        "[UNUSED] Magic Equipment Menu Unlock"
       ]
     },
     {
       "ID": 2604,
       "Entries": [
-        "[Unused] Item sale menu unlock"
+        "[UNUSED] Item sale menu unlock"
       ]
     },
     {
       "ID": 2605,
       "Entries": [
-        "[Unused] Warp menu unlock"
+        "[UNUSED] Warp menu unlock"
       ]
     },
     {
       "ID": 2606,
       "Entries": [
-        "[Unused] Level up menu unlock"
+        "[UNUSED] Level up menu unlock"
       ]
     },
     {
@@ -1012,7 +1108,7 @@
     {
       "ID": 2609,
       "Entries": [
-        "[Unused] Extra menu unlock"
+        "[UNUSED] Extra menu unlock"
       ]
     },
     {

--- a/src/Smithbox.Data/Assets/PARAM/DS1R/Community Row Names/FaceGenParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/DS1R/Community Row Names/FaceGenParam.json
@@ -106,25 +106,25 @@
     {
       "ID": 30,
       "Entries": [
-        "4th Edition Warrior_Male"
+        "April 2011 Version Warrior_Male"
       ]
     },
     {
       "ID": 31,
       "Entries": [
-        "Knights_Male"
+        "April 2011 Version Knight_Male"
       ]
     },
     {
       "ID": 32,
       "Entries": [
-        "4th Edition Wizard _ Woman"
+        "April 2011 Version Sorcerer_Female"
       ]
     },
     {
       "ID": 33,
       "Entries": [
-        "4th Edition Sorcerer_Male"
+        "April 2011 Version Pyromancer_Male"
       ]
     },
     {
@@ -274,7 +274,7 @@
     {
       "ID": 123,
       "Entries": [
-        "default face test_24"
+        "Default face test_24"
       ]
     },
     {
@@ -298,7 +298,7 @@
     {
       "ID": 127,
       "Entries": [
-        "Default Face Test_28"
+        "Default face test_28"
       ]
     },
     {
@@ -328,7 +328,7 @@
     {
       "ID": 132,
       "Entries": [
-        "Default Face Test_33"
+        "Default face test_33"
       ]
     },
     {
@@ -352,7 +352,7 @@
     {
       "ID": 136,
       "Entries": [
-        "Default Face Test_37"
+        "Default face test_37"
       ]
     },
     {
@@ -370,7 +370,7 @@
     {
       "ID": 139,
       "Entries": [
-        "Default Face Test_40"
+        "Default face test_40"
       ]
     },
     {
@@ -382,19 +382,19 @@
     {
       "ID": 141,
       "Entries": [
-        "Default Face Test_42"
+        "Default face test_42"
       ]
     },
     {
       "ID": 142,
       "Entries": [
-        "Default Face Test_43"
+        "Default face test_43"
       ]
     },
     {
       "ID": 143,
       "Entries": [
-        "Default Face Test_44"
+        "Default face test_44"
       ]
     },
     {
@@ -406,31 +406,31 @@
     {
       "ID": 145,
       "Entries": [
-        "Default Face Test_46"
+        "Default face test_46"
       ]
     },
     {
       "ID": 146,
       "Entries": [
-        "Default Face Test_47"
+        "Default face test_47"
       ]
     },
     {
       "ID": 147,
       "Entries": [
-        "Default Face Test_48"
+        "Default face test_48"
       ]
     },
     {
       "ID": 148,
       "Entries": [
-        "Default Face Test_49"
+        "Default face test_49"
       ]
     },
     {
       "ID": 149,
       "Entries": [
-        "Default Face Test_50"
+        "Default face test_50"
       ]
     },
     {
@@ -442,439 +442,439 @@
     {
       "ID": 1000,
       "Entries": [
-        "Common Face"
+        "[Male] Commoner"
       ]
     },
     {
       "ID": 1001,
       "Entries": [
-        "Wuhe River Farmer's Face"
+        "[Male] Delta Farmer"
       ]
     },
     {
       "ID": 1002,
       "Entries": [
-        "Noble Face of Astra"
+        "[Male] Astora Noble"
       ]
     },
     {
       "ID": 1003,
       "Entries": [
-        "Ryu Gakuin Student Face"
+        "[Male] Dragon Scholar"
       ]
     },
     {
       "ID": 1004,
       "Entries": [
-        "Solrondo Saint Face"
+        "[Male] Thorolund Cleric"
       ]
     },
     {
       "ID": 1005,
       "Entries": [
-        "Catalina's cheerful face"
+        "[Male] Jubilant Catarina"
       ]
     },
     {
       "ID": 1006,
       "Entries": [
-        "Kalim's dismal face"
+        "[Male] Dubious Carim"
       ]
     },
     {
       "ID": 1007,
       "Entries": [
-        "Zena's old face"
+        "[Male] Classic Zena"
       ]
     },
     {
       "ID": 1008,
       "Entries": [
-        "Onuma"
+        "[Male] Eerie Great Swamp"
       ]
     },
     {
       "ID": 1009,
       "Entries": [
-        "Eastern alien face"
+        "[Male] Far East Traveler"
       ]
     },
     {
       "ID": 2000,
       "Entries": [
-        "commoner face"
+        "[Female] Commoner"
       ]
     },
     {
       "ID": 2001,
       "Entries": [
-        "Five finger river farmer's face"
+        "[Female] Delta Farmer"
       ]
     },
     {
       "ID": 2002,
       "Entries": [
-        "Astra noble face"
+        "[Female] Astora Noble"
       ]
     },
     {
       "ID": 2003,
       "Entries": [
-        "Ryu Gakuin Student Face"
+        "[Female] Dragon Scholar"
       ]
     },
     {
       "ID": 2004,
       "Entries": [
-        "Sollond's Saint Face"
+        "[Female] Thorolund Cleric"
       ]
     },
     {
       "ID": 2005,
       "Entries": [
-        "Cheerful face of Catalina"
+        "[Female] Jubilant Catarina"
       ]
     },
     {
       "ID": 2006,
       "Entries": [
-        "Kalim's gloomy face"
+        "[Female] Dubious Carim"
       ]
     },
     {
       "ID": 2007,
       "Entries": [
-        "Zena's old face"
+        "[Female] Classic Zena"
       ]
     },
     {
       "ID": 2008,
       "Entries": [
-        "Anomaly of Onuma"
+        "[Female] Eerie Great Swamp"
       ]
     },
     {
       "ID": 2009,
       "Entries": [
-        "Eastern strange face"
+        "[Female] Far East Traveler"
       ]
     },
     {
       "ID": 6000,
       "Entries": [
-        "Sun Knight"
+        "Solaire of Astora"
       ]
     },
     {
       "ID": 6001,
       "Entries": [
-        "Knight of the Sun (Solar Bug Ver.)"
+        "Solaire of Astora (Sunlight Maggot Ver.)"
       ]
     },
     {
       "ID": 6002,
       "Entries": [
-        "Knight of the Sun (dead)"
+        "[UNUSED] Solaire of Astora (Hollow)"
       ]
     },
     {
       "ID": 6010,
       "Entries": [
-        "Dark Moon Knight"
+        "Darkmoon Knightess"
       ]
     },
     {
       "ID": 6020,
       "Entries": [
-        "Knight Ostra"
+        "Oscar of Astora"
       ]
     },
     {
       "ID": 6021,
       "Entries": [
-        "Knight Ostra, hostile"
+        "Oscar of Astora (Hostile)"
       ]
     },
     {
       "ID": 6030,
       "Entries": [
-        "\"Big Hat\" Logan"
+        "Big Hat Logan"
       ]
     },
     {
       "ID": 6031,
       "Entries": [
-        "\"Big hat\" Logan (dead)"
+        "[UNUSED] Big Hat Logan (Hollow)"
       ]
     },
     {
       "ID": 6040,
       "Entries": [
-        "Logan Disciple"
+        "Griggs of Vinheim"
       ]
     },
     {
       "ID": 6041,
       "Entries": [
-        "Logan's apprentice (deceased)"
+        "Griggs of Vinheim (Hollow)"
       ]
     },
     {
       "ID": 6050,
       "Entries": [
-        "Princess of the Exiled"
+        "Dusk of Oolacile"
       ]
     },
     {
       "ID": 6060,
       "Entries": [
-        "Gray Saint"
+        "[UNUSED] Gray Saint"
       ]
     },
     {
       "ID": 6070,
       "Entries": [
-        "White Saint"
+        "Rhea of Thorolund"
       ]
     },
     {
       "ID": 6071,
       "Entries": [
-        "White saint (dead)"
+        "Rhea of Thorolund (Hollow)"
       ]
     },
     {
       "ID": 6080,
       "Entries": [
-        "Saint Knight A"
+        "Petrus of Thorolund"
       ]
     },
     {
       "ID": 6090,
       "Entries": [
-        "Saint Knight B"
+        "Vince of Thorolund"
       ]
     },
     {
       "ID": 6091,
       "Entries": [
-        "Saint Knight B (dead)"
+        "Vince of Thorolund (Hollow)"
       ]
     },
     {
       "ID": 6100,
       "Entries": [
-        "Saint Knight C"
+        "Nico of Thorolund"
       ]
     },
     {
       "ID": 6101,
       "Entries": [
-        "Saint Knight C (dead)"
+        "Nico of Thorolund (Hollow)"
       ]
     },
     {
       "ID": 6130,
       "Entries": [
-        "Vase Sorcerer"
+        "Laurentius of the Great Swamp"
       ]
     },
     {
       "ID": 6131,
       "Entries": [
-        "Vase Sorcerer (dead)"
+        "Laurentius of the Great Swamp (Hollow)"
       ]
     },
     {
       "ID": 6170,
       "Entries": [
-        "Wandering chaos"
+        "Quelana of Izalith"
       ]
     },
     {
       "ID": 6180,
       "Entries": [
-        "Healer"
+        "Ingward"
       ]
     },
     {
       "ID": 6220,
       "Entries": [
-        "Blacksmith Rickert"
+        "Rickert of Vinheim"
       ]
     },
     {
       "ID": 6250,
       "Entries": [
-        "A Broken Merchant"
+        "Crestfallen Merchant"
       ]
     },
     {
       "ID": 6260,
       "Entries": [
-        "trickster"
+        "Domhnall of Zena"
       ]
     },
     {
       "ID": 6270,
       "Entries": [
-        "A Broken Warrior"
+        "Crestfallen Warrior"
       ]
     },
     {
       "ID": 6271,
       "Entries": [
-        "Broken warrior (dead)"
+        "Crestfallen Warrior (Hollow)"
       ]
     },
     {
       "ID": 6280,
       "Entries": [
-        "Onion Knight"
+        "Siegmeyer of Catarina"
       ]
     },
     {
       "ID": 6290,
       "Entries": [
-        "Onion Knight's Daughter"
+        "Sieglinde of Catarina"
       ]
     },
     {
       "ID": 6300,
       "Entries": [
-        "Hugged Knight Lautrek"
+        "Knight Lautrec of Carim"
       ]
     },
     {
       "ID": 6310,
       "Entries": [
-        "Field Takeshi"
+        "Shiva of the East"
       ]
     },
     {
       "ID": 6320,
       "Entries": [
-        "Cemetery Coward Patch"
+        "Trusty Patches"
       ]
     },
     {
       "ID": 6370,
       "Entries": [
-        "Dragon Priest"
+        "Oswald of Carim"
       ]
     },
     {
       "ID": 6390,
       "Entries": [
-        "Black Knight Tarcus"
+        "Black Iron Tarkus"
       ]
     },
     {
       "ID": 6400,
       "Entries": [
-        "Belka Knight"
+        "[UNUSED] Velka Knight"
       ]
     },
     {
       "ID": 6410,
       "Entries": [
-        "Witch Mallows"
+        "Witch Beatrice"
       ]
     },
     {
       "ID": 6420,
       "Entries": [
-        "Ninja"
+        "Shiva's Bodyguard"
       ]
     },
     {
       "ID": 6490,
       "Entries": [
-        "Lautrek companion 1"
+        "Lautrec's Companion 1"
       ]
     },
     {
       "ID": 6500,
       "Entries": [
-        "Lautrek companion 2"
+        "Lautrec's Companion 2"
       ]
     },
     {
       "ID": 6530,
       "Entries": [
-        "Numa Woman (NPC Multi)"
+        "Maneater Mildred"
       ]
     },
     {
       "ID": 6550,
       "Entries": [
-        "Temple Knight (NPC Multi)"
+        "Paladin Leeroy"
       ]
     },
     {
       "ID": 6560,
       "Entries": [
-        "Barb Knight (NPC Multi)"
+        "Kirk, Knight of Thorns"
       ]
     },
     {
       "ID": 6570,
       "Entries": [
-        "Yellow clothing (NPC multi)"
+        "Xanthous King Jeremiah"
       ]
     },
     {
       "ID": 6580,
       "Entries": [
-        "Castle tower NPC (Havel)"
+        "Havel the Rock"
       ]
     },
     {
       "ID": 6600,
       "Entries": [
-        "Royal Castle 1 Tower NPC (Ricard)"
+        "Undead Prince Ricard"
       ]
     },
     {
       "ID": 6610,
       "Entries": [
-        "Crystal Knight"
+        "Hollow Crystal Knight"
       ]
     },
     {
       "ID": 6801,
       "Entries": [
-        "Bandit A Gatekeeper"
+        "Forest Hunter - Bandit"
       ]
     },
     {
       "ID": 6802,
       "Entries": [
-        "Bandit B Warrior"
+        "Forest Hunter - Knight"
       ]
     },
     {
       "ID": 6803,
       "Entries": [
-        "Bandit C Bow Master"
+        "Forest Hunter - Hunter"
       ]
     },
     {
       "ID": 6804,
       "Entries": [
-        "Bandit D Magic (Attack)"
+        "Forest Hunter - Cleric"
       ]
     },
     {
       "ID": 6805,
       "Entries": [
-        "Bandit E Magic (Recovery)"
+        "Forest Hunter - Sorcerer"
       ]
     },
     {
       "ID": 6806,
       "Entries": [
-        "Bandit F Stealth"
+        "Forest Hunter - Thief"
       ]
     }
   ]

--- a/src/Smithbox.Data/Assets/PARAM/DS1R/Community Row Names/GameAreaParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/DS1R/Community Row Names/GameAreaParam.json
@@ -4,121 +4,121 @@
     {
       "ID": 0,
       "Entries": [
-        "テスト"
+        "Test"
       ]
     },
     {
       "ID": 1,
       "Entries": [
-        "テスト1"
+        "Test1"
       ]
     },
     {
       "ID": 100,
       "Entries": [
-        "石柱_なりそこない"
+        "[UNUSED] DeS Beneath the Nexus (King Allant?)"
       ]
     },
     {
       "ID": 200,
       "Entries": [
-        "王城1_ファランクス（本体）"
+        "[UNUSED] DeS 1-1 Phalanx"
       ]
     },
     {
       "ID": 201,
       "Entries": [
-        "王城2_王の盾"
+        "[UNUSED] DeS 1-2 Tower Knight"
       ]
     },
     {
       "ID": 202,
       "Entries": [
-        "王城3_王の剣"
+        "[UNUSED] DeS 1-3 Penetrator"
       ]
     },
     {
       "ID": 203,
       "Entries": [
-        "王城4_レンドル王"
+        "[UNUSED] DeS 1-4 Old King Allant"
       ]
     },
     {
       "ID": 301,
       "Entries": [
-        "古砦1_審判者"
+        "[UNUSED] DeS 4-1 Adjudicator"
       ]
     },
     {
       "ID": 302,
       "Entries": [
-        "古砦2_嵐の戦士"
+        "[UNUSED] DeS 4-2 Old Hero"
       ]
     },
     {
       "ID": 303,
       "Entries": [
-        "古砦3_嵐の獣"
+        "[UNUSED] DeS 4-3 Storm King"
       ]
     },
     {
       "ID": 400,
       "Entries": [
-        "牢城1_カミサマ"
+        "[UNUSED] DeS 3-1 Fool's Idol"
       ]
     },
     {
       "ID": 401,
       "Entries": [
-        "牢城2_キメラ"
+        "[UNUSED] DeS 3-2 Maneater"
       ]
     },
     {
       "ID": 402,
       "Entries": [
-        "牢城3_召喚ＮＰＣ"
+        "[UNUSED] DeS 3-3 Old Monk"
       ]
     },
     {
       "ID": 500,
       "Entries": [
-        "不浄1_蛭デーモン"
+        "[UNUSED] DeS 5-1 Leechmonger"
       ]
     },
     {
       "ID": 501,
       "Entries": [
-        "不浄2_蠅たかり"
+        "[UNUSED] DeS 5-2 Dirty Colossus"
       ]
     },
     {
       "ID": 502,
       "Entries": [
-        "不浄3_聖女リーブラ"
+        "[UNUSED] DeS 5-3 Maiden Astraea"
       ]
     },
     {
       "ID": 600,
       "Entries": [
-        "坑道1_大蜘蛛"
+        "[UNUSED] DeS 2-1 Armor Spider"
       ]
     },
     {
       "ID": 601,
       "Entries": [
-        "坑道2_炎怪人"
+        "[UNUSED] DeS 2-2 Flamelurker"
       ]
     },
     {
       "ID": 602,
       "Entries": [
-        "坑道3_ドラゴンデーモン(坑道)"
+        "[UNUSED] DeS 2-3 Dragon God"
       ]
     },
     {
       "ID": 801,
       "Entries": [
-        "チュートリアル_デブデーモン"
+        "[UNUSED] DeS Tutorial Vanguard"
       ]
     },
     {

--- a/src/Smithbox.Data/Assets/PARAM/DS1R/Community Row Names/HitMtrlParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/DS1R/Community Row Names/HitMtrlParam.json
@@ -10,13 +10,13 @@
     {
       "ID": 1,
       "Entries": [
-        "Cobblestone"
+        "Stone (Outdoor)"
       ]
     },
     {
       "ID": 2,
       "Entries": [
-        "Stone"
+        "Stone (Indoor)"
       ]
     },
     {
@@ -34,7 +34,7 @@
     {
       "ID": 5,
       "Entries": [
-        "Grassland"
+        "Grass"
       ]
     },
     {
@@ -46,61 +46,61 @@
     {
       "ID": 7,
       "Entries": [
-        "Gaps"
+        "Snow"
       ]
     },
     {
       "ID": 8,
       "Entries": [
-        "Trees"
+        "Ice/Crystal"
       ]
     },
     {
       "ID": 9,
       "Entries": [
-        "Swamp"
+        "Metal"
       ]
     },
     {
       "ID": 10,
       "Entries": [
-        "Nest"
+        "Sand"
       ]
     },
     {
       "ID": 11,
       "Entries": [
-        "Iron"
+        "Bone"
       ]
     },
     {
       "ID": 12,
       "Entries": [
-        "Flesh"
+        "Ash"
       ]
     },
     {
       "ID": 14,
       "Entries": [
-        "Bone"
+        "Rotten Wood"
       ]
     },
     {
       "ID": 15,
       "Entries": [
-        "Ash"
+        "Big Tree"
       ]
     },
     {
       "ID": 17,
       "Entries": [
-        "Roof Tiles"
+        "Snow (no footprints)"
       ]
     },
     {
       "ID": 19,
       "Entries": [
-        "Bell"
+        "Water (Slide)"
       ]
     },
     {
@@ -112,37 +112,37 @@
     {
       "ID": 21,
       "Entries": [
-        "Water (ankle level)"
+        "Water (Ankle Level)"
       ]
     },
     {
       "ID": 22,
       "Entries": [
-        "Water (knee)"
+        "Mucus"
       ]
     },
     {
       "ID": 23,
       "Entries": [
-        "Poison Swamp (Blighttown) (shallow)"
+        "Poison Swamp"
       ]
     },
     {
       "ID": 24,
       "Entries": [
-        "Poison Swamp (deep)"
+        "Mud"
       ]
     },
     {
       "ID": 25,
       "Entries": [
-        "Poison Swamp (knee)"
+        "Coal Tar"
       ]
     },
     {
       "ID": 26,
       "Entries": [
-        "Poison Swamp (about puddle)"
+        "Chimera Swamp"
       ]
     },
     {
@@ -160,19 +160,19 @@
     {
       "ID": 29,
       "Entries": [
-        "Without -- なし"
+        "Empty (No visuals)"
       ]
     },
     {
       "ID": 34,
       "Entries": [
-        "木材"
+        "Wood2"
       ]
     },
     {
       "ID": 40,
       "Entries": [
-        "ドボンSFX用"
+        "For Splash SFX"
       ]
     }
   ]

--- a/src/Smithbox.Data/Assets/PARAM/DS1R/Community Row Names/LockCamParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/DS1R/Community Row Names/LockCamParam.json
@@ -10,13 +10,13 @@
     {
       "ID": 1,
       "Entries": [
-        "Summon Magic for range designation"
+        "Summoning Magic Range (summon as in player summon or as in cast magic?)"
       ]
     },
     {
       "ID": 101,
       "Entries": [
-        "Short"
+        "Close"
       ]
     },
     {
@@ -28,86 +28,85 @@
     {
       "ID": 103,
       "Entries": [
-        "Distant"
+        "Far"
       ]
     },
     {
       "ID": 104,
       "Entries": [
-        "Centipede Demon"
+        "[UNUSED] Centipede Demon"
       ]
     },
     {
       "ID": 105,
       "Entries": [
-        "Undead Dragon"
+        "Painted World - Undead Dragon"
       ]
     },
     {
       "ID": 110,
       "Entries": [
-        "Dark"
+        "Dark (Common)"
       ]
     },
     {
       "ID": 111,
       "Entries": [
-        "Dark - Close"
+        "Dark (Close)"
       ]
     },
     {
       "ID": 112,
       "Entries": [
-        "Dark - Medium"
+        "Dark (Medium)"
       ]
     },
     {
       "ID": 113,
       "Entries": [
-        "Dark - Distant"
+        "Dark (Far)"
       ]
     },
     {
       "ID": 200,
       "Entries": [
-        "Dark",
-        "Dark"
+        "Dark (Prototype Map)"
       ]
     },
     {
       "ID": 210,
       "Entries": [
-        "Manus"
+        "[DLC] Manus, Father of the Abyss"
       ]
     },
     {
       "ID": 211,
       "Entries": [
-        "[DLC] Camera for al-Tri-race"
+        "[DLC] Knight Artorias"
       ]
     },
     {
       "ID": 212,
       "Entries": [
-        "Kalameet"
+        "[DLC] Black Dragon Kalameet"
       ]
     },
     {
       "ID": 213,
       "Entries": [
-        "Chained Prisonmer"
+        "[UNUSED, DLC] Chained Prisoner"
       ]
     },
     {
       "ID": 214,
       "Entries": [
-        "[DLC] Camera for Go warfare"
+        "[DLC] Hawkeye Gough"
       ]
     },
     {
       "ID": 220,
       "Entries": [
-        "Arena"
+        "[DLC] Battle of Stoicism Arena"
       ]
     },
     {
@@ -119,109 +118,109 @@
     {
       "ID": 1010,
       "Entries": [
-        "Gargoyle"
+        "Bell Gargoyle"
       ]
     },
     {
       "ID": 1100,
       "Entries": [
-        "Suspension Bridge"
+        "[UNUSED] 1st Map - Suspension Bridge"
       ]
     },
     {
       "ID": 1101,
       "Entries": [
-        "1st Map - Distant"
+        "[UNUSED] 1st Map - Distant"
       ]
     },
     {
       "ID": 1102,
       "Entries": [
-        "1st Map - Boss Room"
+        "[UNUSED] 1st Map - Boss Room"
       ]
     },
     {
       "ID": 1103,
       "Entries": [
-        "1st Map - Boss Room (old)"
+        "[UNUSED] 1st Map - Boss Room (old)"
       ]
     },
     {
       "ID": 1210,
       "Entries": [
-        "Sanctuary Guardian"
+        "[DLC] Sanctuary Guardian"
       ]
     },
     {
       "ID": 1300,
       "Entries": [
-        "Grave - Close"
+        "[UNUSED] The Catacombs/Tomb of the Giants(?) (Close)"
       ]
     },
     {
       "ID": 1301,
       "Entries": [
-        "Grave - Distant"
+        "[UNUSED] The Catacombs/Tomb of the Giants(?) (Far)"
       ]
     },
     {
       "ID": 1410,
       "Entries": [
-        "[Dedicated to the abolition of the visor]"
+        "Bed of Chaos"
       ]
     },
     {
       "ID": 1510,
       "Entries": [
-        "Gargoyle"
+        "Lightning Gargoyle"
       ]
     },
     {
       "ID": 1511,
       "Entries": [
-        "Gargoyle - Dark"
+        "Lightning Gargoyle (Dark Anor Londo)"
       ]
     },
     {
       "ID": 1700,
       "Entries": [
-        "[Sheath Combat Camera]"
+        "Seath the Scaleless"
       ]
     },
     {
       "ID": 10000,
       "Entries": [
-        "Camera - Short"
+        "Camera (Close)"
       ]
     },
     {
       "ID": 10001,
       "Entries": [
-        "Camera - Medium"
+        "Camera (Medium)"
       ]
     },
     {
       "ID": 10002,
       "Entries": [
-        "Camera - Distant"
+        "Camera (Far)"
       ]
     },
     {
       "ID": 10003,
       "Entries": [
-        "Camera - Dark"
+        "Camera (Dark)"
       ]
     },
     {
       "ID": 10004,
       "Entries": [
-        "Camera - Dark"
+        "Camera (Dark - Prototype Map)"
       ]
     },
     {
       "ID": 10005,
       "Entries": [
-        "Camera - Wide"
+        "Camera (A bit Wider(?) - Prototype Map)"
       ]
     }
   ]

--- a/src/Smithbox.Data/Assets/PARAM/DS1R/Community Row Names/MenuColorTableParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/DS1R/Community Row Names/MenuColorTableParam.json
@@ -10,115 +10,115 @@
     {
       "ID": 1,
       "Entries": [
-        "Normal text_brown"
+        "Normal Text - Brown"
       ]
     },
     {
       "ID": 2,
       "Entries": [
-        "Icon color selected in inventory"
+        "Inventory Selected Icon Color"
       ]
     },
     {
       "ID": 3,
       "Entries": [
-        "Parameter text (normal)"
+        "Parameter Text (Normal)"
       ]
     },
     {
       "ID": 4,
       "Entries": [
-        "Parameter text (good)"
+        "Parameter Text (Good)"
       ]
     },
     {
       "ID": 5,
       "Entries": [
-        "Parameter text (bad)"
+        "Parameter text (Bad)"
       ]
     },
     {
       "ID": 6,
       "Entries": [
-        "Information title"
+        "Information Title"
       ]
     },
     {
       "ID": 7,
       "Entries": [
-        "Normal text_white"
+        "Normal Text - White"
       ]
     },
     {
       "ID": 8,
       "Entries": [
-        "Sucrose bar background color"
+        "Scroll Bar Background Color"
       ]
     },
     {
       "ID": 9,
       "Entries": [
-        "Background plate (concentration adjustment)"
+        "Background Plate (Concentration (brightness?) Adjustment)"
       ]
     },
     {
       "ID": 10,
       "Entries": [
-        "Background plate (color adjustment)"
+        "Background Plate (Color Adjustment)"
       ]
     },
     {
       "ID": 11,
       "Entries": [
-        "One-line help"
+        "One-line Help"
       ]
     },
     {
       "ID": 12,
       "Entries": [
-        "Key guide"
+        "Key Guide"
       ]
     },
     {
       "ID": 13,
       "Entries": [
-        "Menu plate"
+        "Menu Plate"
       ]
     },
     {
       "ID": 14,
       "Entries": [
-        "translucent plate"
+        "Translucent Plate"
       ]
     },
     {
       "ID": 15,
       "Entries": [
-        "Translucent gradation plate"
+        "Translucent Gradation Plate"
       ]
     },
     {
       "ID": 16,
       "Entries": [
-        "scroll bar"
+        "Scroll Bar"
       ]
     },
     {
       "ID": 17,
       "Entries": [
-        "blood letter plate"
+        "Bloodstain Plate"
       ]
     },
     {
       "ID": 18,
       "Entries": [
-        "SOS plate"
+        "White Sign Soapstone Plate"
       ]
     },
     {
       "ID": 19,
       "Entries": [
-        "item help blackout"
+        "Item Help Blackout"
       ]
     },
     {
@@ -136,31 +136,31 @@
     {
       "ID": 22,
       "Entries": [
-        "lines"
+        "Line"
       ]
     },
     {
       "ID": 23,
       "Entries": [
-        "Menu tab (in-game)"
+        "Menu Tab (In-game)"
       ]
     },
     {
       "ID": 24,
       "Entries": [
-        "Menu tab (camp)"
+        "Menu Tab (Camp) (Bonfire?)"
       ]
     },
     {
       "ID": 25,
       "Entries": [
-        "Menu tab (blood character input)"
+        "Menu Tab (Bloodstain Input)"
       ]
     },
     {
       "ID": 26,
       "Entries": [
-        "Menu tab (SOS input)"
+        "Menu Tab (White Sign Soapstone Input)"
       ]
     },
     {
@@ -172,7 +172,7 @@
     {
       "ID": 28,
       "Entries": [
-        "Menu tab (title menu)"
+        "Menu Tab (Title Menu)"
       ]
     },
     {
@@ -184,31 +184,31 @@
     {
       "ID": 30,
       "Entries": [
-        "HP bar"
+        "HP Bar"
       ]
     },
     {
       "ID": 31,
       "Entries": [
-        "MP bar"
+        "MP Bar"
       ]
     },
     {
       "ID": 32,
       "Entries": [
-        "SP bar"
+        "SP Bar"
       ]
     },
     {
       "ID": 33,
       "Entries": [
-        "Variable bar"
+        "Variable Bar"
       ]
     },
     {
       "ID": 34,
       "Entries": [
-        "bar plate"
+        "Bar Plate"
       ]
     },
     {
@@ -220,7 +220,7 @@
     {
       "ID": 36,
       "Entries": [
-        "Attack / Defense bar (additional effect)"
+        "Attack / Defense Bar (Additional Effect)"
       ]
     },
     {
@@ -232,31 +232,31 @@
     {
       "ID": 38,
       "Entries": [
-        "Option bar"
+        "Option Bar"
       ]
     },
     {
       "ID": 39,
       "Entries": [
-        "Target sites"
+        "Target Site"
       ]
     },
     {
       "ID": 40,
       "Entries": [
-        "translucent character plate (bright)"
+        "Translucent Character Plate (Light)"
       ]
     },
     {
       "ID": 41,
       "Entries": [
-        "Translucent character plate (dark)"
+        "Translucent Character Plate (Dark)"
       ]
     },
     {
       "ID": 42,
       "Entries": [
-        "button plate"
+        "Button Plate"
       ]
     },
     {
@@ -268,223 +268,223 @@
     {
       "ID": 44,
       "Entries": [
-        "Selection item plate (Akira)"
+        "Selection Plate (Light)"
       ]
     },
     {
       "ID": 45,
       "Entries": [
-        "Selection plate (dark)"
+        "Selection Plate (Dark)"
       ]
     },
     {
       "ID": 46,
       "Entries": [
-        "Selection item plate (OK button)"
+        "Selection Plate (OK button)"
       ]
     },
     {
       "ID": 47,
       "Entries": [
-        "Translucent gradation plate (button)"
+        "Translucent Gradation Plate (Button)"
       ]
     },
     {
       "ID": 48,
       "Entries": [
-        "large plate (dark)"
+        "Large Plate (Dark)"
       ]
     },
     {
       "ID": 49,
       "Entries": [
-        "frames (dark)"
+        "Frame (Dark)"
       ]
     },
     {
       "ID": 50,
       "Entries": [
-        "skills slot"
+        "Skill Slot"
       ]
     },
     {
       "ID": 51,
       "Entries": [
-        "spell slot"
+        "Spell Slot"
       ]
     },
     {
       "ID": 52,
       "Entries": [
-        "white"
+        "White"
       ]
     },
     {
       "ID": 53,
       "Entries": [
-        "Normal text_black"
-      ]
-    },
-    {
-      "ID": 36908,
-      "Entries": [
-        "Title-Face Color 08"
-      ]
-    },
-    {
-      "ID": 36909,
-      "Entries": [
-        "Title-Hair color for face creation 09"
-      ]
-    },
-    {
-      "ID": 36910,
-      "Entries": [
-        "Title-Hair Color for Face Creation 10"
-      ]
-    },
-    {
-      "ID": 37908,
-      "Entries": [
-        "Eye color 08"
-      ]
-    },
-    {
-      "ID": 37909,
-      "Entries": [
-        "Eye color 09 for title face creation"
-      ]
-    },
-    {
-      "ID": 37910,
-      "Entries": [
-        "Eye color for title face creation 10"
+        "Normal Text - Black"
       ]
     },
     {
       "ID": 60,
       "Entries": [
-        "FE human nature numerical value"
+        "FE Humanity Number (Grey While Hollow)"
       ]
     },
     {
       "ID": 61,
       "Entries": [
-        "Test color 11"
+        "Test Color 11"
       ]
     },
     {
       "ID": 62,
       "Entries": [
-        "test color 12"
+        "Test Color 12"
       ]
     },
     {
       "ID": 63,
       "Entries": [
-        "test color 13"
+        "Test Color 13"
       ]
     },
     {
       "ID": 64,
       "Entries": [
-        "test color 14"
+        "Test Color 14"
       ]
     },
     {
       "ID": 65,
       "Entries": [
-        "text color blue"
+        "Text Color - Blue"
       ]
     },
     {
       "ID": 66,
       "Entries": [
-        "text color red"
+        "Text Color - Red"
       ]
     },
     {
       "ID": 36901,
       "Entries": [
-        "Title-Face Color 01"
+        "Title - Hair Color 01"
       ]
     },
     {
       "ID": 36902,
       "Entries": [
-        "Title-Face Color 02"
+        "Title - Hair Color 02"
       ]
     },
     {
       "ID": 36903,
       "Entries": [
-        "Title-Hair Color for Face Creation 03"
+        "Title - Hair Color 03"
       ]
     },
     {
       "ID": 36904,
       "Entries": [
-        "Title-Face Color 04"
+        "Title - Hair Color 04"
       ]
     },
     {
       "ID": 36905,
       "Entries": [
-        "Title-Face Color 05"
+        "Title - Hair Color 05"
       ]
     },
     {
       "ID": 36906,
       "Entries": [
-        "Title-Hair Color for Face Creation 06"
+        "Title - Hair Color 06"
       ]
     },
     {
       "ID": 36907,
       "Entries": [
-        "Title-Face Color 07"
+        "Title - Hair Color 07"
+      ]
+    },
+    {
+      "ID": 36908,
+      "Entries": [
+        "Title - Hair Color 08"
+      ]
+    },
+    {
+      "ID": 36909,
+      "Entries": [
+        "Title - Hair Color 09"
+      ]
+    },
+    {
+      "ID": 36910,
+      "Entries": [
+        "Title - Hair Color 10"
       ]
     },
     {
       "ID": 37901,
       "Entries": [
-        "Eye color for creating title face 01"
+        "Title - Eye Color 01"
       ]
     },
     {
       "ID": 37902,
       "Entries": [
-        "Eye color for creating title face 02"
+        "Title - Eye Color 02"
       ]
     },
     {
       "ID": 37903,
       "Entries": [
-        "Eye color for creating title face 03"
+        "Title - Eye Color 03"
       ]
     },
     {
       "ID": 37904,
       "Entries": [
-        "Eye color for creating face 04"
+        "Title - Eye Color 04"
       ]
     },
     {
       "ID": 37905,
       "Entries": [
-        "Eyes 05 for creating a title face"
+        "Title - Eye Color 05"
       ]
     },
     {
       "ID": 37906,
       "Entries": [
-        "Eye color for creating title face 06"
+        "Title - Eye Color 06"
       ]
     },
     {
       "ID": 37907,
       "Entries": [
-        "Eye color for creating title face 07"
+        "Title - Eye Color 07"
+      ]
+    },
+    {
+      "ID": 37908,
+      "Entries": [
+        "Title - Eye Color 08"
+      ]
+    },
+    {
+      "ID": 37909,
+      "Entries": [
+        "Title - Eye Color 09"
+      ]
+    },
+    {
+      "ID": 37910,
+      "Entries": [
+        "Title - Eye Color 10"
       ]
     }
   ]

--- a/src/Smithbox.Data/Assets/PARAM/DS1R/Community Row Names/MoveParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/DS1R/Community Row Names/MoveParam.json
@@ -4,391 +4,391 @@
     {
       "ID": 0,
       "Entries": [
-        "Lightweight -- 軽量"
+        "Lightweight"
       ]
     },
     {
       "ID": 1,
       "Entries": [
-        "Lightweight + -- 軽量＋"
+        "Lightweight+"
       ]
     },
     {
       "ID": 5,
       "Entries": [
-        "Medium Amount -- 中量"
+        "Medium Weight"
       ]
     },
     {
       "ID": 6,
       "Entries": [
-        "Medium Amount + -- 中量＋"
+        "Medium Weight+"
       ]
     },
     {
       "ID": 10,
       "Entries": [
-        "Weight -- 重量"
+        "Heavyweight"
       ]
     },
     {
       "ID": 15,
       "Entries": [
-        "Over weight -- 重量オーバー"
+        "Encumbered"
       ]
     },
     {
       "ID": 16,
       "Entries": [
-        "Super light -- 超軽量"
+        "Super Lightweight (Dark Wood Grain Ring)"
       ]
     },
     {
       "ID": 20,
       "Entries": [
-        "Mimicry _ Light Weight -- 擬態_軽量"
+        "Mimicry - Lightweight"
       ]
     },
     {
       "ID": 21,
       "Entries": [
-        "Mimicry _ lightweight + -- 擬態_軽量＋"
+        "Mimicry - Lightweight+"
       ]
     },
     {
       "ID": 25,
       "Entries": [
-        "Mimicry _ Medium Volume -- 擬態_中量"
+        "Mimicry - Medium Weight"
       ]
     },
     {
       "ID": 26,
       "Entries": [
-        "Mimicry _ Medium Amount + -- 擬態_中量＋"
+        "Mimicry - Medium Weight+"
       ]
     },
     {
       "ID": 30,
       "Entries": [
-        "Mimicry weight -- 擬態_重量"
+        "Mimicry - Heavyweight"
       ]
     },
     {
       "ID": 35,
       "Entries": [
-        "Mimicry _ over Weight -- 擬態_重量オーバー"
+        "Mimicry - Encumbered"
       ]
     },
     {
       "ID": 36,
       "Entries": [
-        "Mimicry _ ultra-light -- 擬態_超軽量"
+        "Mimicry - Super Lightweight (Dark Wood Grain Ring)"
       ]
     },
     {
       "ID": 40,
       "Entries": [
-        "Underwater (deep) _ Lightweight -- 水中（深）_軽量"
+        "Water (deep) - Lightweight"
       ]
     },
     {
       "ID": 41,
       "Entries": [
-        "Underwater (deep) _ Lightweight + -- 水中（深）_軽量＋"
+        "Water (deep) - Lightweight+"
       ]
     },
     {
       "ID": 45,
       "Entries": [
-        "Underwater (deep) _ Medium volume -- 水中（深）_中量"
+        "Water (deep) - Medium Weight"
       ]
     },
     {
       "ID": 46,
       "Entries": [
-        "Underwater (deep) _ Medium Volume + -- 水中（深）_中量＋"
+        "Water (deep) - Medium Weight+"
       ]
     },
     {
       "ID": 50,
       "Entries": [
-        "Underwater (deep) _ Weight -- 水中（深）_重量"
+        "Water (deep) - Heavyweight"
       ]
     },
     {
       "ID": 55,
       "Entries": [
-        "Underwater (deep) _ Over weight -- 水中（深）_重量オーバー"
+        "Water (deep) - Encumbered"
       ]
     },
     {
       "ID": 56,
       "Entries": [
-        "Underwater (deep) _ Ultra-Light -- 水中（深）_超軽量"
+        "Water (deep) - Super Lightweight (Dark Wood Grain Ring)"
       ]
     },
     {
       "ID": 60,
       "Entries": [
-        "【 SP 】 Guard Vigilance _ Lightweight -- 【SP】ガード警戒_軽量"
+        "Iron Flesh - Lightweight"
       ]
     },
     {
       "ID": 61,
       "Entries": [
-        "【 SP 】 Guard Vigilance _ lightweight + -- 【SP】ガード警戒_軽量＋"
+        "Iron Flesh - Lightweight+"
       ]
     },
     {
       "ID": 65,
       "Entries": [
-        "【 SP 】 Guard Vigilance _ medium volume -- 【SP】ガード警戒_中量"
+        "Iron Flesh - Medium Weight"
       ]
     },
     {
       "ID": 66,
       "Entries": [
-        "【 SP 】 Guard Vigilance _ Medium Amount + -- 【SP】ガード警戒_中量＋"
+        "Iron Flesh - Medium Weight+"
       ]
     },
     {
       "ID": 70,
       "Entries": [
-        "【 SP 】 Guard Vigilance _ Weight -- 【SP】ガード警戒_重量"
+        "Iron Flesh - Heavyweight"
       ]
     },
     {
       "ID": 75,
       "Entries": [
-        "[SP] Guard vigilance _ over weight -- 【SP】ガード警戒_重量オーバー"
+        "Iron Flesh - Encumbered"
       ]
     },
     {
       "ID": 76,
       "Entries": [
-        "[SP] Guard Vigilance _ ultra-light -- 【SP】ガード警戒_超軽量"
-      ]
-    },
-    {
-      "ID": 1001,
-      "Entries": [
-        "プレイヤー重量"
-      ]
-    },
-    {
-      "ID": 1002,
-      "Entries": [
-        "プレイヤー重量過多"
-      ]
-    },
-    {
-      "ID": 1003,
-      "Entries": [
-        "プレイヤー瀕死"
-      ]
-    },
-    {
-      "ID": 1004,
-      "Entries": [
-        "プレイヤー血沼（重量過多）"
-      ]
-    },
-    {
-      "ID": 1005,
-      "Entries": [
-        "プレイヤー毒沼（移動速度低下）"
-      ]
-    },
-    {
-      "ID": 1006,
-      "Entries": [
-        "プレイヤー超重量移動"
-      ]
-    },
-    {
-      "ID": 1010,
-      "Entries": [
-        "プレイヤー通常_擬態"
-      ]
-    },
-    {
-      "ID": 1011,
-      "Entries": [
-        "プレイヤー重量_擬態"
-      ]
-    },
-    {
-      "ID": 1012,
-      "Entries": [
-        "プレイヤー重量過多_擬態"
-      ]
-    },
-    {
-      "ID": 1013,
-      "Entries": [
-        "プレイヤー超重量移動_擬態"
-      ]
-    },
-    {
-      "ID": 1020,
-      "Entries": [
-        "プレイヤー通常_水中（深）"
-      ]
-    },
-    {
-      "ID": 1021,
-      "Entries": [
-        "プレイヤー重量_水中（深）"
-      ]
-    },
-    {
-      "ID": 1022,
-      "Entries": [
-        "プレイヤー重量過多_水中（深）"
-      ]
-    },
-    {
-      "ID": 1023,
-      "Entries": [
-        "プレイヤー超重量移動_水中（深）"
+        "Iron Flesh - Super Lightweight (Dark Wood Grain Ring)"
       ]
     },
     {
       "ID": 100,
       "Entries": [
-        "Enemy Base Combat -- 敵基本\u3000戦闘時"
+        "DeS Base Enemy Combat"
       ]
     },
     {
       "ID": 101,
       "Entries": [
-        "Bird Standard -- 鳥標準"
+        "DeS Bird Standard"
       ]
     },
     {
       "ID": 102,
       "Entries": [
-        "Guard -- ガード"
+        "DeS Guard"
       ]
     },
     {
       "ID": 103,
       "Entries": [
-        "Dog -- 犬"
+        "DeS Dog"
       ]
     },
     {
       "ID": 104,
       "Entries": [
-        "Dragon Demon -- ドラゴンデーモン"
+        "DeS Dragon God"
       ]
     },
     {
       "ID": 105,
       "Entries": [
-        "Enemy base non-combat time -- 敵基本\u3000非戦闘時"
+        "DeS Base Enemy Non-combat Time"
       ]
     },
     {
       "ID": 106,
       "Entries": [
-        "Scale miners during combat -- ウロコ鉱夫\u3000戦闘時"
+        "DeS Scale Miner Combat"
       ]
     },
     {
       "ID": 107,
       "Entries": [
-        "Scales Miners Non-combat (bag) -- ウロコ鉱夫\u3000非戦闘時（袋）"
+        "DeS Scale Miner Non-combat (Bag)"
       ]
     },
     {
       "ID": 108,
       "Entries": [
-        "Scales Miners Non-combat (pick) -- ウロコ鉱夫\u3000非戦闘時（ピックル）"
+        "DeS Scale Miner Non-combat (Pickaxe)"
       ]
     },
     {
       "ID": 109,
       "Entries": [
-        "Big Spider Peeping -- 大蜘蛛\u3000のぞき込み"
+        "DeS Armor Spider Peeking (??)"
       ]
     },
     {
       "ID": 110,
       "Entries": [
-        "Gargoyletest -- ガーゴイルテスト"
+        "DeS Gargoyle Test"
       ]
     },
     {
       "ID": 111,
       "Entries": [
-        "Dragon Demon (mine) -- ドラゴンデーモン（坑道）"
+        "DeS Dragon God (Stonefang Tunnel)"
       ]
     },
     {
       "ID": 112,
       "Entries": [
-        "For the beast of the Storm -- 嵐の獣用"
+        "DeS Storm King"
       ]
     },
     {
       "ID": 113,
       "Entries": [
-        "Storm Beast (CUB) Bichibichi wait -- 嵐の獣（子エイ）ビチビチ待機"
+        "DeS Storm King (Child) Bichibichi Wait"
       ]
     },
     {
       "ID": 114,
       "Entries": [
-        "Scales Miners Non-combat (bare hands) -- ウロコ鉱夫\u3000非戦闘時（素手）"
+        "DeS Scale Miner Non-combat (Bare Hand)"
       ]
     },
     {
       "ID": 115,
       "Entries": [
-        "Octopus head when fighting -- タコ頭 \u3000戦闘時"
+        "DeS Mind Flayer Combat"
       ]
     },
     {
       "ID": 116,
       "Entries": [
-        "Gargoyle aerial (for 3050) -- ガーゴイル空中（3050用）"
+        "DeS Gargoyle Air (for 3050)"
       ]
     },
     {
       "ID": 117,
       "Entries": [
-        "Gargoyle Ground (for 3050) -- ガーゴイル地上（3050用）"
+        "DeS Gargoyle Ground (for 3050)"
       ]
     },
     {
       "ID": 118,
       "Entries": [
-        "Shadow woman _ for disappearing -- 影女＿消える用"
+        "DeS Shadowlurker (Female)? (For Disappearing)"
       ]
     },
     {
       "ID": 119,
       "Entries": [
-        "Blood mites only -- 血ダニ専用"
+        "DeS For Blood Mites (Giant Tick?)"
       ]
     },
     {
       "ID": 120,
       "Entries": [
-        "Paris AIM -- パリィ狙い"
+        "Paris (Pharis?) Aim"
       ]
     },
     {
       "ID": 121,
       "Entries": [
-        "[DLC] Enemy Basic combat (running/swirling anime without version) -- 【DLC】敵基本\u3000戦闘時（走行／旋回アニメなしバージョン）"
+        "[DLC] Base Enemy Combat (No Running/Turning Animation)"
       ]
     },
     {
       "ID": 900,
       "Entries": [
-        "Four-legged type for PG -- PG用4足タイプ"
+        "Quadruped for PG"
+      ]
+    },
+    {
+      "ID": 1001,
+      "Entries": [
+        "[UNUSED] DeS Player - Heavyweight"
+      ]
+    },
+    {
+      "ID": 1002,
+      "Entries": [
+        "[UNUSED] DeS Player - Encumbered"
+      ]
+    },
+    {
+      "ID": 1003,
+      "Entries": [
+        "[UNUSED] DeS Player - Dying?"
+      ]
+    },
+    {
+      "ID": 1004,
+      "Entries": [
+        "[UNUSED] DeS Player - Blood Swamp, Encumbered"
+      ]
+    },
+    {
+      "ID": 1005,
+      "Entries": [
+        "[UNUSED] DeS Player - Poison Swamp, Movespeed decrease"
+      ]
+    },
+    {
+      "ID": 1006,
+      "Entries": [
+        "[UNUSED] Player - Super Lightweight"
+      ]
+    },
+    {
+      "ID": 1010,
+      "Entries": [
+        "[UNUSED] Player - Standard (Mimicry)"
+      ]
+    },
+    {
+      "ID": 1011,
+      "Entries": [
+        "[UNUSED] Player - Heavyweight (Mimicry)"
+      ]
+    },
+    {
+      "ID": 1012,
+      "Entries": [
+        "[UNUSED] Player - Encumbered (Mimicry)"
+      ]
+    },
+    {
+      "ID": 1013,
+      "Entries": [
+        "[UNUSED] Player - Super Lightweight (Mimicry)"
+      ]
+    },
+    {
+      "ID": 1020,
+      "Entries": [
+        "[UNUSED] Player - Standard (Deep Water)"
+      ]
+    },
+    {
+      "ID": 1021,
+      "Entries": [
+        "[UNUSED] Player - Heavyweight (Deep Water)"
+      ]
+    },
+    {
+      "ID": 1022,
+      "Entries": [
+        "[UNUSED] Player - Encumbered (Deep Water)"
+      ]
+    },
+    {
+      "ID": 1023,
+      "Entries": [
+        "[UNUSED] Player - Super Lightweight (Deep Water)"
       ]
     }
   ]

--- a/src/Smithbox.Data/Assets/PARAM/DS1R/Community Row Names/NpcParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/DS1R/Community Row Names/NpcParam.json
@@ -4,13 +4,13 @@
     {
       "ID": 0,
       "Entries": [
-        "Do not erase-can't erase"
+        "Do not erase"
       ]
     },
     {
       "ID": 1,
       "Entries": [
-        "Atarisawari data (copy and paste recommended)-Unobtrusive data (copy and paste recommended)"
+        "Atarisawari (Unobtrusive?) Data (Recommended Source For Copy & Paste)"
       ]
     },
     {
@@ -34,175 +34,175 @@
     {
       "ID": 21,
       "Entries": [
-        "For fire damage test"
+        "For Fire Damage Test"
       ]
     },
     {
       "ID": 200,
       "Entries": [
-        "DS2 for easy logic test"
+        "DeS2 - Easy Logic Test"
       ]
     },
     {
       "ID": 500,
       "Entries": [
-        "DS2 Proto @ Knight who loves ladder"
+        "DeS2 Proto - Knight Who Loves Ladder"
       ]
     },
     {
       "ID": 501,
       "Entries": [
-        "DS2 Proto: A Big Prisoner Helping a Friend"
+        "DeS2 Proto - Big Jailor Who Helps His Friends"
       ]
     },
     {
       "ID": 502,
       "Entries": [
-        "Skeleton test to talk"
+        "Skeleton Talk Test"
       ]
     },
     {
       "ID": 503,
       "Entries": [
-        "Skeleton for coffin throwing (large)"
+        "For Coffin Throwing - Skeleton (Large)"
       ]
     },
     {
       "ID": 510,
       "Entries": [
-        "DS2 Test @ Knight Assumed"
+        "DeS2 Test - Knight Assumed(?)"
       ]
     },
     {
       "ID": 511,
       "Entries": [
-        "Skeleton_Sword Parry"
+        "Skeleton - Sword Parry"
       ]
     },
     {
       "ID": 514,
       "Entries": [
-        "Wyvern Bird Control"
+        "Wyvern - Bird Control"
       ]
     },
     {
       "ID": 520,
       "Entries": [
-        "DS2Test for upstream"
+        "DeS2Test - Upstream"
       ]
     },
     {
       "ID": 521,
       "Entries": [
-        "DS2Test Friend for Kawakami"
+        "DeS2Test - Upstream Friend"
       ]
     },
     {
       "ID": 522,
       "Entries": [
-        "DS2Test Kawakami 2"
+        "DeS2Test - Upstream 2"
       ]
     },
     {
       "ID": 540,
       "Entries": [
-        "For automatic patrol (running)-For automatic patrol (running)"
+        "DeS2 Test - For Watanabe(?)"
       ]
     },
     {
       "ID": 541,
       "Entries": [
-        "Automatic patrol (walking)-For automatic patrol (walking)"
+        "DeS2 Test - For Watanabe spare(??)"
       ]
     },
     {
       "ID": 550,
       "Entries": [
-        "DS2 test wandering for automatic test (Watanabe management)"
+        "DeS2 Test - Wandering For Automatic Test (Managed by Watanabe?)"
       ]
     },
     {
       "ID": 551,
       "Entries": [
-        "DS2 test wandering reserve for automatic test (Watanabe management)"
+        "DeS2 Test - Wandering For Automatic Test (Managed by Watanabe spare?)"
       ]
     },
     {
       "ID": 1000,
       "Entries": [
-        "DS2 Return Test Knight_Sword"
+        "DeS2 - Return Home Test: Knight (Sword)"
       ]
     },
     {
       "ID": 1003,
       "Entries": [
-        "DS2 {4 end} NPC closing the gate"
+        "DeS2 (End of April?) - Gate Closing NPC"
       ]
     },
     {
       "ID": 6000,
       "Entries": [
-        "Knight Solaire"
+        "Solaire of Astora - Undead Burg"
       ]
     },
     {
       "ID": 6001,
       "Entries": [
-        "Knight Solaire"
+        "[UNUSED] Solaire of Astora - Undead Parish"
       ]
     },
     {
       "ID": 6002,
       "Entries": [
-        "Knight Solaire"
+        "Solaire of Astora - Anor Londo"
       ]
     },
     {
       "ID": 6003,
       "Entries": [
-        "Knight Solaire"
+        "Solaire of Astora - Demon Ruins"
       ]
     },
     {
       "ID": 6004,
       "Entries": [
-        "Knight Solaire"
+        "Solaire of Astora (Hostile) - Demon Ruins"
       ]
     },
     {
       "ID": 6010,
       "Entries": [
-        "Lady of the Darkling"
+        "Darkmoon Knightess"
       ]
     },
     {
       "ID": 6020,
       "Entries": [
-        "Oscar, Knight of Astora"
+        "Oscar of Astora"
       ]
     },
     {
       "ID": 6021,
       "Entries": [
-        "Oscar, Knight of Astora"
+        "Oscar of Astora (Hostile)"
       ]
     },
     {
       "ID": 6030,
       "Entries": [
-        "Big Hat Logan"
+        "Big Hat Logan - Sen's Fortress/Firelink Shrine"
       ]
     },
     {
       "ID": 6031,
       "Entries": [
-        "Big Hat Logan"
+        "Big Hat Logan - Duke's Archives"
       ]
     },
     {
       "ID": 6032,
       "Entries": [
-        "Big Hat Logan"
+        "Big Hat Logan (Hollow) - Duke's Archives"
       ]
     },
     {
@@ -214,13 +214,13 @@
     {
       "ID": 6041,
       "Entries": [
-        "Griggs of Vinheim"
+        "Griggs of Vinheim (Hollow)"
       ]
     },
     {
       "ID": 6050,
       "Entries": [
-        "Dusk of Oolacile"
+        "Dusk of Oolacile - Darkroot Basin"
       ]
     },
     {
@@ -268,13 +268,13 @@
     {
       "ID": 6130,
       "Entries": [
-        "Griggs of Vinheim - Undead Burg"
+        "Laurentius of the Great Swamp"
       ]
     },
     {
       "ID": 6131,
       "Entries": [
-        "Griggs of Vinheim (Hollow) - Blighttown"
+        "Laurentius of the Great Swamp (Hollow)"
       ]
     },
     {
@@ -286,13 +286,13 @@
     {
       "ID": 6180,
       "Entries": [
-        "Ingward"
+        "Ingward, Guardian of the Seal"
       ]
     },
     {
       "ID": 6220,
       "Entries": [
-        "Blacksmith Rickert"
+        "Rickert of Vinheim"
       ]
     },
     {
@@ -316,61 +316,61 @@
     {
       "ID": 6271,
       "Entries": [
-        "Crestfallen Warrior (Hollow) - The Depths"
+        "Crestfallen Warrior (Hollow)"
       ]
     },
     {
       "ID": 6280,
       "Entries": [
-        "Siegmeyer of Catarina"
+        "Siegmeyer of Catarina - Sen's Fortress/Ash Lake"
       ]
     },
     {
       "ID": 6281,
       "Entries": [
-        "Siegmeyer of Catarina"
+        "Siegmeyer of Catarina - Anor Londo"
       ]
     },
     {
       "ID": 6282,
       "Entries": [
-        "Siegmeyer of Catarina"
+        "Siegmeyer of Catarina - Firelink Shrine"
       ]
     },
     {
       "ID": 6283,
       "Entries": [
-        "Siegmeyer of Catarina"
+        "Siegmeyer of Catarina - Blighttown"
       ]
     },
     {
       "ID": 6284,
       "Entries": [
-        "Siegmeyer of Catarina"
+        "Siegmeyer of Catarina - Lost Izalith"
       ]
     },
     {
       "ID": 6290,
       "Entries": [
-        "Sieglinde of Catarina"
+        "Sieglinde of Catarina - Duke's Archives/Firelink Shrine"
       ]
     },
     {
       "ID": 6291,
       "Entries": [
-        "Sieglinde of Catarina - Great Hollow"
+        "Sieglinde of Catarina - Ash Lake"
       ]
     },
     {
       "ID": 6300,
       "Entries": [
-        "Knight Lautrec"
+        "Knight Lautrec of Carim"
       ]
     },
     {
       "ID": 6301,
       "Entries": [
-        "Knight Lautrec"
+        "Knight Lautrec of Carim (Invaded)"
       ]
     },
     {
@@ -382,25 +382,25 @@
     {
       "ID": 6311,
       "Entries": [
-        "Shiva of the East (Invaded)"
+        "[UNUSED] Shiva of the East (Invaded)"
       ]
     },
     {
       "ID": 6320,
       "Entries": [
-        "Patches"
+        "Trusty Patches - The Catacombs"
       ]
     },
     {
       "ID": 6321,
       "Entries": [
-        "Patches"
+        "Trusty Patches - Tomb of the Giants/Firelink Shrine"
       ]
     },
     {
       "ID": 6350,
       "Entries": [
-        "絵師エレーアミス"
+        "[UNUSED] Painter Ariamis"
       ]
     },
     {
@@ -412,19 +412,19 @@
     {
       "ID": 6390,
       "Entries": [
-        "Black Knight Tarkus"
+        "[UNUSED] Black Iron Tarkus"
       ]
     },
     {
       "ID": 6400,
       "Entries": [
-        "ベルカ騎士"
+        "[UNUSED] Velka Knight"
       ]
     },
     {
       "ID": 6410,
       "Entries": [
-        "魔女マロース"
+        "[UNUSED] Witch Beatrice"
       ]
     },
     {
@@ -436,121 +436,121 @@
     {
       "ID": 6421,
       "Entries": [
-        "Shiva's Bodyguard (Invaded)"
+        "[UNUSED] Shiva's Bodyguard (Invaded)"
       ]
     },
     {
       "ID": 6490,
       "Entries": [
-        "Lautrec Bodyguard 1"
+        "Lautrec's Companion 1"
       ]
     },
     {
       "ID": 6500,
       "Entries": [
-        "Lautrec Bodyguard 2"
+        "Lautrec's Companion 2"
       ]
     },
     {
       "ID": 6510,
       "Entries": [
-        "Iron Tarkus"
+        "Black Iron Tarkus (Summon) - Sen's Fortress"
       ]
     },
     {
       "ID": 6511,
       "Entries": [
-        "Iron Tarkus"
+        "[UNUSED] Black Iron Tarkus (Hostile) - Lost Izalith"
       ]
     },
     {
       "ID": 6520,
       "Entries": [
-        "Witch Beatrice"
+        "Witch Beatrice (Summon) - Darkroot Garden"
       ]
     },
     {
       "ID": 6521,
       "Entries": [
-        "Witch Beatrice"
+        "Witch Beatrice (Summon) - New Londo Ruins"
       ]
     },
     {
       "ID": 6530,
       "Entries": [
-        "Maneater Mildred"
+        "Maneater Mildred (Summon)"
       ]
     },
     {
       "ID": 6531,
       "Entries": [
-        "Maneater Mildred"
+        "Maneater Mildred (Invader)"
       ]
     },
     {
       "ID": 6540,
       "Entries": [
-        "Knight Solaire"
+        "Solaire of Astora (Summon) - Undead Parish"
       ]
     },
     {
       "ID": 6541,
       "Entries": [
-        "Knight Solaire"
+        "Solaire of Astora (Summon) - The Depths"
       ]
     },
     {
       "ID": 6542,
       "Entries": [
-        "Knight Solaire"
+        "Solaire of Astora (Summon) - Anor Londo"
       ]
     },
     {
       "ID": 6543,
       "Entries": [
-        "Knight Solaire"
+        "Solaire of Astora (Summon) - Demon Ruins"
       ]
     },
     {
       "ID": 6544,
       "Entries": [
-        "Knight Solaire"
+        "Solaire of Astora (Summon) - Kiln of the First Flame"
       ]
     },
     {
       "ID": 6550,
       "Entries": [
-        "Paladin Leeroy"
+        "Paladin Leeroy (Summon)"
       ]
     },
     {
       "ID": 6551,
       "Entries": [
-        "Paladin Leeroy"
+        "Paladin Leeroy (Invader)"
       ]
     },
     {
       "ID": 6560,
       "Entries": [
-        "Knight Kirk"
+        "Kirk, Knight of Thorns (Invader) - The Depths"
       ]
     },
     {
       "ID": 6561,
       "Entries": [
-        "Knight Kirk"
+        "Kirk, Knight of Thorns (Invader) - Demon Ruins"
       ]
     },
     {
       "ID": 6562,
       "Entries": [
-        "Knight Kirk"
+        "Kirk, Knight of Thorns (Invader) - Lost Izalith"
       ]
     },
     {
       "ID": 6570,
       "Entries": [
-        "King Jeremiah"
+        "Xanthous King Jeremiah (Invader)"
       ]
     },
     {
@@ -562,25 +562,25 @@
     {
       "ID": 6590,
       "Entries": [
-        "Knight Lautrec"
+        "Knight Lautrec of Carim - Undead Parish (Summon)"
       ]
     },
     {
       "ID": 6591,
       "Entries": [
-        "Knight Lautrec"
+        "Knight Lautrec of Carim - The Depths (Summon)"
       ]
     },
     {
       "ID": 6600,
       "Entries": [
-        "Prince Ricard"
+        "Undead Prince Ricard"
       ]
     },
     {
       "ID": 6610,
       "Entries": [
-        "Crystal Knight"
+        "Hollow Crystal Knight"
       ]
     },
     {
@@ -592,19 +592,19 @@
     {
       "ID": 6640,
       "Entries": [
-        "Dark Moon Sword (Heavy Knight)"
+        "Darkmoon Soldier (Sword)"
       ]
     },
     {
       "ID": 6650,
       "Entries": [
-        "Dark Moon Sword (Light Knight)"
+        "Darkmoon Soldier (Greatsword)"
       ]
     },
     {
       "ID": 6700,
       "Entries": [
-        "Dusk of Oolacile"
+        "Dusk of Oolacile - Chasm of the Abyss"
       ]
     },
     {
@@ -616,157 +616,157 @@
     {
       "ID": 6801,
       "Entries": [
-        "Forest Hunter - Bandit"
+        "Forest Hunter A - Bandit"
       ]
     },
     {
       "ID": 6802,
       "Entries": [
-        "Forest Hunter - Knight"
+        "Forest Hunter B - Warrior"
       ]
     },
     {
       "ID": 6803,
       "Entries": [
-        "Forest Hunter - Hunter"
+        "Forest Hunter C - Hunter"
       ]
     },
     {
       "ID": 6804,
       "Entries": [
-        "Forest Hunter - Cleric"
+        "Forest Hunter D - Sorcerer"
       ]
     },
     {
       "ID": 6805,
       "Entries": [
-        "Forest Hunter - Sorcerer"
+        "Forest Hunter E - Cleric"
       ]
     },
     {
       "ID": 6806,
       "Entries": [
-        "Forest Hunter - Thief"
+        "Forest Hunter F - Thief"
       ]
     },
     {
       "ID": 6810,
       "Entries": [
-        "Tutorial Prisoner 1"
+        "[UNUSED] Tutorial Prisoner 1"
       ]
     },
     {
       "ID": 6811,
       "Entries": [
-        "Tutorial Prisoner 2"
+        "[UNUSED] Tutorial Prisoner 2"
       ]
     },
     {
       "ID": 7100,
       "Entries": [
-        "Castle 2_Vagrant NPC_Warrior"
+        "[UNUSED] Vagrant NPC - The Depths - Warrior"
       ]
     },
     {
       "ID": 7110,
       "Entries": [
-        "Castle 1 ・ First half_Vagrant NPC_Voyeur"
+        "[UNUSED] Vagrant NPC - Undead Burg - Thief"
       ]
     },
     {
       "ID": 7111,
       "Entries": [
-        "Castle 1st & 2nd half_Vagrant NPC_Voyeur"
+        "[UNUSED] Vagrant NPC - Undead Parish - Thief"
       ]
     },
     {
       "ID": 7120,
       "Entries": [
-        "Painting world_Vagrant NPC_Wanderer"
+        "[UNUSED] Vagrant NPC - Painted World - Wanderer"
       ]
     },
     {
       "ID": 7130,
       "Entries": [
-        "Moriwaba, first half_Vagrant NPC_Hunter"
+        "[UNUSED] Vagrant NPC - Darkroot Garden (1st half) - Hunter"
       ]
     },
     {
       "ID": 7131,
       "Entries": [
-        "Moriwaba, latter half_Vagrant NPC_Hunter"
+        "[UNUSED] Vagrant NPC - Darkroot Garden (2nd half) - Hunter"
       ]
     },
     {
       "ID": 7140,
       "Entries": [
-        "Cemetery 1_Vagrant NPC_Cleric"
+        "[UNUSED] Vagrant NPC - The Catacombs - Cleric"
       ]
     },
     {
       "ID": 7150,
       "Entries": [
-        "Cemetery 2_Vagrant NPC_Cleric"
+        "[UNUSED] Vagrant NPC - Tomb of the Giants - Cleric"
       ]
     },
     {
       "ID": 7160,
       "Entries": [
-        "Underground Lake_Vagrant NPC_Dragon Newt"
+        "[UNUSED] Vagrant NPC - Ash Lake - Dragon Newt"
       ]
     },
     {
       "ID": 7170,
       "Entries": [
-        "Kagemachi_Vagrant NPC_Wanderer"
+        "[UNUSED] Vagrant NPC - Blighttown - Wanderer"
       ]
     },
     {
       "ID": 7180,
       "Entries": [
-        "Closed city, first half_Vagrant NPC_Sorcerer"
+        "[UNUSED] Vagrant NPC - Demon Ruins/Lost Izalith - Pyromancer"
       ]
     },
     {
       "ID": 7190,
       "Entries": [
-        "Royal Castle 1_Vagrant NPC_Warrior"
+        "[UNUSED] Vagrant NPC - Sen's Fortress - Warrior"
       ]
     },
     {
       "ID": 7200,
       "Entries": [
-        "Royal Castle 2_Vagrant NPC_Knight"
+        "[UNUSED] Vagrant NPC - Anor Londo - Knight"
       ]
     },
     {
       "ID": 7210,
       "Entries": [
-        "Abyss_Vagrant NPC_Bandit"
+        "[UNUSED] Vagrant NPC - New Londo Ruins - Bandit"
       ]
     },
     {
       "ID": 7220,
       "Entries": [
-        "Crystal Tower_Vagrant NPC_Sorcerer"
+        "[UNUSED] Vagrant NPC - Duke's Archives/Crystal Cave - Sorcerer"
       ]
     },
     {
       "ID": 7230,
       "Entries": [
-        "Great tomb_Vagrant NPC_Not possessed"
+        "[UNUSED] Vagrant NPC - Kiln of the First Flame - Deprived"
       ]
     },
     {
       "ID": 7240,
       "Entries": [
-        "Tutorial_Vagrant NPC_What You Don't Have"
+        "[UNUSED] Vagrant NPC - Undead Asylum - Deprived"
       ]
     },
     {
       "ID": 10100,
       "Entries": [
-        "NPC Conversation Test 1 (garbled NPC in pot)"
+        "NPC Conversation Test 1 (NPC Disguised as Jar)"
       ]
     },
     {
@@ -784,85 +784,85 @@
     {
       "ID": 120000,
       "Entries": [
-        "Rat"
+        "Large Undead Rat"
       ]
     },
     {
       "ID": 120100,
       "Entries": [
-        "Small Rat"
+        "Small Undead Rat - Firelink Shrine"
       ]
     },
     {
       "ID": 120101,
       "Entries": [
-        "Small Rat"
+        "Small Undead Rat - Undead Burg"
       ]
     },
     {
       "ID": 120102,
       "Entries": [
-        "Small Rat"
+        "Small Undead Rat - The Depths"
       ]
     },
     {
       "ID": 120103,
       "Entries": [
-        "Small Rat"
+        "Small Undead Rat - Painted World"
       ]
     },
     {
       "ID": 120104,
       "Entries": [
-        "Small Rat"
+        "Small Undead Rat (Black Phantom) - The Depths"
       ]
     },
     {
       "ID": 120200,
       "Entries": [
-        "Giant Rat"
+        "Giant Undead Rat"
       ]
     },
     {
       "ID": 120300,
       "Entries": [
-        "Plague Rat"
+        "Undead Snow Rat"
       ]
     },
     {
       "ID": 206000,
       "Entries": [
-        "Infested Ghoul"
+        "Infested Ghoul (Sword)"
       ]
     },
     {
       "ID": 206001,
       "Entries": [
-        "Infested Ghoul"
+        "Infested Ghoul (Spear)"
       ]
     },
     {
       "ID": 206002,
       "Entries": [
-        "Infested Ghoul"
+        "Infested Ghoul (Corpse)"
       ]
     },
     {
       "ID": 206003,
       "Entries": [
-        "Infested Ghoul"
+        "Infested Ghoul (Sword - Black Phantom)"
       ]
     },
     {
       "ID": 206004,
       "Entries": [
-        "Infested Ghoul"
+        "Infested Ghoul (Spear - Black Phantom)"
       ]
     },
     {
       "ID": 206005,
       "Entries": [
-        "Infested Ghoul"
+        "Infested Ghoul (Corpse - Black Phantom)"
       ]
     },
     {
@@ -874,7 +874,7 @@
     {
       "ID": 223100,
       "Entries": [
-        "Firesage Demon"
+        "Demon Firesage"
       ]
     },
     {
@@ -892,13 +892,13 @@
     {
       "ID": 224001,
       "Entries": [
-        "Capra Demon"
+        "Lesser Capra Demon"
       ]
     },
     {
       "ID": 224002,
       "Entries": [
-        "Capra Demon"
+        "Lesser Capra Demon (Black Phantom)"
       ]
     },
     {
@@ -910,13 +910,13 @@
     {
       "ID": 225002,
       "Entries": [
-        "Taurus Demon"
+        "Lesser Taurus Demon"
       ]
     },
     {
       "ID": 225003,
       "Entries": [
-        "Taurus Demon"
+        "[UNUSED] Lesser Taurus Demon (7 Heroes??)"
       ]
     },
     {
@@ -928,79 +928,79 @@
     {
       "ID": 226001,
       "Entries": [
-        "Batwing Demon"
+        "[UNUSED] Batwing Demon - Darkroot Garden"
       ]
     },
     {
       "ID": 227000,
       "Entries": [
-        "Mushroom Parent"
+        "Mushroom-Man Parent - Darkroot Garden"
       ]
     },
     {
       "ID": 227001,
       "Entries": [
-        "Mushroom Parent"
+        "Mushroom-Man Parent - Great Hollow"
       ]
     },
     {
       "ID": 227002,
       "Entries": [
-        "Mushroom Parent"
+        "Mushroom-Man Parent (Black Phantom) - Darkroot Garden"
       ]
     },
     {
       "ID": 228000,
       "Entries": [
-        "Mushroom Child"
+        "Mushroom-Man Child - Darkroot Garden"
       ]
     },
     {
       "ID": 228001,
       "Entries": [
-        "Mushroom Child"
+        "Mushroom-Man Child - Great Hollow"
       ]
     },
     {
       "ID": 228002,
       "Entries": [
-        "Mushroom Child"
+        "Mushroom-Man Child - Darkroot Garden"
       ]
     },
     {
       "ID": 230000,
       "Entries": [
-        "Prowling Demon"
+        "Titanite Demon - The Catacombs"
       ]
     },
     {
       "ID": 230001,
       "Entries": [
-        "Prowling Demon"
+        "Titanite Demon - Undead Parish"
       ]
     },
     {
       "ID": 230002,
       "Entries": [
-        "Prowling Demon"
+        "Titanite Demon - Sen's Fortress"
       ]
     },
     {
       "ID": 230003,
       "Entries": [
-        "Prowling Demon"
+        "Titanite Demon - Sen's Fortress 2"
       ]
     },
     {
       "ID": 230004,
       "Entries": [
-        "Prowling Demon"
+        "Titanite Demon - Anor Londo"
       ]
     },
     {
       "ID": 230005,
       "Entries": [
-        "Prowling Demon"
+        "Titanite Demon - Demon Ruins"
       ]
     },
     {
@@ -1024,43 +1024,43 @@
     {
       "ID": 233001,
       "Entries": [
-        "Demonic Foliage"
+        "Demonic Foliage (Darkroot Garden 2nd half)"
       ]
     },
     {
       "ID": 236000,
       "Entries": [
-        "Smough"
+        "Executioner Smough"
       ]
     },
     {
       "ID": 236001,
       "Entries": [
-        "Smough"
+        "Executioner Smough (Lightning)"
       ]
     },
     {
       "ID": 237000,
       "Entries": [
-        "Channeler"
+        "Channeler - Undead Parish"
       ]
     },
     {
       "ID": 237001,
       "Entries": [
-        "Channeler"
+        "Channeler - Duke's Archives"
       ]
     },
     {
       "ID": 237002,
       "Entries": [
-        "Channeler"
+        "Channeler - The Depths"
       ]
     },
     {
       "ID": 237003,
       "Entries": [
-        "Channeler"
+        "Channeler (Black Phantom) - Duke's Archives"
       ]
     },
     {
@@ -1072,13 +1072,13 @@
     {
       "ID": 238001,
       "Entries": [
-        "Stone Knight"
+        "[UNUSED] Stone Knight - Royal Garden"
       ]
     },
     {
       "ID": 238002,
       "Entries": [
-        "Stone Knight"
+        "Stone Knight (Black Phantom)"
       ]
     },
     {
@@ -1090,7 +1090,7 @@
     {
       "ID": 239003,
       "Entries": [
-        "Darkwraith"
+        "Darkwraith (Black Phantom)"
       ]
     },
     {
@@ -1102,427 +1102,427 @@
     {
       "ID": 241000,
       "Entries": [
-        "Silver Knight"
+        "Silver Knight (Sword)"
       ]
     },
     {
       "ID": 241003,
       "Entries": [
-        "Silver Knight"
+        "Silver Knight (Spear)"
       ]
     },
     {
       "ID": 241004,
       "Entries": [
-        "Silver Knight"
+        "Silver Knight (Greatbow)"
       ]
     },
     {
       "ID": 241005,
       "Entries": [
-        "Silver Knight"
+        "Silver Knight (Sword - Black Phantom)"
       ]
     },
     {
       "ID": 241006,
       "Entries": [
-        "Silver Knight"
+        "Silver Knight (Spear - Black Phantom)"
       ]
     },
     {
       "ID": 243000,
       "Entries": [
-        "Demonic Statue"
+        "Demonic Statue - Demon Ruins"
       ]
     },
     {
       "ID": 243001,
       "Entries": [
-        "Demonic Statue"
+        "Demonic Statue - Lost Izalith"
       ]
     },
     {
       "ID": 250000,
       "Entries": [
-        "Hollow"
+        "Hollow (Sword) - Undead Burg"
       ]
     },
     {
       "ID": 250001,
       "Entries": [
-        "Hollow"
+        "Hollow (Torch) - Undead Burg"
       ]
     },
     {
       "ID": 250010,
       "Entries": [
-        "Hollow"
+        "Hollow (Sword) - Painted World"
       ]
     },
     {
       "ID": 250011,
       "Entries": [
-        "Hollow"
+        "Hollow (Torch) - Painted World"
       ]
     },
     {
       "ID": 250012,
       "Entries": [
-        "Hollow"
+        "Hollow (Bow) - Painted World"
       ]
     },
     {
       "ID": 250020,
       "Entries": [
-        "Hollow"
+        "Hollow (Unarmed) - Undead Asylum"
       ]
     },
     {
       "ID": 250021,
       "Entries": [
-        "Hollow"
+        "Hollow (Bow) - Undead Asylum"
       ]
     },
     {
       "ID": 250022,
       "Entries": [
-        "Hollow"
+        "Hollow (Sword) - Undead Asylum"
       ]
     },
     {
       "ID": 250023,
       "Entries": [
-        "Hollow"
+        "Hollow (Torch) - Undead Asylum (Revisit)"
       ]
     },
     {
       "ID": 250024,
       "Entries": [
-        "Hollow"
+        "Hollow (Bow) - Undead Asylum (Revisit)"
       ]
     },
     {
       "ID": 250025,
       "Entries": [
-        "Hollow"
+        "Hollow (Sword) - Undead Asylum (Revisit)"
       ]
     },
     {
       "ID": 250030,
       "Entries": [
-        "Hollow"
+        "Hollow (Sword) - The Depths"
       ]
     },
     {
       "ID": 250031,
       "Entries": [
-        "Hollow"
+        "Hollow (Torch) - The Depths"
       ]
     },
     {
       "ID": 250032,
       "Entries": [
-        "Hollow"
+        "Hollow (Sword - Black Phantom) - The Depths"
       ]
     },
     {
       "ID": 250033,
       "Entries": [
-        "Hollow"
+        "Hollow (Torch - Black Phantom) - The Depths"
       ]
     },
     {
       "ID": 250040,
       "Entries": [
-        "Hollow"
+        "Hollow (Unarmed) - New Londo Ruins"
       ]
     },
     {
       "ID": 250050,
       "Entries": [
-        "Hollow"
+        "Hollow (Sword) - Undead Parish"
       ]
     },
     {
       "ID": 250051,
       "Entries": [
-        "Hollow"
+        "Hollow (Torch) - Undead Parish"
       ]
     },
     {
       "ID": 250052,
       "Entries": [
-        "Hollow"
+        "Hollow (Bow) - Undead Parish"
       ]
     },
     {
       "ID": 250053,
       "Entries": [
-        "Hollow"
+        "Hollow (Black Phantom) - Undead Parish"
       ]
     },
     {
       "ID": 251000,
       "Entries": [
-        "Undead Merchant"
+        "Undead Merchant (Female)"
       ]
     },
     {
       "ID": 251001,
       "Entries": [
-        "Undead Merchant"
+        "Undead Merchant (Male)"
       ]
     },
     {
       "ID": 252000,
       "Entries": [
-        "Undead Assassin"
+        "Hollow Thief"
       ]
     },
     {
       "ID": 252001,
       "Entries": [
-        "Undead Assassin"
+        "Hollow Thief (Black Phantom)"
       ]
     },
     {
       "ID": 253002,
       "Entries": [
-        "Blowdart Hollow"
+        "Hollow Blowdart Sniper"
       ]
     },
     {
       "ID": 254000,
       "Entries": [
-        "Hollow Warrior"
+        "Hollow Warrior (Sword) - Firelink Shrine"
       ]
     },
     {
       "ID": 254001,
       "Entries": [
-        "Hollow Warrior"
+        "Hollow Warrior (Axe) - Firelink Shrine"
       ]
     },
     {
       "ID": 254002,
       "Entries": [
-        "Hollow Warrior"
+        "Hollow Warrior (Firebomb) - Firelink Shrine"
       ]
     },
     {
       "ID": 254010,
       "Entries": [
-        "Hollow Warrior"
+        "Hollow Warrior (Sword) - Undead Burg"
       ]
     },
     {
       "ID": 254011,
       "Entries": [
-        "Hollow Warrior"
+        "Hollow Warrior (Axe) - Undead Burg"
       ]
     },
     {
       "ID": 254012,
       "Entries": [
-        "Hollow Warrior"
+        "Hollow Warrior (Firebomb) - Undead Burg"
       ]
     },
     {
       "ID": 254013,
       "Entries": [
-        "Hollow Warrior"
+        "Hollow Warrior (Sword - Black Phantom) - Undead Burg"
       ]
     },
     {
       "ID": 254014,
       "Entries": [
-        "Hollow Warrior"
+        "Hollow Warrior (Axe - Black Phantom) - Undead Burg"
       ]
     },
     {
       "ID": 255000,
       "Entries": [
-        "Hollow Soldier"
+        "Hollow Soldier (Spear) - Undead Burg"
       ]
     },
     {
       "ID": 255001,
       "Entries": [
-        "Hollow Soldier"
+        "Hollow Soldier (Sword) - Undead Burg"
       ]
     },
     {
       "ID": 255002,
       "Entries": [
-        "Hollow Soldier"
+        "Hollow Soldier (Crossbow) - Undead Burg"
       ]
     },
     {
       "ID": 255010,
       "Entries": [
-        "Hollow Soldier"
+        "Hollow Soldier (Sword) - Firelink Shrine"
       ]
     },
     {
       "ID": 255030,
       "Entries": [
-        "Hollow Soldier"
+        "Hollow Soldier (Sword) - Undead Asylum"
       ]
     },
     {
       "ID": 255031,
       "Entries": [
-        "Hollow Soldier"
+        "Hollow Soldier (Sword) - Undead Asylum (Revisit)"
       ]
     },
     {
       "ID": 255032,
       "Entries": [
-        "Hollow Soldier"
+        "Hollow Soldier (Spear) - Undead Asylum (Revisit)"
       ]
     },
     {
       "ID": 255040,
       "Entries": [
-        "Hollow Soldier"
+        "Hollow Soldier (Spear) - Undead Parish"
       ]
     },
     {
       "ID": 255041,
       "Entries": [
-        "Hollow Soldier"
+        "Hollow Soldier (Sword) - Undead Parish"
       ]
     },
     {
       "ID": 255042,
       "Entries": [
-        "Hollow Soldier"
+        "Hollow Soldier (Crossbow) - Undead Parish"
       ]
     },
     {
       "ID": 255043,
       "Entries": [
-        "Hollow Soldier"
+        "Hollow Soldier (Spear - Black Phantom) - Undead Parish"
       ]
     },
     {
       "ID": 255044,
       "Entries": [
-        "Hollow Soldier"
+        "Hollow Soldier (Sword - Black Phantom) - Undead Parish"
       ]
     },
     {
       "ID": 256000,
       "Entries": [
-        "Balder Knight"
+        "Balder Knight (Sword) - Undead Parish"
       ]
     },
     {
       "ID": 256001,
       "Entries": [
-        "Balder Knight"
+        "[UNUSED] Balder Knight (Crossbow) - Undead Parish"
       ]
     },
     {
       "ID": 256002,
       "Entries": [
-        "Balder Knight"
+        "Balder Knight (Rapier) - Undead Parish"
       ]
     },
     {
       "ID": 256003,
       "Entries": [
-        "Balder Knight"
+        "Balder Knight (Sword - Black Phantom) - Undead Parish"
       ]
     },
     {
       "ID": 256004,
       "Entries": [
-        "Balder Knight"
+        "Balder Knight (Rapier - Black Phantom) - Undead Parish"
       ]
     },
     {
       "ID": 256010,
       "Entries": [
-        "Balder Knight"
+        "Balder Knight (Sword) - Sen's Fortress"
       ]
     },
     {
       "ID": 256011,
       "Entries": [
-        "Balder Knight"
+        "Balder Knight (Crossbow) - Sen's Fortress"
       ]
     },
     {
       "ID": 256012,
       "Entries": [
-        "Balder Knight"
+        "Balder Knight (Rapier) - Sen's Fortress"
       ]
     },
     {
       "ID": 256013,
       "Entries": [
-        "Balder Knight"
+        "Balder Knight (Sword - Black Phantom) - Sen's Fortress"
       ]
     },
     {
       "ID": 256014,
       "Entries": [
-        "Balder Knight"
+        "Balder Knight (Rapier - Black Phantom) - Sen's Fortress"
       ]
     },
     {
       "ID": 257000,
       "Entries": [
-        "Heavy Knight"
+        "[UNUSED] Berenike Knight (Greatsword) - Undead Parish"
       ]
     },
     {
       "ID": 257001,
       "Entries": [
-        "Heavy Knight"
+        "Berenike Knight (Mace) - Undead Parish"
       ]
     },
     {
       "ID": 257002,
       "Entries": [
-        "Heavy Knight"
+        "Berenike Knight (Greatsword - Black Phantom) - Undead Parish"
       ]
     },
     {
       "ID": 257010,
       "Entries": [
-        "Heavy Knight"
+        "[UNUSED] Berenike Knight (Greatsword) - Sen's Fortress"
       ]
     },
     {
       "ID": 257011,
       "Entries": [
-        "Heavy Knight"
+        "Berenike Knight (Mace) - Sen's Fortress"
       ]
     },
     {
       "ID": 257012,
       "Entries": [
-        "Heavy Knight"
+        "[UNUSED] Berenike Knight (Greatsword - Black Phantom) - Sen's Fortress"
       ]
     },
     {
       "ID": 257020,
       "Entries": [
-        "Heavy Knight"
+        "Berenike Knight (Greatsword) - Painted World"
       ]
     },
     {
       "ID": 257021,
       "Entries": [
-        "Heavy Knight"
+        "[UNUSED] Berenike Knight (Mace) - Painted World"
       ]
     },
     {
       "ID": 257022,
       "Entries": [
-        "Heavy Knight"
+        "[UNUSED] Berenike Knight (Greatsword - Black Phantom) - Painted World"
       ]
     },
     {
@@ -1534,121 +1534,121 @@
     {
       "ID": 265000,
       "Entries": [
-        "Necromancer"
+        "Hollow Necromancer"
       ]
     },
     {
       "ID": 266000,
       "Entries": [
-        "Butcher"
+        "Hollow Maneater Butcher"
       ]
     },
     {
       "ID": 266001,
       "Entries": [
-        "Butcher"
+        "Hollow Maneater Butcher (Black Phantom)"
       ]
     },
     {
       "ID": 267000,
       "Entries": [
-        "Ghost (Male)"
+        "Cursed Ghost (Male)"
       ]
     },
     {
       "ID": 268000,
       "Entries": [
-        "Ghost (Female)"
+        "Cursed Ghost (Female)"
       ]
     },
     {
       "ID": 269000,
       "Entries": [
-        "Serpent Soldier"
+        "Man-Serpent Soldier - Sen's Fortress"
       ]
     },
     {
       "ID": 269001,
       "Entries": [
-        "Serpent Soldier"
+        "Man-Serpent Soldier (Jailer) - Duke's Archives"
       ]
     },
     {
       "ID": 269002,
       "Entries": [
-        "Serpent Soldier"
+        "Man-Serpent Soldier - Duke's Archives"
       ]
     },
     {
       "ID": 269003,
       "Entries": [
-        "Serpent Soldier"
+        "Man-Serpent Soldier (Strong) - Sen's Fortress"
       ]
     },
     {
       "ID": 269004,
       "Entries": [
-        "Serpent Soldier"
+        "Man-Serpent Soldier (Black Phantom) - Sen's Fortress"
       ]
     },
     {
       "ID": 270000,
       "Entries": [
-        "Serpent Mage"
+        "Man-Serpent Sorcerer - Sen's Fortress"
       ]
     },
     {
       "ID": 270001,
       "Entries": [
-        "Serpent Mage"
+        "Man-Serpent Sorcerer - Duke's Archives"
       ]
     },
     {
       "ID": 270002,
       "Entries": [
-        "Serpent Mage"
+        "Man-Serpent Sorcerer (Black Phantom) - Sen's Fortress"
       ]
     },
     {
       "ID": 271000,
       "Entries": [
-        "Crystal Golem"
+        "Crystal Golem - Duke's Archives"
       ]
     },
     {
       "ID": 271001,
       "Entries": [
-        "Crystal Golem"
+        "Crystal Golem - Darkroot Basin"
       ]
     },
     {
       "ID": 271002,
       "Entries": [
-        "Crystal Golem"
+        "Crystal Golem (Black Phantom) - Duke's Archives"
       ]
     },
     {
       "ID": 271100,
       "Entries": [
-        "Crystal Golem (Gold)"
+        "Crystal Golem (Gold) - Darkroot Basin"
       ]
     },
     {
       "ID": 271101,
       "Entries": [
-        "Crystal Golem (Gold)"
+        "Crystal Golem (Gold) - Duke's Archives"
       ]
     },
     {
       "ID": 273000,
       "Entries": [
-        "Priscilla"
+        "Crossbreed Priscilla"
       ]
     },
     {
       "ID": 273100,
       "Entries": [
-        "Priscilla's Tail"
+        "Crossbreed Priscilla's Tail"
       ]
     },
     {
@@ -1660,139 +1660,139 @@
     {
       "ID": 278000,
       "Entries": [
-        "Mimic"
+        "Mimic - Sen's Fortress"
       ]
     },
     {
       "ID": 278010,
       "Entries": [
-        "Mimic"
+        "Mimic - Anor Londo 1"
       ]
     },
     {
       "ID": 278011,
       "Entries": [
-        "Mimic"
+        "Mimic - Anor Londo 2"
       ]
     },
     {
       "ID": 278012,
       "Entries": [
-        "Mimic"
+        "Mimic - Anor Londo 3"
       ]
     },
     {
       "ID": 278013,
       "Entries": [
-        "Mimic"
+        "Mimic - Anor Londo 4"
       ]
     },
     {
       "ID": 278020,
       "Entries": [
-        "Mimic"
+        "Mimic - Duke's Archives 1"
       ]
     },
     {
       "ID": 278021,
       "Entries": [
-        "Mimic"
+        "Mimic - Duke's Archives 2"
       ]
     },
     {
       "ID": 278030,
       "Entries": [
-        "Mimic"
+        "Mimic - Royal Garden 1"
       ]
     },
     {
       "ID": 278031,
       "Entries": [
-        "Mimic"
+        "Mimic - Royal Garden 2"
       ]
     },
     {
       "ID": 279000,
       "Entries": [
-        "Black Knight"
+        "Black Knight (Sword) - Undead Burg"
       ]
     },
     {
       "ID": 279001,
       "Entries": [
-        "Black Knight"
+        "Black Knight (Greatsword) - Undead Parish"
       ]
     },
     {
       "ID": 279010,
       "Entries": [
-        "Black Knight"
+        "Black Knight (Halberd) - Darkroot Basin"
       ]
     },
     {
       "ID": 279020,
       "Entries": [
-        "Black Knight"
+        "Black Knight (Greataxe) - The Catacombs"
       ]
     },
     {
       "ID": 279030,
       "Entries": [
-        "Black Knight"
+        "Black Knight (Halberd) - Tomb of the Giants"
       ]
     },
     {
       "ID": 279050,
       "Entries": [
-        "Black Knight"
+        "Black Knight (Sword) - Kiln of the First Flame"
       ]
     },
     {
       "ID": 279051,
       "Entries": [
-        "Black Knight"
+        "Black Knight (Greatsword) - Kiln of the First Flame"
       ]
     },
     {
       "ID": 279052,
       "Entries": [
-        "Black Knight"
+        "Black Knight (Greataxe) - Kiln of the First Flame"
       ]
     },
     {
       "ID": 279053,
       "Entries": [
-        "Black Knight"
+        "Black Knight (Halberd) - Kiln of the First Flame"
       ]
     },
     {
       "ID": 279060,
       "Entries": [
-        "Black Knight"
+        "Black Knight (Sword - Black Phantom) - Kiln of the First Flame"
       ]
     },
     {
       "ID": 279061,
       "Entries": [
-        "Black Knight"
+        "Black Knight (Greatsword - Black Phantom) - Kiln of the First Flame"
       ]
     },
     {
       "ID": 279062,
       "Entries": [
-        "Black Knight"
+        "Black Knight (Greataxe - Black Phantom) - Kiln of the First Flame"
       ]
     },
     {
       "ID": 279063,
       "Entries": [
-        "Black Knight"
+        "Black Knight (Halberd - Black Phantom) - Kiln of the First Flame"
       ]
     },
     {
       "ID": 279070,
       "Entries": [
-        "Black Knight"
+        "Black Knight (Sword) - Undead Asylum"
       ]
     },
     {
@@ -1804,91 +1804,91 @@
     {
       "ID": 280000,
       "Entries": [
-        "Crystal Hollow"
+        "Hollow Crystallized Soldier (Sword)"
       ]
     },
     {
       "ID": 280001,
       "Entries": [
-        "Crystal Hollow"
+        "Hollow Crystallized Soldier (Bow)"
       ]
     },
     {
       "ID": 281000,
       "Entries": [
-        "Infested Barbarian (Club)"
+        "Hollow Infested Barbarian (Club)"
       ]
     },
     {
       "ID": 281001,
       "Entries": [
-        "Infested Barbarian (Club)"
+        "Hollow Infested Barbarian (Club - Black Phantom)"
       ]
     },
     {
       "ID": 281100,
       "Entries": [
-        "Infested Barbarian (Boulder)"
+        "Hollow Infested Barbarian (Boulder)"
       ]
     },
     {
       "ID": 281101,
       "Entries": [
-        "Infested Barbarian (Boulder)"
+        "Hollow Infested Barbarian (Boulder - Black Phantom)"
       ]
     },
     {
       "ID": 283010,
       "Entries": [
-        "Hollow Phalanx"
+        "Phalanx"
       ]
     },
     {
       "ID": 284000,
       "Entries": [
-        "Engorged Hollow"
+        "Engorged Hollow (Torch)"
       ]
     },
     {
       "ID": 284001,
       "Entries": [
-        "Engorged Hollow"
+        "Engorged Hollow (Unarmed)"
       ]
     },
     {
       "ID": 284002,
       "Entries": [
-        "Engorged Hollow"
+        "Engorged Hollow (Unarmed - Special Drop)"
       ]
     },
     {
       "ID": 284003,
       "Entries": [
-        "Engorged Hollow"
+        "Engorged Hollow (Torch - Black Phantom)"
       ]
     },
     {
       "ID": 284004,
       "Entries": [
-        "Engorged Hollow"
+        "Engorged Hollow (Unarmed - Black Phantom)"
       ]
     },
     {
       "ID": 286000,
       "Entries": [
-        "Giant"
+        "Slave Giant"
       ]
     },
     {
       "ID": 286001,
       "Entries": [
-        "Giant"
+        "Giant Blacksmith"
       ]
     },
     {
       "ID": 286002,
       "Entries": [
-        "Giant"
+        "Slave Giant (Black Phantom)"
       ]
     },
     {
@@ -1900,193 +1900,193 @@
     {
       "ID": 287001,
       "Entries": [
-        "Royal Sentinel"
+        "Royal Sentinel (Black Phantom)"
       ]
     },
     {
       "ID": 287010,
       "Entries": [
-        "Royal Sentinel"
+        "Giant Sentinel"
       ]
     },
     {
       "ID": 287011,
       "Entries": [
-        "Royal Sentinel"
+        "Giant Sentinel (Black Phantom)"
       ]
     },
     {
       "ID": 290000,
       "Entries": [
-        "Skeleton"
+        "Skeleton (Sword) - Firelink Shrine"
       ]
     },
     {
       "ID": 290001,
       "Entries": [
-        "Skeleton"
+        "Skeleton (Bow) - Firelink Shrine"
       ]
     },
     {
       "ID": 290002,
       "Entries": [
-        "Skeleton"
+        "Skeleton (Falchion) - Firelink Shrine"
       ]
     },
     {
       "ID": 290010,
       "Entries": [
-        "Skeleton"
+        "Skeleton (Sword) - The Catacombs"
       ]
     },
     {
       "ID": 290011,
       "Entries": [
-        "Skeleton"
+        "Skeleton (Bow) - The Catacombs"
       ]
     },
     {
       "ID": 290012,
       "Entries": [
-        "Skeleton"
+        "Skeleton (Falchion) - The Catacombs"
       ]
     },
     {
       "ID": 290013,
       "Entries": [
-        "Skeleton"
+        "Skeleton (Sword - Black Phantom) - The Catacombs"
       ]
     },
     {
       "ID": 290014,
       "Entries": [
-        "Skeleton"
+        "Skeleton (Falchion - Black Phantom) - The Catacombs"
       ]
     },
     {
       "ID": 290020,
       "Entries": [
-        "Skeleton"
+        "Skeleton (Sword - Immortal) - The Catacombs"
       ]
     },
     {
       "ID": 290021,
       "Entries": [
-        "Skeleton"
+        "Skeleton (Bow - Immortal) - The Catacombs"
       ]
     },
     {
       "ID": 290022,
       "Entries": [
-        "Skeleton"
+        "Skeleton (Falchion - Immortal) - The Catacombs"
       ]
     },
     {
       "ID": 290030,
       "Entries": [
-        "Skeleton"
+        "Skeleton (Sword - Immortal) - Tomb of the Giants"
       ]
     },
     {
       "ID": 290031,
       "Entries": [
-        "Skeleton"
+        "Skeleton (Bow - Immortal) - Tomb of the Giants"
       ]
     },
     {
       "ID": 290032,
       "Entries": [
-        "Skeleton"
+        "Skeleton (Falchion - Immortal) - Tomb of the Giants"
       ]
     },
     {
       "ID": 291000,
       "Entries": [
-        "Giant Skeleton"
+        "Giant Skeleton (Greatsword) - Firelink Shrine"
       ]
     },
     {
       "ID": 291001,
       "Entries": [
-        "Giant Skeleton"
+        "Giant Skeleton (Greatbow) - The Catacombs"
       ]
     },
     {
       "ID": 291002,
       "Entries": [
-        "Giant Skeleton"
+        "Giant Skeleton (Greatsword) - The Catacombs"
       ]
     },
     {
       "ID": 291010,
       "Entries": [
-        "Giant Skeleton"
+        "Giant Skeleton (Greatbow) - Tomb of the Giants"
       ]
     },
     {
       "ID": 291011,
       "Entries": [
-        "Giant Skeleton"
+        "Giant Skeleton (Greatsword) - Tomb of the Giants"
       ]
     },
     {
       "ID": 291012,
       "Entries": [
-        "Giant Skeleton"
+        "Giant Skeleton (Greatsword - Immortal) - Tomb of the Giants"
       ]
     },
     {
       "ID": 291013,
       "Entries": [
-        "Giant Skeleton"
+        "Giant Skeleton (Greatbow - Strong) - Tomb of the Giants"
       ]
     },
     {
       "ID": 291014,
       "Entries": [
-        "Giant Skeleton"
+        "Giant Skeleton (Greatsword - Strong) - Tomb of the Giants"
       ]
     },
     {
       "ID": 291015,
       "Entries": [
-        "Giant Skeleton"
+        "Giant Skeleton (Greatsword - Black Phantom) - Tomb of the Giants"
       ]
     },
     {
       "ID": 292000,
       "Entries": [
-        "Vamos"
+        "Vamos the Blacksmith"
       ]
     },
     {
       "ID": 292002,
       "Entries": [
-        "Vamos"
+        "Vamos the Blacksmith (Cutscene)"
       ]
     },
     {
       "ID": 293000,
       "Entries": [
-        "Bonewheel Skeleton"
+        "Bonewheel Skeleton - The Catacombs"
       ]
     },
     {
       "ID": 293001,
       "Entries": [
-        "Bonewheel Skeleton"
+        "Bonewheel Skeleton - Painted World"
       ]
     },
     {
       "ID": 293002,
       "Entries": [
-        "Bonewheel Skeleton"
+        "Bonewheel Skeleton (Black Phantom) - Painted World"
       ]
     },
     {
       "ID": 293003,
       "Entries": [
-        "Bonewheel Skeleton"
+        "Bonewheel Skeleton (Black Phantom) - The Catacombs"
       ]
     },
     {
@@ -2098,13 +2098,13 @@
     {
       "ID": 295000,
       "Entries": [
-        "Skeleton Beast"
+        "Skeletal Beast"
       ]
     },
     {
       "ID": 295001,
       "Entries": [
-        "Skeleton Beast"
+        "Skeletal Beast (Black Phantom)"
       ]
     },
     {
@@ -2116,7 +2116,7 @@
     {
       "ID": 309000,
       "Entries": [
-        "Mosquito"
+        "Giant Mosquito"
       ]
     },
     {
@@ -2134,13 +2134,13 @@
     {
       "ID": 321001,
       "Entries": [
-        "Egg Carrier"
+        "Eingyi"
       ]
     },
     {
       "ID": 322000,
       "Entries": [
-        "Chaos Bug"
+        "Vile Maggot"
       ]
     },
     {
@@ -2152,7 +2152,7 @@
     {
       "ID": 323001,
       "Entries": [
-        "Moonlight Butterfly"
+        "Crystal Butterfly"
       ]
     },
     {
@@ -2164,79 +2164,79 @@
     {
       "ID": 324001,
       "Entries": [
-        "Chaos Eater"
+        "Chaos Eater (Black Phantom)"
       ]
     },
     {
       "ID": 325000,
       "Entries": [
-        "Maneater Clam"
+        "Man-Eater Shell - Duke's Archives"
       ]
     },
     {
       "ID": 325001,
       "Entries": [
-        "Maneater Clam"
+        "Man-Eater Shell - Ash Lake"
       ]
     },
     {
       "ID": 327000,
       "Entries": [
-        "Basilisk"
+        "Basilisk - The Depths"
       ]
     },
     {
       "ID": 327001,
       "Entries": [
-        "Basilisk"
+        "Basilisk - Great Hollow/Ash Lake"
       ]
     },
     {
       "ID": 330000,
       "Entries": [
-        "Crystal Lizard"
+        "Crystal Lizard - Great Hollow"
       ]
     },
     {
       "ID": 330010,
       "Entries": [
-        "Crystal Lizard"
+        "Crystal Lizard - Duke's Archives/Crystal Cave"
       ]
     },
     {
       "ID": 330020,
       "Entries": [
-        "Crystal Lizard"
+        "Crystal Lizard - Lost Izalith"
       ]
     },
     {
       "ID": 330030,
       "Entries": [
-        "Crystal Lizard"
+        "Crystal Lizard - The Catacombs"
       ]
     },
     {
       "ID": 330040,
       "Entries": [
-        "Crystal Lizard"
+        "Crystal Lizard - Darkroot Garden"
       ]
     },
     {
       "ID": 330050,
       "Entries": [
-        "Crystal Lizard"
+        "Crystal Lizard - Tomb of the Giants"
       ]
     },
     {
       "ID": 330060,
       "Entries": [
-        "Crystal Lizard"
+        "Crystal Lizard - Undead Burg"
       ]
     },
     {
       "ID": 330070,
       "Entries": [
-        "Crystal Lizard"
+        "Crystal Lizard - Royal Wood"
       ]
     },
     {
@@ -2248,13 +2248,13 @@
     {
       "ID": 332001,
       "Entries": [
-        "Pinwheel"
+        "Pinwheel (Fake)"
       ]
     },
     {
       "ID": 332002,
       "Entries": [
-        "Pinwheel"
+        "Pinwheel Servant"
       ]
     },
     {
@@ -2266,55 +2266,55 @@
     {
       "ID": 333001,
       "Entries": [
-        "Pisaca"
+        "Pisaca (Passive - Soothing Sunlight)"
       ]
     },
     {
       "ID": 333002,
       "Entries": [
-        "Pisaca"
+        "Pisaca (Passive - Bountiful Sunlight)"
       ]
     },
     {
       "ID": 333003,
       "Entries": [
-        "Pisaca"
+        "Pisaca (Black Phantom)"
       ]
     },
     {
       "ID": 334000,
       "Entries": [
-        "Undead Attack Dog"
+        "Undead Attack Dog - Lower Undead Burg"
       ]
     },
     {
       "ID": 334001,
       "Entries": [
-        "Undead Attack Dog"
+        "Undead Attack Dog - The Depths"
       ]
     },
     {
       "ID": 334002,
       "Entries": [
-        "Undead Attack Dog"
+        "Undead Attack Dog (Treasure Guardian - Strong) - The Depths"
       ]
     },
     {
       "ID": 334003,
       "Entries": [
-        "Undead Attack Dog"
+        "Undead Attack Dog (Capra Demon) - Lower Undead Burg"
       ]
     },
     {
       "ID": 334100,
       "Entries": [
-        "Flaming Attack Dog"
+        "Chaos Attack Dog"
       ]
     },
     {
       "ID": 335000,
       "Entries": [
-        "Walking Tree"
+        "Possessed Tree"
       ]
     },
     {
@@ -2326,85 +2326,85 @@
     {
       "ID": 338000,
       "Entries": [
-        "Leech"
+        "Giant Leech"
       ]
     },
     {
       "ID": 339000,
       "Entries": [
-        "Burrower"
+        "[UNUSED] Burrowing Rockworm (Lost Izalith Shortcut)"
       ]
     },
     {
       "ID": 339001,
       "Entries": [
-        "Burrower"
+        "Burrowing Rockworm (Ground)"
       ]
     },
     {
       "ID": 339002,
       "Entries": [
-        "Burrower"
+        "Burrowing Rockworm (Wall)"
       ]
     },
     {
       "ID": 339003,
       "Entries": [
-        "Burrower"
+        "Burrowing Rockworm (Ceiling)"
       ]
     },
     {
       "ID": 340000,
       "Entries": [
-        "Cragspider"
+        "Chaos Crag-Spider"
       ]
     },
     {
       "ID": 341000,
       "Entries": [
-        "Frog-Ray"
+        "Frog-Ray - Darkroot Garden (1st half)"
       ]
     },
     {
       "ID": 341001,
       "Entries": [
-        "Frog-Ray"
+        "Frog-Ray - Darkroot Garden (2nd half)"
       ]
     },
     {
       "ID": 342000,
       "Entries": [
-        "Undead Dragon"
+        "Undead Dragon - Painted World"
       ]
     },
     {
       "ID": 342001,
       "Entries": [
-        "Undead Dragon"
+        "[UNUSED] Undead Dragon"
       ]
     },
     {
       "ID": 342002,
       "Entries": [
-        "Undead Dragon"
+        "Undead Dragon - Valley of Drakes"
       ]
     },
     {
       "ID": 342100,
       "Entries": [
-        "Undead Dragon - Legs"
+        "Undead Dragon (Lower Half) - Painted World"
       ]
     },
     {
       "ID": 342101,
       "Entries": [
-        "Undead Dragon - Legs"
+        "Undead Dragon (Lower Half) - Lost Izalith"
       ]
     },
     {
       "ID": 342200,
       "Entries": [
-        "Undead Dragon - Wings"
+        "Undead Dragon (Upper Half)"
       ]
     },
     {
@@ -2434,13 +2434,13 @@
     {
       "ID": 346000,
       "Entries": [
-        "Armored Tusk"
+        "Fang Boar"
       ]
     },
     {
       "ID": 346100,
       "Entries": [
-        "Armored Tusk - Reinforced"
+        "Fang Boar (Fully-Armored)"
       ]
     },
     {
@@ -2458,7 +2458,7 @@
     {
       "ID": 347101,
       "Entries": [
-        "Sanctuary Guardian"
+        "Lesser Sanctuary Guardian"
       ]
     },
     {
@@ -2470,373 +2470,373 @@
     {
       "ID": 348000,
       "Entries": [
-        "Chaos Bug"
+        "Sunlight Maggot"
       ]
     },
     {
       "ID": 348001,
       "Entries": [
-        "Chaos Bug"
+        "Sunlight Maggot (Special)"
       ]
     },
     {
       "ID": 349000,
       "Entries": [
-        "Vagrant (Passive)"
+        "[UNUSED] Vagrant (Good) - Undead Asylum"
       ]
     },
     {
       "ID": 349001,
       "Entries": [
-        "Vagrant (Passive)"
+        "Vagrant (Good) - Undead Burg"
       ]
     },
     {
       "ID": 349002,
       "Entries": [
-        "Vagrant (Passive)"
+        "Vagrant (Good) - Lower Undead Burg/Parish"
       ]
     },
     {
       "ID": 349003,
       "Entries": [
-        "Vagrant (Passive)"
+        "Vagrant (Good) - The Depths"
       ]
     },
     {
       "ID": 349004,
       "Entries": [
-        "Vagrant (Passive)"
+        "Vagrant (Good) - Darkroot Garden/Basin"
       ]
     },
     {
       "ID": 349005,
       "Entries": [
-        "Vagrant (Passive)"
+        "Vagrant (Good) - The Catacombs"
       ]
     },
     {
       "ID": 349006,
       "Entries": [
-        "Vagrant (Passive)"
+        "Vagrant (Good) - Undead Asylum/New Londo Ruins"
       ]
     },
     {
       "ID": 349007,
       "Entries": [
-        "Vagrant (Passive)"
+        "Vagrant (Good) - Blighttown"
       ]
     },
     {
       "ID": 349008,
       "Entries": [
-        "Vagrant (Passive)"
+        "Vagrant (Good) - Sen's Fortress"
       ]
     },
     {
       "ID": 349009,
       "Entries": [
-        "Vagrant (Passive)"
+        "Vagrant (Good) - Anor Londo"
       ]
     },
     {
       "ID": 349010,
       "Entries": [
-        "Vagrant (Passive)"
+        "Vagrant (Good) - Darkroot Garden (2nd half)"
       ]
     },
     {
       "ID": 349011,
       "Entries": [
-        "Vagrant (Passive)"
+        "Vagrant (Good) - Tomb of the Giants"
       ]
     },
     {
       "ID": 349012,
       "Entries": [
-        "Vagrant (Passive)"
+        "Vagrant (Good) - Demon Ruins/Lost Izalith"
       ]
     },
     {
       "ID": 349013,
       "Entries": [
-        "Vagrant (Passive)"
+        "Vagrant (Good) - Painted World/Duke's Archives/DLC"
       ]
     },
     {
       "ID": 349014,
       "Entries": [
-        "Vagrant (Passive)"
+        "Vagrant (Good) - Kiln of the First Flame"
       ]
     },
     {
       "ID": 349050,
       "Entries": [
-        "Vagrant (Passive)"
+        "[UNUSED] Vagrant (Good - Black Phantom) - Undead Asylum"
       ]
     },
     {
       "ID": 349051,
       "Entries": [
-        "Vagrant (Passive)"
+        "Vagrant (Good - Black Phantom) - Undead Burg"
       ]
     },
     {
       "ID": 349052,
       "Entries": [
-        "Vagrant (Passive)"
+        "Vagrant (Good - Black Phantom) - Lower Undead Burg/Parish"
       ]
     },
     {
       "ID": 349053,
       "Entries": [
-        "Vagrant (Passive)"
+        "Vagrant (Good - Black Phantom) - The Depths"
       ]
     },
     {
       "ID": 349054,
       "Entries": [
-        "Vagrant (Passive)"
+        "Vagrant (Good - Black Phantom) - Darkroot Garden/Basin"
       ]
     },
     {
       "ID": 349055,
       "Entries": [
-        "Vagrant (Passive)"
+        "Vagrant (Good - Black Phantom) - The Catacombs"
       ]
     },
     {
       "ID": 349056,
       "Entries": [
-        "Vagrant (Passive)"
+        "Vagrant (Good - Black Phantom) - Undead Asylum/New Londo Ruins"
       ]
     },
     {
       "ID": 349057,
       "Entries": [
-        "Vagrant (Passive)"
+        "Vagrant (Good - Black Phantom) - Blighttown"
       ]
     },
     {
       "ID": 349058,
       "Entries": [
-        "Vagrant (Passive)"
+        "Vagrant (Good - Black Phantom) - Sen's Fortress"
       ]
     },
     {
       "ID": 349059,
       "Entries": [
-        "Vagrant (Passive)"
+        "Vagrant (Good - Black Phantom) - Anor Londo"
       ]
     },
     {
       "ID": 349060,
       "Entries": [
-        "Vagrant (Passive)"
+        "Vagrant (Good - Black Phantom) - Darkroot Garden (2nd half)"
       ]
     },
     {
       "ID": 349061,
       "Entries": [
-        "Vagrant (Passive)"
+        "Vagrant (Good - Black Phantom) - Tomb of the Giants"
       ]
     },
     {
       "ID": 349062,
       "Entries": [
-        "Vagrant (Passive)"
+        "Vagrant (Good - Black Phantom) - Demon Ruins/Lost Izalith"
       ]
     },
     {
       "ID": 349063,
       "Entries": [
-        "Vagrant (Passive)"
+        "Vagrant (Good - Black Phantom) - Painted World/Duke's Archives/DLC"
       ]
     },
     {
       "ID": 349064,
       "Entries": [
-        "Vagrant (Passive)"
+        "Vagrant (Good - Black Phantom) - Kiln of the First Flame"
       ]
     },
     {
       "ID": 349100,
       "Entries": [
-        "Vagrant (Aggressive) - 1"
+        "[UNUSED] Vagrant (Evil) - Undead Asylum"
       ]
     },
     {
       "ID": 349101,
       "Entries": [
-        "Vagrant (Aggressive) - 1"
+        "Vagrant (Evil) - Undead Burg"
       ]
     },
     {
       "ID": 349102,
       "Entries": [
-        "Vagrant (Aggressive) - 1"
+        "Vagrant (Evil) - Lower Undead Burg/Parish"
       ]
     },
     {
       "ID": 349103,
       "Entries": [
-        "Vagrant (Aggressive) - 1"
+        "Vagrant (Evil) - The Depths"
       ]
     },
     {
       "ID": 349104,
       "Entries": [
-        "Vagrant (Aggressive) - 1"
+        "Vagrant (Evil) - Darkroot Garden/Basin"
       ]
     },
     {
       "ID": 349105,
       "Entries": [
-        "Vagrant (Aggressive) - 1"
+        "Vagrant (Evil) - The Catacombs"
       ]
     },
     {
       "ID": 349106,
       "Entries": [
-        "Vagrant (Aggressive) - 1"
+        "Vagrant (Evil) - Undead Asylum/New Londo Ruins"
       ]
     },
     {
       "ID": 349107,
       "Entries": [
-        "Vagrant (Aggressive) - 1"
+        "Vagrant (Evil) - Blighttown"
       ]
     },
     {
       "ID": 349108,
       "Entries": [
-        "Vagrant (Aggressive) - 1"
+        "Vagrant (Evil) - Sen's Fortress"
       ]
     },
     {
       "ID": 349109,
       "Entries": [
-        "Vagrant (Aggressive) - 1"
+        "Vagrant (Evil) - Anor Londo"
       ]
     },
     {
       "ID": 349110,
       "Entries": [
-        "Vagrant (Aggressive) - 1"
+        "Vagrant (Evil) - Darkroot Garden (2nd half)"
       ]
     },
     {
       "ID": 349111,
       "Entries": [
-        "Vagrant (Aggressive) - 1"
+        "Vagrant (Evil) - Tomb of the Giants"
       ]
     },
     {
       "ID": 349112,
       "Entries": [
-        "Vagrant (Aggressive) - 1"
+        "Vagrant (Evil) - Demon Ruins/Lost Izalith"
       ]
     },
     {
       "ID": 349113,
       "Entries": [
-        "Vagrant (Aggressive) - 1"
+        "Vagrant (Evil) - Painted World/Duke's Archives/DLC"
       ]
     },
     {
       "ID": 349114,
       "Entries": [
-        "Vagrant (Aggressive) - 1"
+        "Vagrant (Evil) - Kiln of the First Flame"
       ]
     },
     {
       "ID": 349200,
       "Entries": [
-        "Vagrant (Aggressive) - 2"
+        "[UNUSED] Vagrant (Evil - Black Phantom) - Undead Asylum"
       ]
     },
     {
       "ID": 349201,
       "Entries": [
-        "Vagrant (Aggressive) - 2"
+        "Vagrant (Evil - Black Phantom) - Undead Burg"
       ]
     },
     {
       "ID": 349202,
       "Entries": [
-        "Vagrant (Aggressive) - 2"
+        "Vagrant (Evil - Black Phantom) - Lower Undead Burg/Parish"
       ]
     },
     {
       "ID": 349203,
       "Entries": [
-        "Vagrant (Aggressive) - 2"
+        "Vagrant (Evil - Black Phantom) - The Depths"
       ]
     },
     {
       "ID": 349204,
       "Entries": [
-        "Vagrant (Aggressive) - 2"
+        "Vagrant (Evil - Black Phantom) - Darkroot Garden/Basin"
       ]
     },
     {
       "ID": 349205,
       "Entries": [
-        "Vagrant (Aggressive) - 2"
+        "Vagrant (Evil - Black Phantom) - The Catacombs"
       ]
     },
     {
       "ID": 349206,
       "Entries": [
-        "Vagrant (Aggressive) - 2"
+        "Vagrant (Evil - Black Phantom) - Undead Asylum/New Londo Ruins"
       ]
     },
     {
       "ID": 349207,
       "Entries": [
-        "Vagrant (Aggressive) - 2"
+        "Vagrant (Evil - Black Phantom) - Blighttown"
       ]
     },
     {
       "ID": 349208,
       "Entries": [
-        "Vagrant (Aggressive) - 2"
+        "Vagrant (Evil - Black Phantom) - Sen's Fortress"
       ]
     },
     {
       "ID": 349209,
       "Entries": [
-        "Vagrant (Aggressive) - 2"
+        "Vagrant (Evil - Black Phantom) - Anor Londo"
       ]
     },
     {
       "ID": 349210,
       "Entries": [
-        "Vagrant (Aggressive) - 2"
+        "Vagrant (Evil - Black Phantom) - Darkroot Garden (2nd half)"
       ]
     },
     {
       "ID": 349211,
       "Entries": [
-        "Vagrant (Aggressive) - 2"
+        "Vagrant (Evil - Black Phantom) - Tomb of the Giants"
       ]
     },
     {
       "ID": 349212,
       "Entries": [
-        "Vagrant (Aggressive) - 2"
+        "Vagrant (Evil - Black Phantom) - Demon Ruins/Lost Izalith"
       ]
     },
     {
       "ID": 349213,
       "Entries": [
-        "Vagrant (Aggressive) - 2"
+        "Vagrant (Evil - Black Phantom) - Painted World/Duke's Archives/DLC"
       ]
     },
     {
       "ID": 349214,
       "Entries": [
-        "Vagrant (Aggressive) - 2"
+        "Vagrant (Evil - Black Phantom) - Kiln of the First Flame"
       ]
     },
     {
@@ -2848,13 +2848,13 @@
     {
       "ID": 350100,
       "Entries": [
-        "Wisp"
+        "Wisp - New Londo Ruins"
       ]
     },
     {
       "ID": 350101,
       "Entries": [
-        "Wisp"
+        "Wisp - The Catacombs"
       ]
     },
     {
@@ -2866,43 +2866,43 @@
     {
       "ID": 352000,
       "Entries": [
-        "Drake"
+        "[UNUSED] Drake (Flying)"
       ]
     },
     {
       "ID": 352002,
       "Entries": [
-        "Drake"
+        "Drake (Ground)"
       ]
     },
     {
       "ID": 352005,
       "Entries": [
-        "Drake"
+        "[UNUSED] Drake (Flying)"
       ]
     },
     {
       "ID": 353000,
       "Entries": [
-        "Hydra"
+        "Hydra - Ash Lake"
       ]
     },
     {
       "ID": 353001,
       "Entries": [
-        "Hydra"
+        "Hydra - Darkroot Basin"
       ]
     },
     {
       "ID": 353100,
       "Entries": [
-        "Hydra's Head"
+        "Hydra's Head - Ash Lake"
       ]
     },
     {
       "ID": 353101,
       "Entries": [
-        "Hydra's Head"
+        "Hydra's Head - Darkroot Basin"
       ]
     },
     {
@@ -2914,7 +2914,7 @@
     {
       "ID": 409010,
       "Entries": [
-        "Marvellous Chester"
+        "Marvellous Chester (Invader)"
       ]
     },
     {
@@ -2938,133 +2938,133 @@
     {
       "ID": 412001,
       "Entries": [
-        "Stone Guardian"
+        "Stone Guardian (Black Phantom)"
       ]
     },
     {
       "ID": 413000,
       "Entries": [
-        "Scarecrow"
+        "Scarecrow Gardener (Pitchfork)"
       ]
     },
     {
       "ID": 413001,
       "Entries": [
-        "Scarecrow"
+        "Scarecrow Gardener (Pitchfork - Cast Off?)"
       ]
     },
     {
       "ID": 413002,
       "Entries": [
-        "Scarecrow"
+        "Scarecrow Gardener (Pitchfork - Shirtless)"
       ]
     },
     {
       "ID": 413003,
       "Entries": [
-        "Scarecrow"
+        "Scarecrow Gardener (Pitchfork - Pant-less)"
       ]
     },
     {
       "ID": 413004,
       "Entries": [
-        "Scarecrow"
+        "Scarecrow Gardener (Pitchfork - Black Phantom)"
       ]
     },
     {
       "ID": 413010,
       "Entries": [
-        "Scarecrow"
+        "Scarecrow Gardener (Shears)"
       ]
     },
     {
       "ID": 413011,
       "Entries": [
-        "Scarecrow"
+        "Scarecrow Gardener (Shears - Cast Off?)"
       ]
     },
     {
       "ID": 413012,
       "Entries": [
-        "Scarecrow"
+        "Scarecrow Gardener (Shears - Shirtless)"
       ]
     },
     {
       "ID": 413013,
       "Entries": [
-        "Scarecrow"
+        "Scarecrow Gardener (Shears - Pant-less)"
       ]
     },
     {
       "ID": 413014,
       "Entries": [
-        "Scarecrow"
+        "Scarecrow Gardener (Shears - Black Phantom)"
       ]
     },
     {
       "ID": 414000,
       "Entries": [
-        "Elizabeth"
+        "Elizabeth, Keeper of the Sanctuary"
       ]
     },
     {
       "ID": 415000,
       "Entries": [
-        "Bloathead"
+        "Oolacile Resident (Melee)"
       ]
     },
     {
       "ID": 415001,
       "Entries": [
-        "Bloathead"
+        "Oolacile Resident (Melee - Black Phantom)"
       ]
     },
     {
       "ID": 415020,
       "Entries": [
-        "Bloathead"
+        "Oolacile Resident (Melee - Lit Eyes)"
       ]
     },
     {
       "ID": 416000,
       "Entries": [
-        "Bloathead Sorcerer"
+        "Oolacile Resident (Sorceress)"
       ]
     },
     {
       "ID": 416001,
       "Entries": [
-        "Bloathead Sorcerer"
+        "Oolacile Resident (Sorceress - Black Phantom)"
       ]
     },
     {
       "ID": 416010,
       "Entries": [
-        "Bloathead Sorcerer"
+        "Oolacile Resident (Sorceress - Ultra-Defensive - For Event)"
       ]
     },
     {
       "ID": 416020,
       "Entries": [
-        "Bloathead Sorcerer"
+        "Oolacile Resident (Sorceress - Lit Eyes)"
       ]
     },
     {
       "ID": 417000,
       "Entries": [
-        "Humanity Phantom (Large)"
+        "Humanity (Large)"
       ]
     },
     {
       "ID": 417100,
       "Entries": [
-        "Humanity Phantom (Medium)"
+        "Humanity (Medium)"
       ]
     },
     {
       "ID": 417200,
       "Entries": [
-        "Humanity Phantom (Small)"
+        "Humanity (Small)"
       ]
     },
     {
@@ -3076,13 +3076,13 @@
     {
       "ID": 418001,
       "Entries": [
-        "Chained Prisoner"
+        "Chained Prisoner (Black Phantom)"
       ]
     },
     {
       "ID": 419000,
       "Entries": [
-        "Undead Attack Dog (DLC)"
+        "Scaled Attack Dog"
       ]
     },
     {
@@ -3094,19 +3094,19 @@
     {
       "ID": 451000,
       "Entries": [
-        "Kalameet"
+        "Black Dragon Kalameet"
       ]
     },
     {
       "ID": 451001,
       "Entries": [
-        "Kalameet"
+        "Black Dragon Kalameet (Grounded)"
       ]
     },
     {
       "ID": 451100,
       "Entries": [
-        "Kalameet's Tail"
+        "Black Dragon Kalameet's Tail"
       ]
     },
     {
@@ -3118,13 +3118,13 @@
     {
       "ID": 452010,
       "Entries": [
-        "Great Grey Wolf Sif (DLC)"
+        "Great Grey Wolf Sif (DLC - Summon)"
       ]
     },
     {
       "ID": 453100,
       "Entries": [
-        "Alvina (DLC)"
+        "Alvina of the Darkroot Wood (DLC)"
       ]
     },
     {
@@ -3166,7 +3166,7 @@
     {
       "ID": 523100,
       "Entries": [
-        "Bed Of Chaos (Moving)"
+        "[UNUSED] Bed Of Chaos (Moving)"
       ]
     },
     {
@@ -3196,13 +3196,13 @@
     {
       "ID": 527000,
       "Entries": [
-        "Dragonslayer Ornstein"
+        "Dragon Slayer Ornstein"
       ]
     },
     {
       "ID": 527100,
       "Entries": [
-        "Dragonslayer Ornstein (Giant)"
+        "Dragon Slayer Ornstein (Giant)"
       ]
     },
     {
@@ -3214,31 +3214,31 @@
     {
       "ID": 529000,
       "Entries": [
-        "Seath the Scaleless"
+        "Seath the Scaleless - Crystal Cave"
       ]
     },
     {
       "ID": 529001,
       "Entries": [
-        "Seath the Scaleless"
+        "Seath the Scaleless - Duke's Archives"
       ]
     },
     {
       "ID": 529100,
       "Entries": [
-        "Seath's Tail"
+        "Seath the Scaleless's Tail"
       ]
     },
     {
       "ID": 531000,
       "Entries": [
-        "Gwynevere"
+        "Gwynevere, Princess of Sunlight"
       ]
     },
     {
       "ID": 532000,
       "Entries": [
-        "Gwyndolin"
+        "Dark Sun Gwyndolin"
       ]
     },
     {
@@ -3262,31 +3262,31 @@
     {
       "ID": 535000,
       "Entries": [
-        "Gargoyle"
+        "Bell Gargoyle"
       ]
     },
     {
       "ID": 535001,
       "Entries": [
-        "Gargoyle"
+        "Bell Gargoyle (2nd)"
       ]
     },
     {
       "ID": 535100,
       "Entries": [
-        "Gargoyle [Anor Londo]"
+        "Lightning Gargoyle"
       ]
     },
     {
       "ID": 535200,
       "Entries": [
-        "Gargoyle's Tail"
+        "Bell Gargoyle's Tail"
       ]
     },
     {
       "ID": 535300,
       "Entries": [
-        "Gargoyle's Tail [Anor Londo]"
+        "Lightning Gargoyle's Tail"
       ]
     },
     {
@@ -3304,7 +3304,7 @@
     {
       "ID": 536100,
       "Entries": [
-        "Alvina"
+        "Alvina of the Darkroot Wood"
       ]
     },
     {
@@ -3316,25 +3316,25 @@
     {
       "ID": 539000,
       "Entries": [
-        "Four Kings"
+        "Four Kings (Total HP)"
       ]
     },
     {
       "ID": 539001,
       "Entries": [
-        "Four Kings"
+        "Four Kings (Individual)"
       ]
     },
     {
       "ID": 540000,
       "Entries": [
-        "Bed of Chaos Arm"
+        "Bed of Chaos (Arm)"
       ]
     },
     {
       "ID": 540100,
       "Entries": [
-        "Bed of Chaos Worm"
+        "Bed of Chaos (Worm)"
       ]
     }
   ]

--- a/src/Smithbox.Data/Assets/PARAM/DS1R/Community Row Names/NpcThinkParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/DS1R/Community Row Names/NpcThinkParam.json
@@ -4,283 +4,283 @@
     {
       "ID": 0,
       "Entries": [
-        "For testing-For testing"
+        "For Test"
       ]
     },
     {
       "ID": 1,
       "Entries": [
-        "For not doing anything-for nothing"
+        "For nothing"
       ]
     },
     {
       "ID": 2,
       "Entries": [
-        "Atarisawari data (copy and paste recommended)-Unobtrusive data (copy and paste recommended)"
+        "Atarisawari (Unobtrusive?) Data (Recommended Source For Copy & Paste)"
       ]
     },
     {
       "ID": 100,
       "Entries": [
-        "Automatic patrol (default)-For automatic patrol (default)"
+        "DeS2 - Return Home Test: Knight (Sword)"
       ]
     },
     {
       "ID": 200,
       "Entries": [
-        "DS2 for easy logic test"
+        "DeS2 - Easy Logic Test"
       ]
     },
     {
       "ID": 500,
       "Entries": [
-        "Hirai test I love ladder"
+        "Hirai Test - I Love Ladders"
       ]
     },
     {
       "ID": 501,
       "Entries": [
-        "Hirai test help"
+        "Hirai Test - Help Your Friends"
       ]
     },
     {
       "ID": 502,
       "Entries": [
-        "Hirai Test-Laddy Love NPC"
+        "Hirai Test - Ladder-Loving NPC"
       ]
     },
     {
       "ID": 503,
       "Entries": [
-        "Skeleton for coffin throwing (large)"
+        "For Coffin Throwing - Skeleton (Large)"
       ]
     },
     {
       "ID": 505,
       "Entries": [
-        "Dead spirit (male) Calling friend"
+        "Ghost (Male) Calling Friend Test"
       ]
     },
     {
       "ID": 506,
       "Entries": [
-        "Dead spirit (woman) Calling friends"
+        "Ghost (Female) Calling Friend Test"
       ]
     },
     {
       "ID": 510,
       "Entries": [
-        "Return Test Immortal"
+        "Return Home Test: Undead"
       ]
     },
     {
       "ID": 511,
       "Entries": [
-        "Hirai test Parry exclusive skeleton"
+        "Hirai Test - Parry-Only Skeleton"
       ]
     },
     {
       "ID": 512,
       "Entries": [
-        "Hirai Test New Type of Immortal (Heavy Warrior / Spear)"
+        "Hirai Test - New Type of Undead (Heavy Soldier / Spear)"
       ]
     },
     {
       "ID": 513,
       "Entries": [
-        "Hirai Test I Love Guards"
+        "Hirai Test - I Love Guarding"
       ]
     },
     {
       "ID": 514,
       "Entries": [
-        "Wyvern Bird Control Test"
+        "Wyvern - Bird Control Test"
       ]
     },
     {
       "ID": 515,
       "Entries": [
-        "Wyvern Bird Control Test (2nd)"
+        "Wyvern - Bird Control Test (2nd)"
       ]
     },
     {
       "ID": 520,
       "Entries": [
-        "NPC player test"
+        "NPC Player Test"
       ]
     },
     {
       "ID": 530,
       "Entries": [
-        "DS2Test 0 for upstream test"
+        "DeS2Test - For Upstream Test 0"
       ]
     },
     {
       "ID": 531,
       "Entries": [
-        "DS2Test 1 for upstream test"
+        "DeS2Test - For Upstream Test 1"
       ]
     },
     {
       "ID": 532,
       "Entries": [
-        "DS2Test for upstream test 2"
+        "DeS2Test - For Upstream Test 2"
       ]
     },
     {
       "ID": 533,
       "Entries": [
-        "DS2Test 3 for upstream test"
+        "DeS2Test - For Upstream Test 3"
       ]
     },
     {
       "ID": 534,
       "Entries": [
-        "DS2Test 4 for upstream test"
+        "DeS2Test - For Upstream Test 4"
       ]
     },
     {
       "ID": 535,
       "Entries": [
-        "DS2Test 5 for upstream test"
+        "DeS2Test - For Upstream Test 5"
       ]
     },
     {
       "ID": 536,
       "Entries": [
-        "DS2Test 6 for upstream test"
+        "DeS2Test - For Upstream Test 6"
       ]
     },
     {
       "ID": 537,
       "Entries": [
-        "DS2Test 7 for upstream test"
+        "DeS2Test - For Upstream Test 7"
       ]
     },
     {
       "ID": 538,
       "Entries": [
-        "DS2Test 8 for upstream test"
+        "DeS2Test - For Upstream Test 8"
       ]
     },
     {
       "ID": 539,
       "Entries": [
-        "DS2Test 9 for upstream test"
+        "DeS2Test - For Upstream Test 9"
       ]
     },
     {
       "ID": 540,
       "Entries": [
-        "For automatic patrol (running)-For automatic patrol (running)"
+        "DeS2 Test - For Watanabe(?)"
       ]
     },
     {
       "ID": 541,
       "Entries": [
-        "Automatic patrol (walking)-For automatic patrol (walking)"
+        "DeS2 Test - For Watanabe spare(??)"
       ]
     },
     {
       "ID": 550,
       "Entries": [
-        "DS2 test wandering for automatic test (Watanabe management)"
+        "DeS2 Test - Wandering For Automatic Test (Managed by Watanabe?)"
       ]
     },
     {
       "ID": 551,
       "Entries": [
-        "DS2 test wandering reservation for automatic test (Watanabe management)"
+        "DeS2 Test - Wandering For Automatic Test (Managed by Watanabe spare?)"
       ]
     },
     {
       "ID": 600,
       "Entries": [
-        "Return Test @ General Soldier _ Sword"
+        "Return Home Test - Normal Soldier (Sword)"
       ]
     },
     {
       "ID": 601,
       "Entries": [
-        "Return Test @ General Soldier _ Sword (Fire)"
+        "Return Home Test - Normal Soldier (Sword - Fire)"
       ]
     },
     {
       "ID": 602,
       "Entries": [
-        "Homecoming Test @ General Soldier _ Bow"
+        "Return Home Test - Normal Soldier (Bow)"
       ]
     },
     {
       "ID": 603,
       "Entries": [
-        "Return Test @ Knight _ Sword"
+        "Return Home Test - Knight (Sword)"
       ]
     },
     {
       "ID": 700,
       "Entries": [
-        "Calling Test Beggar"
+        "Beggar For Calling Friends Test"
       ]
     },
     {
       "ID": 701,
       "Entries": [
-        "Snake A for Calling Friends"
+        "Snake A for Calling Friends Test"
       ]
     },
     {
       "ID": 702,
       "Entries": [
-        "Room for Calling Buddy for Buddy"
+        "Beggar For Calling Friends Test (Different Room?)"
       ]
     },
     {
       "ID": 6000,
       "Entries": [
-        "Sun Knight"
+        "Solaire of Astora"
       ]
     },
     {
       "ID": 6010,
       "Entries": [
-        "Dark Moon Knight"
+        "Darkmoon Knightess"
       ]
     },
     {
       "ID": 6020,
       "Entries": [
-        "Knight Ostra"
+        "Oscar of Astora"
       ]
     },
     {
       "ID": 6030,
       "Entries": [
-        "\"Big Hat\" Logan II First Stage"
+        "Big Hat Logan - Sen's Fortress/Firelink Shrine"
       ]
     },
     {
       "ID": 6031,
       "Entries": [
-        "\"Big Hat\" Logan II Stage 2"
+        "Big Hat Logan - Duke's Archives"
       ]
     },
     {
       "ID": 6032,
       "Entries": [
-        "\"Big Hat\" Logan III Stage"
+        "Big Hat Logan (Hollow) - Duke's Archives"
       ]
     },
     {
       "ID": 6040,
       "Entries": [
-        "Logan Disciple"
+        "Griggs of Vinheim"
       ]
     },
     {
       "ID": 6050,
       "Entries": [
-        "Princess of the Exiled"
+        "Dusk of Oolacile - Darkroot Basin"
       ]
     },
     {
@@ -292,577 +292,577 @@
     {
       "ID": 6070,
       "Entries": [
-        "White Saint"
+        "Rhea of Thorolund"
       ]
     },
     {
       "ID": 6080,
       "Entries": [
-        "Saint Knight A"
+        "Petrus of Thorolund"
       ]
     },
     {
       "ID": 6090,
       "Entries": [
-        "Saint Knight B"
+        "Nico of Thorolund"
       ]
     },
     {
       "ID": 6091,
       "Entries": [
-        "Saint Knight B (dead)"
+        "Nico of Thorolund (Hollow)"
       ]
     },
     {
       "ID": 6100,
       "Entries": [
-        "Saint Knight C"
+        "Vince of Thorolund"
       ]
     },
     {
       "ID": 6101,
       "Entries": [
-        "Saint Knight C (dead)"
+        "Vince of Thorolund (Hollow)"
       ]
     },
     {
       "ID": 6130,
       "Entries": [
-        "Vase Sorcerer"
+        "Laurentius of the Great Swamp"
       ]
     },
     {
       "ID": 6170,
       "Entries": [
-        "Wandering chaos"
+        "Quelana of Izalith"
       ]
     },
     {
       "ID": 6180,
       "Entries": [
-        "Healer"
+        "Ingward, Guardian of the Seal"
       ]
     },
     {
       "ID": 6220,
       "Entries": [
-        "Blacksmith Rickert"
+        "Rickert of Vinheim"
       ]
     },
     {
       "ID": 6250,
       "Entries": [
-        "A Broken Merchant"
+        "Crestfallen Merchant"
       ]
     },
     {
       "ID": 6260,
       "Entries": [
-        "trickster"
+        "Domhnall of Zena"
       ]
     },
     {
       "ID": 6270,
       "Entries": [
-        "A Broken Warrior"
+        "Crestfallen Warrior"
       ]
     },
     {
       "ID": 6271,
       "Entries": [
-        "Broken warrior (dead)"
+        "Crestfallen Warrior (Hollow)"
       ]
     },
     {
       "ID": 6280,
       "Entries": [
-        "Onion Knight"
+        "Siegmeyer of Catarina"
       ]
     },
     {
       "ID": 6290,
       "Entries": [
-        "Onion Knight's Daughter"
+        "Sieglinde of Catarina"
       ]
     },
     {
       "ID": 6300,
       "Entries": [
-        "Hugged Knight Lautrek"
+        "Knight Lautrec of Carim"
       ]
     },
     {
       "ID": 6310,
       "Entries": [
-        "Field Takeshi"
+        "Shiva of the East"
       ]
     },
     {
       "ID": 6320,
       "Entries": [
-        "Cemetery Coward Patch"
+        "Trusty Patches"
       ]
     },
     {
       "ID": 6350,
       "Entries": [
-        "Elle Amis"
+        "[UNUSED] Painter Ariamis"
       ]
     },
     {
       "ID": 6370,
       "Entries": [
-        "Dragon Priest"
+        "Oswald of Carim"
       ]
     },
     {
       "ID": 6390,
       "Entries": [
-        "Black Knight Tarcus"
+        "[UNUSED] Black Iron Tarkus"
       ]
     },
     {
       "ID": 6400,
       "Entries": [
-        "Belka Knight"
+        "[UNUSED] Velka Knight"
       ]
     },
     {
       "ID": 6410,
       "Entries": [
-        "Witch Mallows"
+        "[UNUSED] Witch Beatrice"
       ]
     },
     {
       "ID": 6420,
       "Entries": [
-        "Ninja"
+        "Shiva's Bodyguard"
       ]
     },
     {
       "ID": 6490,
       "Entries": [
-        "Lautrek companion 1 (Black Knight Tarcus)"
+        "Lautrec's Companion 1"
       ]
     },
     {
       "ID": 6500,
       "Entries": [
-        "Lautrek companion (Ninja)"
+        "Lautrec's Companion 2"
       ]
     },
     {
       "ID": 6510,
       "Entries": [
-        "Black Iron Knight"
+        "Black Iron Tarkus (Summon) - Sen's Fortress"
       ]
     },
     {
       "ID": 6511,
       "Entries": [
-        "Black Iron Knight (Enemy)"
+        "[UNUSED] Black Iron Tarkus (Enemy) - Lost Izalith"
       ]
     },
     {
       "ID": 6520,
       "Entries": [
-        "Witch @ Abyss"
+        "Witch Beatrice (Summon) - New Londo Ruins"
       ]
     },
     {
       "ID": 6521,
       "Entries": [
-        "Witch Moriniwa"
+        "Witch Beatrice (Summon) - Darkroot Garden"
       ]
     },
     {
       "ID": 6530,
       "Entries": [
-        "Swamp Aunt @ Kagecho"
+        "Maneater Mildred (Summon)"
       ]
     },
     {
       "ID": 6531,
       "Entries": [
-        "Swamp Aunt @ Kagecho (Invasion)"
+        "Maneater Mildred (Invader)"
       ]
     },
     {
       "ID": 6540,
       "Entries": [
-        "Sun Knight II Castle 1"
+        "Solaire of Astora (Summon) - Undead Parish"
       ]
     },
     {
       "ID": 6541,
       "Entries": [
-        "Sun Knight Castle 2"
+        "Solaire of Astora (Summon) - The Depths"
       ]
     },
     {
       "ID": 6542,
       "Entries": [
-        "Sun Knight Closed City"
+        "Solaire of Astora (Summon) - Demon Ruins"
       ]
     },
     {
       "ID": 6543,
       "Entries": [
-        "Sun Knight, Ojo 2"
+        "Solaire of Astora (Summon) - Anor Londo"
       ]
     },
     {
       "ID": 6544,
       "Entries": [
-        "Sun Knight Great Tomb"
+        "Solaire of Astora (Summon) - Kiln of the First Flame"
       ]
     },
     {
       "ID": 6550,
       "Entries": [
-        "Temple Knight Cemetery 1"
+        "Paladin Leeroy (Summon)"
       ]
     },
     {
       "ID": 6551,
       "Entries": [
-        "Temple Knight II Cemetery 2 (Invasion)"
+        "Paladin Leeroy (Invader)"
       ]
     },
     {
       "ID": 6560,
       "Entries": [
-        "Barb Knight Closed City 1 (Invasion)"
+        "Kirk, Knight of Thorns (Invader) - The Depths/Demon Ruins"
       ]
     },
     {
       "ID": 6561,
       "Entries": [
-        "Barb Knight: Closed City 2 (Invasion)"
+        "Kirk, Knight of Thorns (Invader) - Lost Izalith"
       ]
     },
     {
       "ID": 6562,
       "Entries": [
-        "Barb Knight II Castle 2 (Invasion)"
+        "[UNUSED] Kirk, Knight of Thorns (Invader) - The Depths"
       ]
     },
     {
       "ID": 6570,
       "Entries": [
-        "Yellow Cloth: Painting World (Invasion)"
+        "Xanthous King Jeremiah (Invader)"
       ]
     },
     {
       "ID": 6580,
       "Entries": [
-        "Lookout Tower NPC (Havel)"
+        "Havel the Rock"
       ]
     },
     {
       "ID": 6590,
       "Entries": [
-        "Lautrek Castle 1 (NPC Multi)"
+        "Knight Lautrec of Carim - Undead Parish (Summon)"
       ]
     },
     {
       "ID": 6591,
       "Entries": [
-        "Lautrec Castle 2 (NPC Multi)"
+        "Knight Lautrec of Carim - Undead Parish (Summon)"
       ]
     },
     {
       "ID": 6600,
       "Entries": [
-        "Royal Castle 1 Tower NPC (Ricard)"
+        "Undead Prince Ricard"
       ]
     },
     {
       "ID": 6610,
       "Entries": [
-        "Crystal Knight"
+        "Hollow Crystal Knight"
       ]
     },
     {
       "ID": 6620,
       "Entries": [
-        "Krag's sister (enemy)"
+        "Daughter of Chaos"
       ]
     },
     {
       "ID": 6640,
       "Entries": [
-        "Dark Moon Sword (Heavy Knight)"
+        "Darkmoon Soldier (Sword)"
       ]
     },
     {
       "ID": 6650,
       "Entries": [
-        "Dark Moon Sword (Light Knight)"
+        "Darkmoon Soldier (Greatsword)"
       ]
     },
     {
       "ID": 6700,
       "Entries": [
-        "Princess of the Exiled (Past Forest)"
+        "Dusk of Oolacile - Chasm of the Abyss"
       ]
     },
     {
       "ID": 6740,
       "Entries": [
-        "Kiarlan"
+        "Lord's Blade Ciaran"
       ]
     },
     {
       "ID": 6801,
       "Entries": [
-        "Bandit A Gatekeeper"
+        "Forest Hunter A - Bandit"
       ]
     },
     {
       "ID": 6802,
       "Entries": [
-        "Bandit B Warrior"
+        "Forest Hunter B - Warrior"
       ]
     },
     {
       "ID": 6803,
       "Entries": [
-        "Bandit C Bow Master"
+        "Forest Hunter C - Hunter"
       ]
     },
     {
       "ID": 6804,
       "Entries": [
-        "Bandit D Magic (Attack)"
+        "Forest Hunter D - Sorcerer"
       ]
     },
     {
       "ID": 6805,
       "Entries": [
-        "Bandit E Magic (Recovery)"
+        "Forest Hunter E - Cleric"
       ]
     },
     {
       "ID": 6806,
       "Entries": [
-        "Bandit F Stealth"
+        "Forest Hunter F - Thief"
       ]
     },
     {
       "ID": 6810,
       "Entries": [
-        "Tutorial Prisoner 1"
+        "[UNUSED] Tutorial Prisoner 1"
       ]
     },
     {
       "ID": 6811,
       "Entries": [
-        "Tutorial Prisoner 2"
+        "[UNUSED] Tutorial Prisoner 2"
       ]
     },
     {
       "ID": 7100,
       "Entries": [
-        "Castle 2_Vagrant NPC_Warrior"
+        "[UNUSED] Vagrant NPC - The Depths - Warrior"
       ]
     },
     {
       "ID": 7110,
       "Entries": [
-        "Castle 1 ・ First half_Vagrant NPC_Voyeur"
+        "[UNUSED] Vagrant NPC - Undead Burg - Thief"
       ]
     },
     {
       "ID": 7111,
       "Entries": [
-        "Castle 1st & 2nd half_Vagrant NPC_Voyeur"
+        "[UNUSED] Vagrant NPC - Undead Parish - Thief"
       ]
     },
     {
       "ID": 7120,
       "Entries": [
-        "Painting world_Vagrant NPC_Wanderer"
+        "[UNUSED] Vagrant NPC - Painted World - Wanderer"
       ]
     },
     {
       "ID": 7130,
       "Entries": [
-        "Moriwaba, first half_Vagrant NPC_Hunter"
+        "[UNUSED] Vagrant NPC - Darkroot Garden (1st half) - Hunter"
       ]
     },
     {
       "ID": 7131,
       "Entries": [
-        "Moriwaba, latter half_Vagrant NPC_Hunter"
+        "[UNUSED] Vagrant NPC - Darkroot Garden (2nd half) - Hunter"
       ]
     },
     {
       "ID": 7140,
       "Entries": [
-        "Cemetery 1_Vagrant NPC_Cleric"
+        "[UNUSED] Vagrant NPC - The Catacombs - Cleric"
       ]
     },
     {
       "ID": 7150,
       "Entries": [
-        "Cemetery 2_Vagrant NPC_Cleric"
+        "[UNUSED] Vagrant NPC - Tomb of the Giants - Cleric"
       ]
     },
     {
       "ID": 7160,
       "Entries": [
-        "Underground Lake_Vagrant NPC_Dragon Newt"
+        "[UNUSED] Vagrant NPC - Ash Lake - Dragon Newt"
       ]
     },
     {
       "ID": 7170,
       "Entries": [
-        "Kagemachi_Vagrant NPC_Wanderer"
+        "[UNUSED] Vagrant NPC - Blighttown - Wanderer"
       ]
     },
     {
       "ID": 7180,
       "Entries": [
-        "Closed city, first half_Vagrant NPC_Sorcerer"
+        "[UNUSED] Vagrant NPC - Demon Ruins/Lost Izalith - Pyromancer"
       ]
     },
     {
       "ID": 7190,
       "Entries": [
-        "Royal Castle 1_Vagrant NPC_Warrior"
+        "[UNUSED] Vagrant NPC - Sen's Fortress - Warrior"
       ]
     },
     {
       "ID": 7200,
       "Entries": [
-        "Royal Castle 2_Vagrant NPC_Knight"
+        "[UNUSED] Vagrant NPC - Anor Londo - Knight"
       ]
     },
     {
       "ID": 7210,
       "Entries": [
-        "Abyss_Vagrant NPC_Bandit"
+        "[UNUSED] Vagrant NPC - New Londo Ruins - Bandit"
       ]
     },
     {
       "ID": 7220,
       "Entries": [
-        "Crystal Tower_Vagrant NPC_Sorcerer"
+        "[UNUSED] Vagrant NPC - Duke's Archives/Crystal Cave - Sorcerer"
       ]
     },
     {
       "ID": 7230,
       "Entries": [
-        "Great tomb_Vagrant NPC_Not possessed"
+        "[UNUSED] Vagrant NPC - Kiln of the First Flame - Deprived"
       ]
     },
     {
       "ID": 7240,
       "Entries": [
-        "Tutorial_Vagrant NPC_What You Don't Have"
+        "[UNUSED] Vagrant NPC - Undead Asylum - Deprived"
       ]
     },
     {
       "ID": 10000,
       "Entries": [
-        "Patrol Leader"
+        "Homing (Crystal) Soulmass"
       ]
     },
     {
       "ID": 10001,
       "Entries": [
-        "Patrol Leader - DLC"
+        "[DLC] Pursuers"
       ]
     },
     {
       "ID": 120000,
       "Entries": [
-        "Rat"
+        "Large Undead rat"
       ]
     },
     {
       "ID": 120001,
       "Entries": [
-        "Rat"
+        "[UNUSED] Large Undead Rat (Crown)"
       ]
     },
     {
       "ID": 120010,
       "Entries": [
-        "Rat"
+        "Large Undead Rat (Defensive)"
       ]
     },
     {
       "ID": 120100,
       "Entries": [
-        "Small Rat"
+        "Small Undead Rat"
       ]
     },
     {
       "ID": 120101,
       "Entries": [
-        "Small Rat"
+        "Small Undead Rat (Aggressive)"
       ]
     },
     {
       "ID": 120102,
       "Entries": [
-        "Small Rat"
+        "Small Undead Rat (Reactionless)"
       ]
     },
     {
       "ID": 120103,
       "Entries": [
-        "Small Rat"
+        "[UNUSED] Small Undead Rat (Return Home Immediately)"
       ]
     },
     {
       "ID": 120110,
       "Entries": [
-        "Small Rat"
+        "Small Undead Rat (Aggressive) - Painted World"
       ]
     },
     {
       "ID": 120200,
       "Entries": [
-        "Giant Rat"
+        "Giant Undead Rat"
       ]
     },
     {
       "ID": 120300,
       "Entries": [
-        "Plague Rat"
+        "Undead Snow Rat"
       ]
     },
     {
       "ID": 206000,
       "Entries": [
-        "Infested Ghoul"
+        "Infested Ghoul (Sword)"
       ]
     },
     {
       "ID": 206001,
       "Entries": [
-        "Infested Ghoul"
+        "Infested Ghoul (Spear)"
       ]
     },
     {
       "ID": 206002,
       "Entries": [
-        "Infested Ghoul"
+        "Infested Ghoul (Corpse)"
       ]
     },
     {
       "ID": 223000,
       "Entries": [
-        "Stray Demon"
+        "[UNUSED] Stray Demon"
       ]
     },
     {
       "ID": 223001,
       "Entries": [
-        "Stray Demon"
+        "Stray Demon (Tutorial)"
       ]
     },
     {
@@ -880,43 +880,43 @@
     {
       "ID": 224000,
       "Entries": [
-        "Capra Demon"
+        "Capra Demon - Demon Ruins"
       ]
     },
     {
       "ID": 224001,
       "Entries": [
-        "Capra Demon"
+        "Capra Demon (Boss) - Lower Undead Burg"
       ]
     },
     {
       "ID": 224002,
       "Entries": [
-        "Capra Demon"
+        "[UNUSED] Capra Demon (Somehwat Defensive)"
       ]
     },
     {
       "ID": 224003,
       "Entries": [
-        "Capra Demon"
+        "Capra Demon (Defensive) - Demon Ruins"
       ]
     },
     {
       "ID": 224004,
       "Entries": [
-        "Capra Demon"
+        "Capra Demon (Ultra Defensive) - Demon Ruins"
       ]
     },
     {
       "ID": 225000,
       "Entries": [
-        "Taurus Demon"
+        "Taurus Demon (Boss) - Undead Burg"
       ]
     },
     {
       "ID": 225001,
       "Entries": [
-        "Taurus Demon"
+        "[UNUSED] Taurus Demon - Undead Asylum"
       ]
     },
     {
@@ -928,7 +928,7 @@
     {
       "ID": 225003,
       "Entries": [
-        "Taurus Demon - Demon Ruins"
+        "Taurus Demon (Won't Leave Home) - Demon Ruins"
       ]
     },
     {
@@ -940,73 +940,73 @@
     {
       "ID": 226001,
       "Entries": [
-        "Batwing Demon"
+        "Batwing Demon (Defensive)"
       ]
     },
     {
       "ID": 227000,
       "Entries": [
-        "Mushroom Parent"
+        "Mushroom-Man Parent - Great Hollow"
       ]
     },
     {
       "ID": 227001,
       "Entries": [
-        "Mushroom Parent"
+        "Mushroom-Man Parent (Defensive) - Darkroot Garden"
       ]
     },
     {
       "ID": 228000,
       "Entries": [
-        "Mushroom Child"
+        "Mushroom-Man Child - Darkroot Garden/Great Hollow"
       ]
     },
     {
       "ID": 228001,
       "Entries": [
-        "Mushroom Child"
+        "Mushroom-Man Child - Darkroot Garden"
       ]
     },
     {
       "ID": 229000,
       "Entries": [
-        "Salivan watchdog (Large) -- サリヴァーンの番犬（大）"
+        "[UNUSED] Chained Prisoner (Proto)"
       ]
     },
     {
       "ID": 230000,
       "Entries": [
-        "Prowling Demon - Catacombs"
+        "Titanite Demon - The Catacombs"
       ]
     },
     {
       "ID": 230001,
       "Entries": [
-        "Prowling Demon - Sen's Fortress"
+        "Titanite Demon - Sen's Fortress"
       ]
     },
     {
       "ID": 230002,
       "Entries": [
-        "Prowling Demon - Sen's Fortress"
+        "Titanite Demon - Sen's Fortress 2"
       ]
     },
     {
       "ID": 230003,
       "Entries": [
-        "Prowling Demon - Undead Parish"
+        "Titanite Demon - Undead Parish"
       ]
     },
     {
       "ID": 230004,
       "Entries": [
-        "Prowling Demon - Anor Londo"
+        "Titanite Demon - Anor Londo"
       ]
     },
     {
       "ID": 230005,
       "Entries": [
-        "Prowling Demon - Demon Ruins"
+        "Titanite Demon - Demon Ruins"
       ]
     },
     {
@@ -1030,31 +1030,31 @@
     {
       "ID": 236000,
       "Entries": [
-        "Smough"
+        "Executioner Smough"
       ]
     },
     {
       "ID": 236001,
       "Entries": [
-        "Smough"
+        "Executioner Smough (Lightning)"
       ]
     },
     {
       "ID": 237000,
       "Entries": [
-        "Channeler"
+        "Channeler - Undead Parish"
       ]
     },
     {
       "ID": 237001,
       "Entries": [
-        "Channeler"
+        "Channeler - Duke's Archives"
       ]
     },
     {
       "ID": 237002,
       "Entries": [
-        "Channeler"
+        "Channeler - The Depths"
       ]
     },
     {
@@ -1072,7 +1072,7 @@
     {
       "ID": 239001,
       "Entries": [
-        "Darkwraith"
+        "Darkwraith (Defensive)"
       ]
     },
     {
@@ -1084,451 +1084,451 @@
     {
       "ID": 240001,
       "Entries": [
-        "Painting Guardian"
+        "Painting Guardian (Fixed Turret)"
       ]
     },
     {
       "ID": 241000,
       "Entries": [
-        "Silver Knight"
+        "Silver Knight (Sword)"
       ]
     },
     {
       "ID": 241003,
       "Entries": [
-        "Silver Knight"
+        "Silver Knight (Spear)"
       ]
     },
     {
       "ID": 241004,
       "Entries": [
-        "Silver Knight"
+        "Silver Knight (Greatbow)"
       ]
     },
     {
       "ID": 241010,
       "Entries": [
-        "Silver Knight"
+        "Silver Knight (Sword - Defensive)"
       ]
     },
     {
       "ID": 241013,
       "Entries": [
-        "Silver Knight"
+        "[UNUSED] Silver Knight (Spear - Defensive)"
       ]
     },
     {
       "ID": 241014,
       "Entries": [
-        "Silver Knight"
+        "Silver Knight (Greatbow - Long Range)"
       ]
     },
     {
       "ID": 241023,
       "Entries": [
-        "Silver Knight"
+        "Silver Knight (Spear - Ultra-Defensive)"
       ]
     },
     {
       "ID": 243000,
       "Entries": [
-        "Moving Statue"
+        "Demonic Statue"
       ]
     },
     {
       "ID": 243001,
       "Entries": [
-        "Moving Statue"
+        "Demonic Statue (Ultra-Defensive)"
       ]
     },
     {
       "ID": 250000,
       "Entries": [
-        "Hollow"
+        "Hollow (Sword)"
       ]
     },
     {
       "ID": 250001,
       "Entries": [
-        "Hollow"
+        "Hollow (Sword - 15m Aggro) - Undead Burg/The Depths"
       ]
     },
     {
       "ID": 250002,
       "Entries": [
-        "Hollow"
+        "Hollow (Sword - Defensive 9m Aggro) - Undead Burg/The Depths/Undead Asylum"
       ]
     },
     {
       "ID": 250004,
       "Entries": [
-        "Hollow"
+        "Hollow (Sword - Ultra-Defensive 5m Aggro) - Undead Asylum"
       ]
     },
     {
       "ID": 250005,
       "Entries": [
-        "Hollow"
+        "Hollow (Sword - Defensive 12m Aggro) - Undead Asylum"
       ]
     },
     {
       "ID": 250006,
       "Entries": [
-        "Hollow"
+        "Hollow (Sword - Don't attack) - Undead Parish/Undead Asylum"
       ]
     },
     {
       "ID": 250007,
       "Entries": [
-        "Hollow"
+        "Hollow (Sword - Hollow Ambush Room 6m Aggro) - Undead Parish"
       ]
     },
     {
       "ID": 250008,
       "Entries": [
-        "Hollow"
+        "Hollow (Sword - Flee Into Hollow Ambush Room 6m Aggro) - Undead Parish"
       ]
     },
     {
       "ID": 250010,
       "Entries": [
-        "Hollow"
+        "Hollow (Torch) - Painted World/Undead Asylum"
       ]
     },
     {
       "ID": 250011,
       "Entries": [
-        "Hollow"
+        "Hollow (Torch - 15m Aggro) - The Depths"
       ]
     },
     {
       "ID": 250012,
       "Entries": [
-        "Hollow"
+        "Hollow (Torch - Defensive 9m Aggro) - Lower Undead Burg/The Depths"
       ]
     },
     {
       "ID": 250013,
       "Entries": [
-        "Hollow"
+        "Hollow (Torch - Ultra-Defensive 5m Aggro) - Lower Undead Burg/The Depths"
       ]
     },
     {
       "ID": 250020,
       "Entries": [
-        "Hollow"
+        "Hollow (Bow) - Undead Burg/Painted World/Undead Asylum"
       ]
     },
     {
       "ID": 250021,
       "Entries": [
-        "Hollow"
+        "Hollow (Bow - Region Monitoring) - Undead Asylum"
       ]
     },
     {
       "ID": 250030,
       "Entries": [
-        "Hollow"
+        "Hollow (Sword - 15m Aggro - Face Target)"
       ]
     },
     {
       "ID": 251000,
       "Entries": [
-        "Undead Merchant"
+        "Undead Merchant (Male)"
       ]
     },
     {
       "ID": 251001,
       "Entries": [
-        "Undead Merchant"
+        "Undead Merchant (Female)"
       ]
     },
     {
       "ID": 252000,
       "Entries": [
-        "Undead Assassin"
+        "Hollow Thief"
       ]
     },
     {
       "ID": 252001,
       "Entries": [
-        "Undead Assassin"
+        "[UNUSED] Hollow Thief (Run Home On Request)"
       ]
     },
     {
       "ID": 252010,
       "Entries": [
-        "Undead Assassin"
+        "Hollow Thief (Defensive)"
       ]
     },
     {
       "ID": 253000,
       "Entries": [
-        "Blowdart Hollow"
+        "[UNUSED] \"Bagworm\" Hollow (Club)"
       ]
     },
     {
       "ID": 253001,
       "Entries": [
-        "Blowdart Hollow"
+        "[UNUSED] \"Bagworm\" Hollow (Poison Stick)"
       ]
     },
     {
       "ID": 253002,
       "Entries": [
-        "Blowdart Hollow"
+        "Hollow Blowdart Sniper"
       ]
     },
     {
       "ID": 253100,
       "Entries": [
-        "Blowdart Hollow"
+        "[UNUSED] \"Bagworm\" Hollow (RocK)"
       ]
     },
     {
       "ID": 254000,
       "Entries": [
-        "Hollow Warrior"
+        "Hollow Warrior (Sword)"
       ]
     },
     {
       "ID": 254001,
       "Entries": [
-        "Hollow Warrior"
+        "Hollow Warrior (Axe)"
       ]
     },
     {
       "ID": 254002,
       "Entries": [
-        "Hollow Warrior"
+        "Hollow Warrior (Firebomb)"
       ]
     },
     {
       "ID": 254006,
       "Entries": [
-        "Hollow Warrior"
+        "Hollow Warrior (Sword - Defensive)"
       ]
     },
     {
       "ID": 254007,
       "Entries": [
-        "Hollow Warrior"
+        "Hollow Warrior (Axe - Defensive)"
       ]
     },
     {
       "ID": 254008,
       "Entries": [
-        "Hollow Warrior"
+        "Hollow Warrior (Sword - Firelink Shrine)"
       ]
     },
     {
       "ID": 254009,
       "Entries": [
-        "Hollow Warrior"
+        "Hollow Warrior (Axe - Firelink Shrine)"
       ]
     },
     {
       "ID": 254010,
       "Entries": [
-        "Hollow Warrior"
+        "[UNUSED] Hollow Warrior (Firebomb - Firelink Shrine)"
       ]
     },
     {
       "ID": 254011,
       "Entries": [
-        "Hollow Warrior"
+        "Hollow Warrior (Sword - Defensive - Firelink Shrine)"
       ]
     },
     {
       "ID": 254020,
       "Entries": [
-        "Hollow Warrior"
+        "Hollow Warrior (Sword - Ultra-Defensive)"
       ]
     },
     {
       "ID": 254030,
       "Entries": [
-        "Hollow Warrior"
+        "Hollow Warrior (Sword - Undead Burg)"
       ]
     },
     {
       "ID": 255000,
       "Entries": [
-        "Hollow Soldier"
+        "Hollow Soldier (Spear)"
       ]
     },
     {
       "ID": 255001,
       "Entries": [
-        "Hollow Soldier"
+        "Hollow Soldier (Sword)"
       ]
     },
     {
       "ID": 255002,
       "Entries": [
-        "Hollow Soldier"
+        "Hollow Soldier (Crossbow/Switch)"
       ]
     },
     {
       "ID": 255003,
       "Entries": [
-        "Hollow Soldier"
+        "Hollow Soldier (Crossbow - Tutorial)"
       ]
     },
     {
       "ID": 255004,
       "Entries": [
-        "Hollow Soldier"
+        "Hollow Soldier (Crossbow/Specialist)"
       ]
     },
     {
       "ID": 255005,
       "Entries": [
-        "Hollow Soldier"
+        "Hollow Soldier (Sword - Defensive)"
       ]
     },
     {
       "ID": 255006,
       "Entries": [
-        "Hollow Soldier"
+        "Hollow Soldier (Crossbow/Specialist - No Crouch Fire/Defensive)"
       ]
     },
     {
       "ID": 255007,
       "Entries": [
-        "Hollow Soldier"
+        "Hollow Soldier (Crossbow/Specialist - No Crouch Fire/General Use)"
       ]
     },
     {
       "ID": 255008,
       "Entries": [
-        "Hollow Soldier"
+        "Hollow Soldier (Sword - Defensive - For Base Use)"
       ]
     },
     {
       "ID": 255011,
       "Entries": [
-        "Hollow Soldier"
+        "Hollow Soldier (Spear - Defensive)"
       ]
     },
     {
       "ID": 255012,
       "Entries": [
-        "Hollow Soldier"
+        "Hollow Soldier (Spear - Kick Door Open)"
       ]
     },
     {
       "ID": 255020,
       "Entries": [
-        "Hollow Soldier"
+        "Hollow Soldier (Sword - Gate Open/Close)"
       ]
     },
     {
       "ID": 255030,
       "Entries": [
-        "Hollow Soldier"
+        "Hollow Soldier (Crossbow/Specialist - No Crouch Fire/Undead Burg Event)"
       ]
     },
     {
       "ID": 255040,
       "Entries": [
-        "Hollow Soldier"
+        "Hollow Soldier (Sword) - Undead Burg (Gate)"
       ]
     },
     {
       "ID": 256000,
       "Entries": [
-        "Balder Knight"
+        "Balder Knight (Sword)"
       ]
     },
     {
       "ID": 256001,
       "Entries": [
-        "Balder Knight"
+        "Balder Knight (Crossbow)"
       ]
     },
     {
       "ID": 256002,
       "Entries": [
-        "Balder Knight"
+        "Balder Knight (Rapier)"
       ]
     },
     {
       "ID": 256003,
       "Entries": [
-        "Balder Knight"
+        "Balder Knight (Sword - Defensive)"
       ]
     },
     {
       "ID": 256004,
       "Entries": [
-        "Balder Knight"
+        "Balder Knight (Sword) - Sen's Fortress (Rooftop A)"
       ]
     },
     {
       "ID": 256005,
       "Entries": [
-        "Balder Knight"
+        "Balder Knight (Sword) - Sen's Fortress (Rooftop B)"
       ]
     },
     {
       "ID": 256006,
       "Entries": [
-        "Balder Knight"
+        "Balder Knight (Rapier) - Sen's Fortress (Rooftop)"
       ]
     },
     {
       "ID": 256007,
       "Entries": [
-        "Balder Knight"
+        "Balder Knight (Rapier - Defensive)"
       ]
     },
     {
       "ID": 256008,
       "Entries": [
-        "Balder Knight"
+        "Balder Knight (Sword - Sound Reaction)"
       ]
     },
     {
       "ID": 257000,
       "Entries": [
-        "Heavy Knight"
+        "Berenike Knight (Greatsword)"
       ]
     },
     {
       "ID": 257001,
       "Entries": [
-        "Heavy Knight"
+        "Berenike Knight (Mace)"
       ]
     },
     {
       "ID": 257010,
       "Entries": [
-        "Heavy Knight"
+        "Berenike Knight (Greatsword - Defensive)"
       ]
     },
     {
       "ID": 257011,
       "Entries": [
-        "Heavy Knight"
+        "Berenike Knight (Mace - Defensive)"
       ]
     },
     {
       "ID": 257012,
       "Entries": [
-        "Heavy Knight"
+        "Heavy Knight (Mace - Defensive) - Sen's Fortress (Rooftop)"
       ]
     },
     {
       "ID": 259000,
       "Entries": [
-        "King's Secretary Sniper"
+        "[UNUSED] Marvellous Chester (Prototype)"
       ]
     },
     {
       "ID": 259100,
       "Entries": [
-        "King's Secretary Sniper, Anger"
+        "[UNUSED] Marvellous Chester (Prototype - Angry)"
       ]
     },
     {
@@ -1540,133 +1540,133 @@
     {
       "ID": 265000,
       "Entries": [
-        "Necromancer"
+        "Hollow Necromancer"
       ]
     },
     {
       "ID": 266000,
       "Entries": [
-        "Butcher"
+        "Hollow Maneater Butcher"
       ]
     },
     {
       "ID": 267000,
       "Entries": [
-        "Ghost (Male)"
+        "Cursed Ghost (Male)"
       ]
     },
     {
       "ID": 267001,
       "Entries": [
-        "Ghost (Male)"
+        "Cursed Ghost (Male - Defensive)"
       ]
     },
     {
       "ID": 267002,
       "Entries": [
-        "Ghost (Male)"
+        "Cursed Ghost (Male - Ignore Navmesh)"
       ]
     },
     {
       "ID": 267010,
       "Entries": [
-        "Ghost (Male)"
+        "Cursed Ghost (Male)"
       ]
     },
     {
       "ID": 267011,
       "Entries": [
-        "Ghost (Male)"
+        "Cursed Ghost (Male - Defensive)"
       ]
     },
     {
       "ID": 267020,
       "Entries": [
-        "Ghost (Male)"
+        "Cursed Ghost (Male)"
       ]
     },
     {
       "ID": 267021,
       "Entries": [
-        "Ghost (Male)"
+        "Cursed Ghost (Male - Defensive)"
       ]
     },
     {
       "ID": 267030,
       "Entries": [
-        "Ghost (Male)"
+        "Cursed Ghost (Male)"
       ]
     },
     {
       "ID": 267031,
       "Entries": [
-        "Ghost (Male)"
+        "Cursed Ghost (Male - Defensive)"
       ]
     },
     {
       "ID": 267040,
       "Entries": [
-        "Ghost (Male)"
+        "Cursed Ghost (Male)"
       ]
     },
     {
       "ID": 267041,
       "Entries": [
-        "Ghost (Male)"
+        "Cursed Ghost (Male - Defensive)"
       ]
     },
     {
       "ID": 267050,
       "Entries": [
-        "Ghost (Male)"
+        "Cursed Ghost (Male - Ignore Navmesh)"
       ]
     },
     {
       "ID": 268000,
       "Entries": [
-        "Ghost (Female)"
+        "Cursed Ghost (Female)"
       ]
     },
     {
       "ID": 268001,
       "Entries": [
-        "Ghost (Female)"
+        "Cursed Ghost (Female - Defensive)"
       ]
     },
     {
       "ID": 269000,
       "Entries": [
-        "Serpent Soldier"
+        "Man-Serpent Soldier"
       ]
     },
     {
       "ID": 269001,
       "Entries": [
-        "Serpent Soldier"
+        "Man-Serpent Soldier (Defensive)"
       ]
     },
     {
       "ID": 269010,
       "Entries": [
-        "Serpent Soldier"
+        "Man-Serpent Soldier (Crystal Performance?)"
       ]
     },
     {
       "ID": 270000,
       "Entries": [
-        "Serpent Mage"
+        "Man-Serpent Sorcerer"
       ]
     },
     {
       "ID": 270001,
       "Entries": [
-        "Serpent Mage"
+        "Man-Serpent Sorcerer (Defensive)"
       ]
     },
     {
       "ID": 270002,
       "Entries": [
-        "Serpent Mage"
+        "Man-Serpent Sorcerer (Fixed Turret)"
       ]
     },
     {
@@ -1678,13 +1678,13 @@
     {
       "ID": 271001,
       "Entries": [
-        "Crystal Golem"
+        "Crystal Golem (Defensive)"
       ]
     },
     {
       "ID": 271002,
       "Entries": [
-        "Crystal Golem"
+        "Crystal Golem (Defensive)"
       ]
     },
     {
@@ -1696,19 +1696,19 @@
     {
       "ID": 271101,
       "Entries": [
-        "Crystal Golem (Gold)"
+        "Crystal Golem (Gold - Defensive)"
       ]
     },
     {
       "ID": 273000,
       "Entries": [
-        "Priscilla"
+        "Crossbreed Priscilla"
       ]
     },
     {
       "ID": 273100,
       "Entries": [
-        "Priscilla's Tail"
+        "Crossbreed Priscilla's Tail"
       ]
     },
     {
@@ -1726,49 +1726,49 @@
     {
       "ID": 278001,
       "Entries": [
-        "Mimic"
+        "Mimic (Can't Leave Home)"
       ]
     },
     {
       "ID": 278002,
       "Entries": [
-        "Mimic"
+        "Mimic (Again, Can't Leave Home [injoke?])"
       ]
     },
     {
       "ID": 279000,
       "Entries": [
-        "Black Knight"
+        "Black Knight (Sword)"
       ]
     },
     {
       "ID": 279001,
       "Entries": [
-        "Black Knight"
+        "Black Knight (Greatsword)"
       ]
     },
     {
       "ID": 279002,
       "Entries": [
-        "Black Knight"
+        "Black Knight (Greataxe)"
       ]
     },
     {
       "ID": 279003,
       "Entries": [
-        "Black Knight"
+        "Black Knight (Halberd - No Sweeping Attacks)"
       ]
     },
     {
       "ID": 279004,
       "Entries": [
-        "Black Knight"
+        "Black Knight (Halberd)"
       ]
     },
     {
       "ID": 279010,
       "Entries": [
-        "Black Knight"
+        "Black Knight (Sword - Defensive)"
       ]
     },
     {
@@ -1780,73 +1780,73 @@
     {
       "ID": 280000,
       "Entries": [
-        "Crystal Hollow"
+        "Hollow Crystallized Soldier (Sword)"
       ]
     },
     {
       "ID": 280001,
       "Entries": [
-        "Crystal Hollow"
+        "Hollow Crystallized Soldier (Bow)"
       ]
     },
     {
       "ID": 280002,
       "Entries": [
-        "Crystal Hollow"
+        "Hollow Crystallized Soldier (Sword - Defensive)"
       ]
     },
     {
       "ID": 281000,
       "Entries": [
-        "Infested Barbarian (Club)"
+        "Hollow Infested Barbarian (Club)"
       ]
     },
     {
       "ID": 281001,
       "Entries": [
-        "Infested Barbarian (Club)"
+        "Hollow Infested Barbarian (Club - Defensive)"
       ]
     },
     {
       "ID": 281100,
       "Entries": [
-        "Infested Barbarian (Boulder)"
+        "Hollow Infested Barbarian (Boulder)"
       ]
     },
     {
       "ID": 282000,
       "Entries": [
-        "Immortals (Krug followers)"
+        "[UNUSED] Hollow Crag Worshipper"
       ]
     },
     {
       "ID": 283010,
       "Entries": [
-        "Hollow Phalanx"
+        "Phalanx"
       ]
     },
     {
       "ID": 284000,
       "Entries": [
-        "Engorged Hollow"
+        "Engorged Hollow (Torch)"
       ]
     },
     {
       "ID": 284001,
       "Entries": [
-        "Engorged Hollow"
+        "Engorged Hollow (Unarmed)"
       ]
     },
     {
       "ID": 286000,
       "Entries": [
-        "Giant"
+        "Slave Giant"
       ]
     },
     {
       "ID": 286001,
       "Entries": [
-        "Giant"
+        "Slave Giant (Throwing)"
       ]
     },
     {
@@ -1858,109 +1858,109 @@
     {
       "ID": 287010,
       "Entries": [
-        "Royal Sentinel"
+        "Giant Sentinel"
       ]
     },
     {
       "ID": 287011,
       "Entries": [
-        "Royal Sentinel"
+        "Giant Sentinel (Defensive)"
       ]
     },
     {
       "ID": 287012,
       "Entries": [
-        "Royal Sentinel"
+        "Giant Sentinel (Ultra-Defensive)"
       ]
     },
     {
       "ID": 287013,
       "Entries": [
-        "Royal Sentinel"
+        "Giant Sentinel"
       ]
     },
     {
       "ID": 290000,
       "Entries": [
-        "Skeleton"
+        "Skeleton (Sword)"
       ]
     },
     {
       "ID": 290001,
       "Entries": [
-        "Skeleton"
+        "Skeleton (Bow)"
       ]
     },
     {
       "ID": 290002,
       "Entries": [
-        "Skeleton"
+        "Skeleton (Falchion)"
       ]
     },
     {
       "ID": 290003,
       "Entries": [
-        "Skeleton"
+        "Skeleton (Sword - \"Lunging Drill\" Attack)"
       ]
     },
     {
       "ID": 290004,
       "Entries": [
-        "Skeleton"
+        "Skeleton (Falchion - \"Lunging Drill\" Attack)"
       ]
     },
     {
       "ID": 290005,
       "Entries": [
-        "Skeleton"
+        "Skeleton (Sword - Defensive)"
       ]
     },
     {
       "ID": 290006,
       "Entries": [
-        "Skeleton"
+        "Skeleton (Falchion - Defensive)"
       ]
     },
     {
       "ID": 290007,
       "Entries": [
-        "Skeleton"
+        "Skeleton (Bow - Sound Unresponsive)"
       ]
     },
     {
       "ID": 291000,
       "Entries": [
-        "Giant Skeleton"
+        "Giant Skeleton (Greatsword - Defensive)"
       ]
     },
     {
       "ID": 291001,
       "Entries": [
-        "Giant Skeleton"
+        "Giant Skeleton (Greatbow)"
       ]
     },
     {
       "ID": 291002,
       "Entries": [
-        "Giant Skeleton"
+        "Giant Skeleton (Greatsword)"
       ]
     },
     {
       "ID": 291003,
       "Entries": [
-        "Giant Skeleton"
+        "Giant Skeleton (Greatsword) - Tomb of the Giants"
       ]
     },
     {
       "ID": 292000,
       "Entries": [
-        "Vamos"
+        "Vamos the Blacksmith (Miner)"
       ]
     },
     {
       "ID": 292001,
       "Entries": [
-        "Vamos"
+        "Vamos the Blacksmith (Combat)"
       ]
     },
     {
@@ -1972,7 +1972,7 @@
     {
       "ID": 293010,
       "Entries": [
-        "Bonewheel Skeleton"
+        "Bonewheel Skeleton (Somewhat Defensive)"
       ]
     },
     {
@@ -1984,13 +1984,13 @@
     {
       "ID": 295000,
       "Entries": [
-        "Skeleton Beast"
+        "Skeletal Beast"
       ]
     },
     {
       "ID": 295001,
       "Entries": [
-        "Skeleton Beast"
+        "Skeletal Beast - Tomb of the Giants"
       ]
     },
     {
@@ -2002,13 +2002,13 @@
     {
       "ID": 296001,
       "Entries": [
-        "Bone Tower"
+        "Bone Tower - Tomb of the Giants"
       ]
     },
     {
       "ID": 309000,
       "Entries": [
-        "Mosquito"
+        "Giant Mosquito"
       ]
     },
     {
@@ -2026,13 +2026,13 @@
     {
       "ID": 321001,
       "Entries": [
-        "Egg Carrier - NPC"
+        "Eingyi"
       ]
     },
     {
       "ID": 322000,
       "Entries": [
-        "Chaos Bug"
+        "Vile Maggot"
       ]
     },
     {
@@ -2044,7 +2044,7 @@
     {
       "ID": 323001,
       "Entries": [
-        "Moonlight Butterfly"
+        "Crystal Butterfly"
       ]
     },
     {
@@ -2056,19 +2056,19 @@
     {
       "ID": 324001,
       "Entries": [
-        "Chaos Eater"
+        "Chaos Eater (Siegmeyer Enemy)"
       ]
     },
     {
       "ID": 324002,
       "Entries": [
-        "Chaos Eater"
+        "Chaos Eater (Normal Placement - Region Monitoring)"
       ]
     },
     {
       "ID": 325000,
       "Entries": [
-        "Maneater Clam"
+        "Man-Eater Shell"
       ]
     },
     {
@@ -2086,7 +2086,7 @@
     {
       "ID": 329000,
       "Entries": [
-        "king bugs and mosquitoes"
+        "[UNUSED] King Bug and Mosquitoes"
       ]
     },
     {
@@ -2098,7 +2098,7 @@
     {
       "ID": 330001,
       "Entries": [
-        "Crystal Lizard"
+        "Crystal Lizard (Undead Burg Barrel)"
       ]
     },
     {
@@ -2110,55 +2110,55 @@
     {
       "ID": 332001,
       "Entries": [
-        "Pinwheel"
+        "Pinwheel (Fake)"
       ]
     },
     {
       "ID": 332002,
       "Entries": [
-        "Pinwheel"
+        "Pinwheel Servant"
       ]
     },
     {
       "ID": 332003,
       "Entries": [
-        "Pinwheel"
+        "Pinwheel Servant (Fixed Turret)"
       ]
     },
     {
       "ID": 333000,
       "Entries": [
-        "Pisaca"
+        "Pisaca (Patrol Point A)"
       ]
     },
     {
       "ID": 333001,
       "Entries": [
-        "Pisaca"
+        "Pisaca (Patrol Point B)"
       ]
     },
     {
       "ID": 333002,
       "Entries": [
-        "Pisaca"
+        "Pisaca (Patrol Point C)"
       ]
     },
     {
       "ID": 333003,
       "Entries": [
-        "Pisaca"
+        "Pisaca (Patrol Point D)"
       ]
     },
     {
       "ID": 333004,
       "Entries": [
-        "Pisaca"
+        "Pisaca (Patrol Point E)"
       ]
     },
     {
       "ID": 333005,
       "Entries": [
-        "Pisaca"
+        "Pisaca (Sunlight Miracle Loot)"
       ]
     },
     {
@@ -2170,37 +2170,37 @@
     {
       "ID": 334001,
       "Entries": [
-        "Undead Attack Dog"
+        "Undead Attack Dog (Defensive)"
       ]
     },
     {
       "ID": 334010,
       "Entries": [
-        "Undead Attack Dog"
+        "Undead Attack Dog - The Depths"
       ]
     },
     {
       "ID": 334011,
       "Entries": [
-        "Undead Attack Dog"
+        "Undead Attack Dog (Defensive) - The Depths"
       ]
     },
     {
       "ID": 334100,
       "Entries": [
-        "Flaming Attack Dog"
+        "Chaos Attack Dog"
       ]
     },
     {
       "ID": 334101,
       "Entries": [
-        "Flaming Attack Dog"
+        "Chaos Attack Dog (Defensive)"
       ]
     },
     {
       "ID": 335000,
       "Entries": [
-        "Walking Tree"
+        "Possessed Tree"
       ]
     },
     {
@@ -2212,37 +2212,37 @@
     {
       "ID": 338000,
       "Entries": [
-        "Leech"
+        "Giant Leech"
       ]
     },
     {
       "ID": 339000,
       "Entries": [
-        "Burrower"
+        "Burrowing Rockworm"
       ]
     },
     {
       "ID": 339001,
       "Entries": [
-        "Burrower"
+        "Burrowing Rockworm (Ground)"
       ]
     },
     {
       "ID": 339002,
       "Entries": [
-        "Burrower"
+        "Burrowing Rockworm (Wall)"
       ]
     },
     {
       "ID": 339003,
       "Entries": [
-        "Burrower"
+        "Burrowing Rockworm (Ceiling)"
       ]
     },
     {
       "ID": 340000,
       "Entries": [
-        "Cragspider"
+        "Chaos Crag-Spider"
       ]
     },
     {
@@ -2260,19 +2260,19 @@
     {
       "ID": 342001,
       "Entries": [
-        "Undead Dragon"
+        "Undead Dragon (Moving)"
       ]
     },
     {
       "ID": 342002,
       "Entries": [
-        "Undead Dragon"
+        "Undead Dragon - Valley of Drakes"
       ]
     },
     {
       "ID": 342100,
       "Entries": [
-        "Undead Dragon - Legs"
+        "Undead Dragon (Lower Half)"
       ]
     },
     {
@@ -2284,7 +2284,7 @@
     {
       "ID": 343001,
       "Entries": [
-        "Hellkite Drake"
+        "[UNUSED] Hellkite Drake - Firelink Shrine"
       ]
     },
     {
@@ -2296,13 +2296,13 @@
     {
       "ID": 346000,
       "Entries": [
-        "Armored Tusk"
+        "Fang Boar"
       ]
     },
     {
       "ID": 346100,
       "Entries": [
-        "Armored Tusk - Reinforced"
+        "Fang Boar (Fully-Armored)"
       ]
     },
     {
@@ -2320,13 +2320,13 @@
     {
       "ID": 347101,
       "Entries": [
-        "Sanctuary Guardian"
+        "Lesser Sanctuary Guardian"
       ]
     },
     {
       "ID": 348000,
       "Entries": [
-        "Chaos Bug"
+        "Sunlight Maggot"
       ]
     },
     {
@@ -2350,13 +2350,13 @@
     {
       "ID": 350100,
       "Entries": [
-        "Wisp"
+        "Wisp - New Londo Ruins"
       ]
     },
     {
       "ID": 350101,
       "Entries": [
-        "Wisp"
+        "Wisp - The Catacombs"
       ]
     },
     {
@@ -2368,61 +2368,61 @@
     {
       "ID": 352000,
       "Entries": [
-        "Drake"
+        "[UNUSED] Drake"
       ]
     },
     {
       "ID": 352001,
       "Entries": [
-        "Drake"
+        "Drake - Valley of Drakes"
       ]
     },
     {
       "ID": 352002,
       "Entries": [
-        "Drake"
+        "Drake (Ground)"
       ]
     },
     {
       "ID": 352003,
       "Entries": [
-        "Drake"
+        "Drake (Ground - Never Return Home)"
       ]
     },
     {
       "ID": 352005,
       "Entries": [
-        "Drake"
+        "[UNUSED] Drake (Flying)"
       ]
     },
     {
       "ID": 352006,
       "Entries": [
-        "Drake"
+        "[UNUSED] Drake (Flying - 2nd one)"
       ]
     },
     {
       "ID": 353000,
       "Entries": [
-        "Hydra"
+        "Hydra - Ash Lake"
       ]
     },
     {
       "ID": 353001,
       "Entries": [
-        "Hydra"
+        "Hydra - Darkroot Basin"
       ]
     },
     {
       "ID": 353100,
       "Entries": [
-        "Hydra's Head"
+        "Hydra's Head (Thick Neck)"
       ]
     },
     {
       "ID": 353200,
       "Entries": [
-        "Hydra's Head"
+        "Hydra's Head (Thin Neck)"
       ]
     },
     {
@@ -2446,7 +2446,7 @@
     {
       "ID": 411001,
       "Entries": [
-        "Hawkeye Gough"
+        "Hawkeye Gough (With Vision)"
       ]
     },
     {
@@ -2458,169 +2458,169 @@
     {
       "ID": 412001,
       "Entries": [
-        "Stone Guardian"
+        "Stone Guardian (Defensive)"
       ]
     },
     {
       "ID": 413000,
       "Entries": [
-        "Scarecrow"
+        "Scarecrow Gardener (Pitchfork)"
       ]
     },
     {
       "ID": 413001,
       "Entries": [
-        "Scarecrow"
+        "Scarecrow Gardener (Pitchfork - Defensive)"
       ]
     },
     {
       "ID": 413002,
       "Entries": [
-        "Scarecrow"
+        "Scarecrow Gardener (Pitchfork - Good Vision)"
       ]
     },
     {
       "ID": 413010,
       "Entries": [
-        "Scarecrow"
+        "Scarecrow Gardener (Shears)"
       ]
     },
     {
       "ID": 413011,
       "Entries": [
-        "Scarecrow"
+        "Scarecrow Gardener (Shears - Defensive)"
       ]
     },
     {
       "ID": 413012,
       "Entries": [
-        "Scarecrow"
+        "Scarecrow Gardener (Shears - Good Vision)"
       ]
     },
     {
       "ID": 414000,
       "Entries": [
-        "Elizabeth"
+        "Elizabeth, Keeper of the Sanctuary"
       ]
     },
     {
       "ID": 415000,
       "Entries": [
-        "Bloathead"
+        "Oolacile Resident (Melee)"
       ]
     },
     {
       "ID": 415001,
       "Entries": [
-        "Bloathead"
+        "Oolacile Resident (Melee - Defensive)"
       ]
     },
     {
       "ID": 415002,
       "Entries": [
-        "Bloathead"
+        "Oolacile Resident (Melee - Restricted Vision)"
       ]
     },
     {
       "ID": 415010,
       "Entries": [
-        "Bloathead"
+        "Oolacile Resident (Melee - Pointing Rarer)"
       ]
     },
     {
       "ID": 415011,
       "Entries": [
-        "Bloathead"
+        "Oolacile Resident (Melee - Pointing Rarer - Defensive)"
       ]
     },
     {
       "ID": 415012,
       "Entries": [
-        "Bloathead"
+        "Oolacile Resident (Melee - Pointing Rarer - Defensive - Restricted Vision)"
       ]
     },
     {
       "ID": 415020,
       "Entries": [
-        "Bloathead"
+        "Oolacile Resident (Melee - Lit Eyes)"
       ]
     },
     {
       "ID": 415021,
       "Entries": [
-        "Bloathead"
+        "Oolacile Resident (Melee - Lit Eyes - Defensive)"
       ]
     },
     {
       "ID": 415022,
       "Entries": [
-        "Bloathead"
+        "Oolacile Resident (Melee - Lit Eyes - For Attic)"
       ]
     },
     {
       "ID": 416000,
       "Entries": [
-        "Bloathead Sorcerer"
+        "Oolacile Resident (Sorceress)"
       ]
     },
     {
       "ID": 416001,
       "Entries": [
-        "Bloathead Sorcerer"
+        "Oolacile Resident (Sorceress - Defensive)"
       ]
     },
     {
       "ID": 416002,
       "Entries": [
-        "Bloathead Sorcerer"
+        "Oolacile Resident (Sorceress - Ultra-Defensive)"
       ]
     },
     {
       "ID": 416003,
       "Entries": [
-        "Bloathead Sorcerer"
+        "Oolacile Resident (Sorceress - Restricted Vision)"
       ]
     },
     {
       "ID": 416020,
       "Entries": [
-        "Bloathead Sorcerer"
+        "Oolacile Resident (Sorceress - Lit Eyes)"
       ]
     },
     {
       "ID": 416021,
       "Entries": [
-        "Bloathead Sorcerer"
+        "Oolacile Resident (Sorceress - Lit Eyes - Somewhat Defensive)"
       ]
     },
     {
       "ID": 416022,
       "Entries": [
-        "Bloathead Sorcerer"
+        "Oolacile Resident (Sorceress) - Chasm of the Abyss Sniper"
       ]
     },
     {
       "ID": 417000,
       "Entries": [
-        "Humanity Phantom (Large)"
+        "Humanity (Large)"
       ]
     },
     {
       "ID": 417100,
       "Entries": [
-        "Humanity Phantom (Medium)"
+        "Humanity (Medium)"
       ]
     },
     {
       "ID": 417101,
       "Entries": [
-        "Humanity Phantom (Medium)"
+        "Humanity (Medium - Aggressive)"
       ]
     },
     {
       "ID": 417200,
       "Entries": [
-        "Humanity Phantom (Small)"
+        "Humanity (Small)"
       ]
     },
     {
@@ -2632,19 +2632,19 @@
     {
       "ID": 418001,
       "Entries": [
-        "Chained Prisoner"
+        "Chained Prisoner (Defensive)"
       ]
     },
     {
       "ID": 419000,
       "Entries": [
-        "Undead Attack Dog (DLC)"
+        "Scaled Attack Dog"
       ]
     },
     {
       "ID": 419001,
       "Entries": [
-        "Undead Attack Dog (DLC)"
+        "Scaled Attack Dog (Defensive)"
       ]
     },
     {
@@ -2656,13 +2656,13 @@
     {
       "ID": 451000,
       "Entries": [
-        "Kalameet"
+        "Black Dragon Kalameet"
       ]
     },
     {
       "ID": 452000,
       "Entries": [
-        "Great Grey Wolf Sif (DLC)"
+        "(DLC) Great Grey Wolf Sif"
       ]
     },
     {
@@ -2704,7 +2704,7 @@
     {
       "ID": 523100,
       "Entries": [
-        "Bed Of Chaos (Moving)"
+        "[UNUSED] Bed Of Chaos (Moving)"
       ]
     },
     {
@@ -2728,13 +2728,13 @@
     {
       "ID": 527000,
       "Entries": [
-        "Dragonslayer Ornstein"
+        "Dragon Slayer Ornstein"
       ]
     },
     {
       "ID": 527100,
       "Entries": [
-        "Dragonslayer Ornstein (Giant)"
+        "Dragon Slayer Ornstein (Giant)"
       ]
     },
     {
@@ -2746,13 +2746,13 @@
     {
       "ID": 529000,
       "Entries": [
-        "Seath the Scaleless"
+        "Seath the Scaleless - Crystal Cave"
       ]
     },
     {
       "ID": 529001,
       "Entries": [
-        "Seath the Scaleless"
+        "Seath the Scaleless - Duke's Archives"
       ]
     },
     {
@@ -2764,13 +2764,13 @@
     {
       "ID": 531000,
       "Entries": [
-        "Gwynevere"
+        "Gwynevere, Princess of Sunlight"
       ]
     },
     {
       "ID": 532000,
       "Entries": [
-        "Gwyndolin"
+        "Dark Sun Gwyndolin"
       ]
     },
     {
@@ -2788,7 +2788,7 @@
     {
       "ID": 533002,
       "Entries": [
-        "Darkstalker Kaathe"
+        "[UNUSED] Kingseeker"
       ]
     },
     {
@@ -2800,19 +2800,19 @@
     {
       "ID": 535000,
       "Entries": [
-        "Gargoyle"
+        "Bell Gargoyle"
       ]
     },
     {
       "ID": 535001,
       "Entries": [
-        "Gargoyle"
+        "Bell Gargoyle (2nd)"
       ]
     },
     {
       "ID": 535100,
       "Entries": [
-        "Gargoyle - Anor Londo"
+        "Lightning Gargoyle"
       ]
     },
     {
@@ -2824,7 +2824,7 @@
     {
       "ID": 536100,
       "Entries": [
-        "Alvina"
+        "Alvina of the Darkroot Wood"
       ]
     },
     {
@@ -2848,13 +2848,13 @@
     {
       "ID": 540100,
       "Entries": [
-        "Bed of Chaos Worm"
+        "Bed of Chaos (Worm)"
       ]
     },
     {
       "ID": 807000,
       "Entries": [
-        "Used for test NPC"
+        "Used for Test NPC"
       ]
     }
   ]

--- a/src/Smithbox.Data/Assets/PARAM/DS1R/Community Row Names/RagdollParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/DS1R/Community Row Names/RagdollParam.json
@@ -4,217 +4,217 @@
     {
       "ID": 0,
       "Entries": [
-        "Move -- 動かない"
+        "Not Moving"
       ]
     },
     {
       "ID": 1,
       "Entries": [
-        "Havok Default Value -- Havokのデフォルト値"
+        "Havok Default Value"
       ]
     },
     {
       "ID": 100,
       "Entries": [
-        "ムカデの頭部"
+        "DeS Centipede's Head"
       ]
     },
     {
       "ID": 101,
       "Entries": [
-        "ムカデの尻尾"
+        "DeS Centipede's Tail"
       ]
     },
     {
       "ID": 200,
       "Entries": [
-        "血ダニの本体"
+        "DeS Giant Tick's Body"
       ]
     },
     {
       "ID": 201,
       "Entries": [
-        "血ダニのふくろ"
+        "DeS Giant Tick's Sack"
       ]
     },
     {
       "ID": 1000,
       "Entries": [
-        "Segunda: The Evil Spirits -- グンダ：邪霊"
+        "Test Dragon's Body"
       ]
     },
     {
       "ID": 1010,
       "Entries": [
-        "テスト飛竜の尻尾"
+        "Test Dragon's Tail"
       ]
     },
     {
       "ID": 1020,
       "Entries": [
-        "テスト飛竜の右翼"
+        "Test Dragon's Right Wing"
       ]
     },
     {
       "ID": 1050,
       "Entries": [
-        "騎士の頭部"
+        "Knight's Head"
       ]
     },
     {
       "ID": 1100,
       "Entries": [
-        "Snake Spirit: Right arm -- 蛇霊：右腕"
+        "Snake Spirit's Right arm"
       ]
     },
     {
       "ID": 1110,
       "Entries": [
-        "ムカデボスの尻尾"
+        "Centipede Demon's Tail"
       ]
     },
     {
       "ID": 1120,
       "Entries": [
-        "ムカデボスの右腕"
+        "Centipede Demon's Right Arm"
       ]
     },
     {
       "ID": 1200,
       "Entries": [
-        "墓王の本体"
+        "Gravelord Nito's Body"
       ]
     },
     {
       "ID": 1201,
       "Entries": [
-        "King of the Dead: Crown -- 死霊の王：王冠"
+        "Gravelord Nito's Crown"
       ]
     },
     {
       "ID": 1202,
       "Entries": [
-        "King of the Dead: torso -- 死霊の王：胴体"
+        "Gravelord Nito's Torso"
       ]
     },
     {
       "ID": 1203,
       "Entries": [
-        "King of the dead: right arm -- 死霊の王：右腕"
+        "Gravelord Nito's Right Arm"
       ]
     },
     {
       "ID": 1210,
       "Entries": [
-        "墓王のマント"
+        "Gravelord Nito's Mantle"
       ]
     },
     {
       "ID": 1301,
       "Entries": [
-        "Mad Warrior Hallec: Head -- 狂戦士ハレック：頭"
+        "Gaping Dragon's Tail"
       ]
     },
     {
       "ID": 1400,
       "Entries": [
-        "湖獣の首①"
+        "Hydra's Head 1"
       ]
     },
     {
       "ID": 1401,
       "Entries": [
-        "Dead Slug (dumpling): Dead dumpling -- 蝕のナメクジ（亡者団子）：亡者団子"
+        "Hydra's Head 2"
       ]
     },
     {
       "ID": 1402,
       "Entries": [
-        "湖獣の首③"
+        "Hydra's Head 3"
       ]
     },
     {
       "ID": 1403,
       "Entries": [
-        "湖獣の首④"
+        "Hydra's Head 4"
       ]
     },
     {
       "ID": 1404,
       "Entries": [
-        "湖獣の首⑤"
+        "Hydra's Head 5"
       ]
     },
     {
       "ID": 1405,
       "Entries": [
-        "湖獣の首⑥"
+        "Hydra's Head 6"
       ]
     },
     {
       "ID": 1406,
       "Entries": [
-        "湖獣の首⑦"
+        "Hydra's Head 7"
       ]
     },
     {
       "ID": 1501,
       "Entries": [
-        "Hell Kite: Before your left ankle -- ヘルカイト：左足の足首より先"
+        "Seath the Scaleless's Crystal Armor"
       ]
     },
     {
       "ID": 1601,
       "Entries": [
-        "ヒロインの尻尾"
+        "Crossbreed Priscilla's Tail"
       ]
     },
     {
       "ID": 1701,
       "Entries": [
-        "ヘルカイトの尻尾"
+        "Hellkite Drake's Tail"
       ]
     },
     {
       "ID": 1801,
       "Entries": [
-        "座禅ドラゴンの尻尾"
+        "Stone Dragon's Tail"
       ]
     },
     {
       "ID": 1901,
       "Entries": [
-        "ガーゴイルの尻尾"
+        "Bell Gargoyle's Tail"
       ]
     },
     {
       "ID": 1902,
       "Entries": [
-        "ガーゴイル2体目破損部位"
+        "2nd Bell Gargoyle's Damaged Part"
       ]
     },
     {
       "ID": 2001,
       "Entries": [
-        "ガーゴイル（色違い）の尻尾"
+        "Lightning Gargoyle's Tail"
       ]
     },
     {
       "ID": 2101,
       "Entries": [
-        "白竜シースの尻尾"
+        "Seath the Scaleless' Tail"
       ]
     },
     {
       "ID": 2201,
       "Entries": [
-        "金キメラの尻尾"
+        "Sanctuary Guardian's Tail"
       ]
     },
     {
       "ID": 2301,
       "Entries": [
-        "黒竜の尻尾"
+        "Black Dragon Kalameet's Tail"
       ]
     }
   ]

--- a/src/Smithbox.Data/Assets/PARAM/DS1R/Community Row Names/TalkParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/DS1R/Community Row Names/TalkParam.json
@@ -4,2731 +4,2731 @@
     {
       "ID": 10000000,
       "Entries": [
-        "そいつが、鍵を持ってる"
+        "He has the key."
       ]
     },
     {
       "ID": 10000001,
       "Entries": [
-        "…あとは、貴公次第だ"
+        "The choice is yours."
       ]
     },
     {
       "ID": 10010100,
       "Entries": [
-        "おお、貴公！どうやら亡者ではないらしいな"
+        "Ah, hello! You don't look Hollow, far from it!"
       ]
     },
     {
       "ID": 10010101,
       "Entries": [
-        "俺はアストラのソラール。見ての通り、太陽の神の信徒だ"
+        "I am Solaire of Astora, an adherent of the Lord of Sunlight."
       ]
     },
     {
       "ID": 10010102,
       "Entries": [
-        "不死となり、大王グウィンの生まれたこの地に、俺自身の太陽を探しにきた！"
+        "Now that I am Undead, I have come to this great land, the\nbirthplace of Lord Gwyn, to seek my very own sun!"
       ]
     },
     {
       "ID": 10010103,
       "Entries": [
-        "…変人だ、と思ったか？まあ、その通りだ"
+        "...Do you find that strange? Well, you should!"
       ]
     },
     {
       "ID": 10010104,
       "Entries": [
-        "気にするな。皆同じ顔をする"
+        "No need to hide your reaction. I get that look all the time!"
       ]
     },
     {
       "ID": 10010105,
       "Entries": [
-        "ウワッハッハッハハ"
+        "Hah hah hah!"
       ]
     },
     {
       "ID": 10010200,
       "Entries": [
-        "おお、貴公。また声をかけてくれるとは"
+        "Oh, ah-hah! So, I didn't scare you?"
       ]
     },
     {
       "ID": 10010201,
       "Entries": [
-        "丁度考えていたことがあるんだ。少し時間をもらってよいか？"
+        "I have a proposition, if you have a moment."
       ]
     },
     {
       "ID": 10010250,
       "Entries": [
-        "いや、貴公とは奇妙な縁があると思ってな"
+        "The way I see it, our fates appear to be intertwined."
       ]
     },
     {
       "ID": 10010251,
       "Entries": [
-        "亡者ばかりのこの地で、こうして貴公と出会った…"
+        "In a land brimming with Hollows, could that really be mere\nchance?"
       ]
     },
     {
       "ID": 10010252,
       "Entries": [
-        "だから、どうだろう、貴公と俺、互いが旅の助けにならないか？"
+        "So, what do you say? Why not help one another on this lonely\njourney?"
       ]
     },
     {
       "ID": 10010300,
       "Entries": [
-        "そりゃあよかった！じゃあ、こいつを渡しておこう"
+        "This pleases me greatly! Well then, take this."
       ]
     },
     {
       "ID": 10010310,
       "Entries": [
-        "ここは、まったくおかしな場所だ"
+        "We are amidst strange beings, in a strange land."
       ]
     },
     {
       "ID": 10010311,
       "Entries": [
-        "時の流れが淀んで、100年以上前の伝説がいると思えば"
+        "The flow of time itself is convoluted; with heroes centuries old\nphasing in and out."
       ]
     },
     {
       "ID": 10010312,
       "Entries": [
-        "ひどく不安定で、色んなものがすぐにずれやがる"
+        "The very fabric wavers, and relations shift and obscure."
       ]
     },
     {
       "ID": 10010313,
       "Entries": [
-        "貴公と俺の世界も、いつまで重なっているか、分からない"
+        "There's no telling how much longer your world and mine will\nremain in contact."
       ]
     },
     {
       "ID": 10010314,
       "Entries": [
-        "だが、こいつを使えば…"
+        "But, use this,"
       ]
     },
     {
       "ID": 10010315,
       "Entries": [
-        "世界のずれを超えて、協力ができる"
+        "to summon one another as spirits, cross the gaps between the\nworlds,"
       ]
     },
     {
       "ID": 10010316,
       "Entries": [
-        "霊として召喚することで、「ずれ」を渡るのさ"
+        "and engage in jolly co-operation!"
       ]
     },
     {
       "ID": 10010317,
       "Entries": [
-        "もっとも、そうしてるのは俺たちばかりじゃあないが…"
+        "Of course, we are not the only ones engaged in this."
       ]
     },
     {
       "ID": 10010318,
       "Entries": [
-        "俺は太陽の戦士、召喚のサインも、光り輝く特別製だからな"
+        "But I am a warrior of the sun! Spot my summon signature easily by\nits brilliant aura."
       ]
     },
     {
       "ID": 10010319,
       "Entries": [
-        "よーく目立つと思うぜ"
+        "If you miss it, you must be blind!"
       ]
     },
     {
       "ID": 10010320,
       "Entries": [
-        "ウワッハッハッハハ"
+        "Hah hah hah!"
       ]
     },
     {
       "ID": 10010350,
       "Entries": [
-        "…そうか。まあ、そうだろうな"
+        "Well, yes, quite understandable."
       ]
     },
     {
       "ID": 10010351,
       "Entries": [
-        "いや、すまん。困らせるつもりもなかったんだ"
+        "Not to worry. I do not wish to impose."
       ]
     },
     {
       "ID": 10010352,
       "Entries": [
-        "つまらんことを言った。笑って忘れてくれ"
+        "I was in the wrong. We'll laugh it off, shall we?"
       ]
     },
     {
       "ID": 10010353,
       "Entries": [
-        "ウワッハッハ"
+        "Hah hah hah!"
       ]
     },
     {
       "ID": 10010360,
       "Entries": [
-        "…そうか。まあ、そうだろうな"
+        "Well, yes, quite understandable."
       ]
     },
     {
       "ID": 10010361,
       "Entries": [
-        "いや、すまん。困らせるつもりもなかったんだ"
+        "Not to worry. I do not wish to impose."
       ]
     },
     {
       "ID": 10010362,
       "Entries": [
-        "つまらんことを言った。笑って忘れてくれ"
+        "I was in the wrong. We'll laugh it off, shall we?"
       ]
     },
     {
       "ID": 10010363,
       "Entries": [
-        "ウワッハッハ"
+        "Hah hah hah!"
       ]
     },
     {
       "ID": 10010400,
       "Entries": [
-        "ああ、貴公か。俺は、しばらくここで太陽を眺めていくよ"
+        "Oh, hello there. I will stay behind, to gaze at the sun."
       ]
     },
     {
       "ID": 10010401,
       "Entries": [
-        "太陽は偉大だ。すばらしい父のようだ"
+        "The sun is a wondrous body. Like a magnificent father!"
       ]
     },
     {
       "ID": 10010402,
       "Entries": [
-        "俺もいつか、あんな風にでっかく熱くなりたいんだよ…"
+        "If only I could be so grossly incandescent!"
       ]
     },
     {
       "ID": 10010500,
       "Entries": [
-        "おお、貴公。懲りずに、また声をかけてくれるとは"
+        "Oh, hello. You're still keen on speaking to me?"
       ]
     },
     {
       "ID": 10010501,
       "Entries": [
-        "もしかして、例の話、考え直してくれたのか？"
+        "Then, perhaps you have reconsidered my offer?"
       ]
     },
     {
       "ID": 10010600,
       "Entries": [
-        "グッ"
+        "Hrg!"
       ]
     },
     {
       "ID": 10010610,
       "Entries": [
-        "ウッ"
+        "Ooh!"
       ]
     },
     {
       "ID": 10010620,
       "Entries": [
-        "うおっ！"
+        "Whoa!"
       ]
     },
     {
       "ID": 10010630,
       "Entries": [
-        "何をっ！"
+        "What the...!"
       ]
     },
     {
       "ID": 10010640,
       "Entries": [
-        "むうう、貴公、どうしたのだ？"
+        "What's wrong with you?!"
       ]
     },
     {
       "ID": 10010700,
       "Entries": [
-        "言葉の通じぬ獣なら、仕方ない"
+        "If a stubborn beast you be, I have no choice!"
       ]
     },
     {
       "ID": 10010701,
       "Entries": [
-        "太陽の戦士の、責を果たそう！"
+        "A Warrior of the Sun will not just sit and take it!"
       ]
     },
     {
       "ID": 10010702,
       "Entries": [
-        "うおうりゃあああああっ！"
+        "Hrgraaah!"
       ]
     },
     {
       "ID": 10010800,
       "Entries": [
-        "き、貴公…"
+        "Why, you..."
       ]
     },
     {
       "ID": 10010801,
       "Entries": [
-        "こんなところで…"
+        "How could this...?"
       ]
     },
     {
       "ID": 10010802,
       "Entries": [
-        "俺の、太陽…"
+        "My...my sun..."
       ]
     },
     {
       "ID": 10020000,
       "Entries": [
-        "おお、貴公"
+        "Oh, there you are."
       ]
     },
     {
       "ID": 10020001,
       "Entries": [
-        "こうして直接会うのは、久しぶりだな"
+        "You've been quiet these days."
       ]
     },
     {
       "ID": 10020002,
       "Entries": [
-        "召喚は、うまく使っているか？"
+        "Smooth summoning out there?"
       ]
     },
     {
       "ID": 10020003,
       "Entries": [
-        "もし俺の、光り輝くサインを見つけたら、遠慮なく召喚してくれ"
+        "Anytime you see my brilliantly shining signature, do not hesitate\nto call upon me."
       ]
     },
     {
       "ID": 10020004,
       "Entries": [
-        "どうにも貴公を気に入っているんだ。助けになりたいのさ"
+        "You've left me with quite an impression. I would relish a chance\nto assist you."
       ]
     },
     {
       "ID": 10020100,
       "Entries": [
-        "貴公は、よく俺に話しかけてくれるな"
+        "You really are fond of chatting with me, aren't you?"
       ]
     },
     {
       "ID": 10020101,
       "Entries": [
-        "俺に付き合うなど、貴公もかなりの変人かもな"
+        "If I didn't know better, I'd think you had feelings for me!"
       ]
     },
     {
       "ID": 10020102,
       "Entries": [
-        "いや、悪い悪い。冗談だよ、冗談"
+        "Oh, no, dear me. Pretend you didn't hear that!"
       ]
     },
     {
       "ID": 10020103,
       "Entries": [
-        "ウワッハッハッハハ"
+        "Hah hah hah!"
       ]
     },
     {
       "ID": 10020200,
       "Entries": [
-        "おお、貴公か"
+        "Oh, hello there."
       ]
     },
     {
       "ID": 10020201,
       "Entries": [
-        "無事でなによりだ"
+        "I'm glad to see you alive."
       ]
     },
     {
       "ID": 10020202,
       "Entries": [
-        "…だが、貴公、随分と鍛えたものだな"
+        "...You have done well, indeed you have."
       ]
     },
     {
       "ID": 10020203,
       "Entries": [
-        "腕っ節が強く、神を敬い、何よりも心が強い"
+        "You've a strong arm, strong faith, and most importantly, a strong\nheart."
       ]
     },
     {
       "ID": 10020204,
       "Entries": [
-        "大したものだ"
+        "I am in awe, really."
       ]
     },
     {
       "ID": 10020205,
       "Entries": [
-        "うん…うん…"
+        "Yes, yes..."
       ]
     },
     {
       "ID": 10020206,
       "Entries": [
-        "どうだろう？俺と同じように、太陽の戦士にならないか？"
+        "What do you think? Why not join me, as a warrior of the Sun?"
       ]
     },
     {
       "ID": 10020207,
       "Entries": [
-        "神と太陽の名の元に仲間を守り、剣を振るう、光の騎士だ"
+        "Righteous knights, guardians of all that is good, in the name of\nthe Lord of Sunlight!"
       ]
     },
     {
       "ID": 10020208,
       "Entries": [
-        "むろん、貴公が望めばだが…どうだ？"
+        "...Only if it would please you, of course. Well?"
       ]
     },
     {
       "ID": 10020250,
       "Entries": [
-        "おお、そうか！やはりそうだろう！"
+        "Oh! Magnificent! I knew you would fancy it!"
       ]
     },
     {
       "ID": 10020251,
       "Entries": [
-        "では、早速誓約だ！少し、じっとしていてくれ…"
+        "Then, join the Covenant! Here, stay still for a moment..."
       ]
     },
     {
       "ID": 10020260,
       "Entries": [
-        "これでよし。あとは、そこにある太陽の祭壇で、祈ってみてくれ"
+        "And there we are. Now, just say a prayer at the Altar of\nSunlight, right there."
       ]
     },
     {
       "ID": 10020261,
       "Entries": [
-        "貴公にも、太陽の力が分かるはずさ"
+        "Then you shall know the brilliance of our Sun."
       ]
     },
     {
       "ID": 10020300,
       "Entries": [
-        "…そうか。まあ、信仰は人それぞれだ。太陽以外の神もある"
+        "Yes, well, each has one's beliefs."
       ]
     },
     {
       "ID": 10020301,
       "Entries": [
-        "もし、気が変わったら、また声をかけてくれ"
+        "But if you change your mind, the offer is open."
       ]
     },
     {
       "ID": 10020400,
       "Entries": [
-        "おお、貴公。まだいたのか"
+        "Oh, hello there. Still here?"
       ]
     },
     {
       "ID": 10020401,
       "Entries": [
-        "それにしても、頼もしい仲間が増えて、俺も誇らしいぜ"
+        "I could not hope for a braver companion than you!"
       ]
     },
     {
       "ID": 10020402,
       "Entries": [
-        "ウワッハッハッハハ"
+        "Gah hah hah hah hah!"
       ]
     },
     {
       "ID": 10020500,
       "Entries": [
-        "おお、貴公か"
+        "Oh, hello there."
       ]
     },
     {
       "ID": 10020501,
       "Entries": [
-        "どうした？もしかして、例の話、気が変わったのか？"
+        "What is it? Have you changed your mind about my offer?"
       ]
     },
     {
       "ID": 10020600,
       "Entries": [
-        "…！あ、ああ、貴公か"
+        "Hmm! Ah, oh...hello there."
       ]
     },
     {
       "ID": 10020601,
       "Entries": [
-        "すまない、少し考え事をしていたんだ…どうにも、うまくいかなくてな…"
+        "Forgive me, I was just pondering...about my poor fortune."
       ]
     },
     {
       "ID": 10020602,
       "Entries": [
-        "アノール・ロンドでも、日陰の病み村でも、俺の太陽は見つからなかった"
+        "I did not find my own sun, not in Anor Londo, nor in Twilight\nBlighttown."
       ]
     },
     {
       "ID": 10020603,
       "Entries": [
-        "後は、廃都イザリスか、それとも死の王の墓場か…そんなところに、俺の太陽があるんだろうか…"
+        "Where else might my sun be? Lost Izalith, or the Tomb of the\nGravelord...?"
       ]
     },
     {
       "ID": 10020604,
       "Entries": [
-        "勿論、諦めたわけじゃあない。俺は、このために不死にすらなったんだ"
+        "But I cannot give up. I became Undead to pursue this!"
       ]
     },
     {
       "ID": 10020605,
       "Entries": [
-        "だが、あの空に太陽を見ると、思うことがあるんだ"
+        "But when I peer at the Sun up above, it occurs to me..."
       ]
     },
     {
       "ID": 10020606,
       "Entries": [
-        "実は俺は、皆が、笑って囃すように…目玉が見えない、とんでもない愚か者なんじゃあないかってな…"
+        "What if I am seen as a laughing stock, as a blind fool without\nreason?"
       ]
     },
     {
       "ID": 10020607,
       "Entries": [
-        "だとしたら、ひどく滑稽なことだなあ…"
+        "Well, I suppose they wouldn't be far off!"
       ]
     },
     {
       "ID": 10020608,
       "Entries": [
-        "ウワッハッハ"
+        "Hah hah hah!"
       ]
     },
     {
       "ID": 10020700,
       "Entries": [
-        "おお、貴公か"
+        "Oh, hello there."
       ]
     },
     {
       "ID": 10020701,
       "Entries": [
-        "すごいものだろう？太陽の力は"
+        "Exhilarating, is it not? The power of the Sun!"
       ]
     },
     {
       "ID": 10020702,
       "Entries": [
-        "頼もしい仲間が増えて、俺も誇らしいぜ"
+        "I am blessed to have found such a brave companion!"
       ]
     },
     {
       "ID": 10020703,
       "Entries": [
-        "ウワッハッハッハハ"
+        "Hah hah hah!"
       ]
     },
     {
       "ID": 10020800,
       "Entries": [
-        "グッ"
+        "Hrg!"
       ]
     },
     {
       "ID": 10020810,
       "Entries": [
-        "ウッ"
+        "Ooh!"
       ]
     },
     {
       "ID": 10020820,
       "Entries": [
-        "うおっ！"
+        "Whoa!"
       ]
     },
     {
       "ID": 10020830,
       "Entries": [
-        "何をっ！"
+        "What the...!"
       ]
     },
     {
       "ID": 10020840,
       "Entries": [
-        "むうう、貴公、どうしたのだ？"
+        "What's wrong with you?!"
       ]
     },
     {
       "ID": 10020900,
       "Entries": [
-        "言葉の通じぬ獣なら、仕方ない"
+        "If a stubborn beast you be, I have no choice!"
       ]
     },
     {
       "ID": 10020901,
       "Entries": [
-        "太陽の戦士の、責を果たそう！"
+        "A Warrior of the Sun will not just sit and take it!"
       ]
     },
     {
       "ID": 10020902,
       "Entries": [
-        "うおうりゃあああああっ！"
+        "Hrgraaah!"
       ]
     },
     {
       "ID": 10021000,
       "Entries": [
-        "き、貴公…"
+        "Why, you..."
       ]
     },
     {
       "ID": 10021001,
       "Entries": [
-        "こんなところで…"
+        "How could this...?"
       ]
     },
     {
       "ID": 10021002,
       "Entries": [
-        "俺の、太陽…"
+        "My...my sun..."
       ]
     },
     {
       "ID": 10022000,
       "Entries": [
-        "おお、貴公"
+        "Oh, there you are."
       ]
     },
     {
       "ID": 10022001,
       "Entries": [
-        "こうして直接会うのは、久しぶりだな"
+        "You've been quiet these days."
       ]
     },
     {
       "ID": 10022002,
       "Entries": [
-        "召喚は、うまく使っているか？"
+        "Smooth summoning out there?"
       ]
     },
     {
       "ID": 10022003,
       "Entries": [
-        "もし俺の、光り輝くサインを見つけたら、遠慮なく召喚してくれ"
+        "Anytime you see my brilliantly shining signature, do not hesitate\nto call upon me."
       ]
     },
     {
       "ID": 10022004,
       "Entries": [
-        "どうにも貴公を気に入っているんだ。助けになりたいのさ"
+        "You've left me with quite an impression. I would relish a chance\nto assist you."
       ]
     },
     {
       "ID": 10022100,
       "Entries": [
-        "貴公は、よく俺に話しかけてくれるな"
+        "You really are fond of chatting with me, aren't you?"
       ]
     },
     {
       "ID": 10022101,
       "Entries": [
-        "俺に付き合うなど、貴公もかなりの変人かもな"
+        "If I didn't know better, I'd think you had feelings for me!"
       ]
     },
     {
       "ID": 10022102,
       "Entries": [
-        "いや、悪い悪い。冗談だよ、冗談"
+        "Oh, no, dear me. Pretend you didn't hear that!"
       ]
     },
     {
       "ID": 10022103,
       "Entries": [
-        "ウワッハッハッハハ"
+        "Hah hah hah!"
       ]
     },
     {
       "ID": 10022200,
       "Entries": [
-        "おお、貴公か"
+        "Oh, hello there."
       ]
     },
     {
       "ID": 10022201,
       "Entries": [
-        "無事でなによりだ"
+        "I'm glad to see you alive."
       ]
     },
     {
       "ID": 10022202,
       "Entries": [
-        "…だが、貴公、随分と鍛えたものだな"
+        "...You have done well, indeed you have."
       ]
     },
     {
       "ID": 10022203,
       "Entries": [
-        "腕っ節が強く、神を敬い、何よりも心が強い"
+        "You've a strong arm, strong faith, and most importantly, a strong\nheart."
       ]
     },
     {
       "ID": 10022204,
       "Entries": [
-        "大したものだ"
+        "I am in awe, really."
       ]
     },
     {
       "ID": 10022205,
       "Entries": [
-        "うん…うん…"
+        "Yes, yes..."
       ]
     },
     {
       "ID": 10022206,
       "Entries": [
-        "どうだろう？俺と同じように、太陽の戦士にならないか？"
+        "What do you think? Why not join me, as a warrior of the Sun?"
       ]
     },
     {
       "ID": 10022207,
       "Entries": [
-        "神と太陽の名の元に仲間を守り、剣を振るう、光の騎士だ"
+        "Righteous knights, guardians of all that is good, in the name of\nthe Lord of Sunlight!"
       ]
     },
     {
       "ID": 10022208,
       "Entries": [
-        "むろん、貴公が望めばだが…どうだ？"
+        "...Only if it would please you, of course. Well?"
       ]
     },
     {
       "ID": 10022250,
       "Entries": [
-        "おお、そうか！やはりそうだろう！"
+        "Oh! Magnificent! I knew you would fancy it!"
       ]
     },
     {
       "ID": 10022251,
       "Entries": [
-        "では、早速誓約だ！少し、じっとしていてくれ…"
+        "Then, join the Covenant! Here, stay still for a moment..."
       ]
     },
     {
       "ID": 10022260,
       "Entries": [
-        "これでよし。あとは、そこにある太陽の祭壇で、祈ってみてくれ"
+        "And there we are. Now, just say a prayer at the Altar of\nSunlight, right there."
       ]
     },
     {
       "ID": 10022261,
       "Entries": [
-        "貴公にも、太陽の力が分かるはずさ"
+        "Then you shall know the brilliance of our Sun."
       ]
     },
     {
       "ID": 10022300,
       "Entries": [
-        "…そうか。まあ、信仰は人それぞれだ。太陽以外の神もある"
+        "Yes, well, each has one's beliefs."
       ]
     },
     {
       "ID": 10022301,
       "Entries": [
-        "もし、気が変わったら、また声をかけてくれ"
+        "But if you change your mind, the offer is open."
       ]
     },
     {
       "ID": 10022400,
       "Entries": [
-        "おお、貴公。まだいたのか"
+        "Oh, hello there. Still here?"
       ]
     },
     {
       "ID": 10022401,
       "Entries": [
-        "それにしても、頼もしい仲間が増えて、俺も誇らしいぜ"
+        "I could not hope for a braver companion than you!"
       ]
     },
     {
       "ID": 10022402,
       "Entries": [
-        "ウワッハッハッハハ"
+        "Gah hah hah hah hah!"
       ]
     },
     {
       "ID": 10022500,
       "Entries": [
-        "おお、貴公か"
+        "Oh, hello there."
       ]
     },
     {
       "ID": 10022501,
       "Entries": [
-        "どうした？もしかして、例の話、気が変わったのか？"
+        "What is it? Have you changed your mind about my offer?"
       ]
     },
     {
       "ID": 10022600,
       "Entries": [
-        "…！あ、ああ、貴公か"
+        "Hmm! Ah, oh...hello there."
       ]
     },
     {
       "ID": 10022601,
       "Entries": [
-        "すまない、少し考え事をしていたんだ…どうにも、うまくいかなくてな…"
+        "Forgive me, I was just pondering...about my poor fortune."
       ]
     },
     {
       "ID": 10022602,
       "Entries": [
-        "アノール・ロンドでも、日陰の病み村でも、俺の太陽は見つからなかった"
+        "I did not find my own sun, not in Anor Londo, nor in Twilight\nBlighttown."
       ]
     },
     {
       "ID": 10022603,
       "Entries": [
-        "後は、廃都イザリスか、それとも死の王の墓場か…そんなところに、俺の太陽があるんだろうか…"
+        "Where else might my sun be? Lost Izalith, or the Tomb of the\nGravelord...?"
       ]
     },
     {
       "ID": 10022604,
       "Entries": [
-        "勿論、諦めたわけじゃあない。俺は、このために不死にすらなったんだ"
+        "But I cannot give up. I became Undead to pursue this!"
       ]
     },
     {
       "ID": 10022605,
       "Entries": [
-        "だが、あの空に太陽を見ると、思うことがあるんだ"
+        "But when I peer at the Sun up above, it occurs to me..."
       ]
     },
     {
       "ID": 10022606,
       "Entries": [
-        "実は俺は、皆が、笑って囃すように…目玉が見えない、とんでもない愚か者なんじゃあないかってな…"
+        "What if I am seen as a laughing stock, as a blind fool without\nreason?"
       ]
     },
     {
       "ID": 10022607,
       "Entries": [
-        "だとしたら、ひどく滑稽なことだなあ…"
+        "Well, I suppose they wouldn't be far off!"
       ]
     },
     {
       "ID": 10022608,
       "Entries": [
-        "ウワッハッハ"
+        "Hah hah hah!"
       ]
     },
     {
       "ID": 10022700,
       "Entries": [
-        "おお、貴公か"
+        "Oh, hello there."
       ]
     },
     {
       "ID": 10022701,
       "Entries": [
-        "すごいものだろう？太陽の力は"
+        "Exhilarating, is it not? The power of the Sun!"
       ]
     },
     {
       "ID": 10022702,
       "Entries": [
-        "頼もしい仲間が増えて、俺も誇らしいぜ"
+        "I am blessed to have found such a brave companion!"
       ]
     },
     {
       "ID": 10022703,
       "Entries": [
-        "ウワッハッハッハハ"
+        "Hah hah hah!"
       ]
     },
     {
       "ID": 10022800,
       "Entries": [
-        "グッ"
+        "Hrg!"
       ]
     },
     {
       "ID": 10022810,
       "Entries": [
-        "ウッ"
+        "Ooh!"
       ]
     },
     {
       "ID": 10022820,
       "Entries": [
-        "うおっ！"
+        "Whoa!"
       ]
     },
     {
       "ID": 10022830,
       "Entries": [
-        "何をっ！"
+        "What the...!"
       ]
     },
     {
       "ID": 10022840,
       "Entries": [
-        "むうう、貴公、どうしたのだ？"
+        "What's wrong with you?!"
       ]
     },
     {
       "ID": 10022900,
       "Entries": [
-        "言葉の通じぬ獣なら、仕方ない"
+        "If a stubborn beast you be, I have no choice!"
       ]
     },
     {
       "ID": 10022901,
       "Entries": [
-        "太陽の戦士の、責を果たそう！"
+        "A Warrior of the Sun will not just sit and take it!"
       ]
     },
     {
       "ID": 10022902,
       "Entries": [
-        "うおうりゃあああああっ！"
+        "Hrgraaah!"
       ]
     },
     {
       "ID": 10023000,
       "Entries": [
-        "き、貴公…"
+        "Why, you..."
       ]
     },
     {
       "ID": 10023001,
       "Entries": [
-        "こんなところで…"
+        "How could this...?"
       ]
     },
     {
       "ID": 10023002,
       "Entries": [
-        "俺の、太陽…"
+        "My...my sun..."
       ]
     },
     {
       "ID": 10030000,
       "Entries": [
-        "…う、う、うううううっ…"
+        "...Hrg, rg...Arrrgh..."
       ]
     },
     {
       "ID": 10030001,
       "Entries": [
-        "…ついに、ついに、手に入れたぞ、入れたんだ…"
+        "...Finally, I have found it, I have!..."
       ]
     },
     {
       "ID": 10030002,
       "Entries": [
-        "…俺の…俺の太陽、俺が太陽だ…"
+        "...My very own sun...I...am the sun!..."
       ]
     },
     {
       "ID": 10030003,
       "Entries": [
-        "…やった…やったぞ…"
+        "...I've done it...I have..."
       ]
     },
     {
       "ID": 10030004,
       "Entries": [
-        "…どうだっ…俺は、やったんだ…"
+        "...Yes, I did it...I did!..."
       ]
     },
     {
       "ID": 10030005,
       "Entries": [
-        "…お、おお…"
+        "...Ohh, ohhh..."
       ]
     },
     {
       "ID": 10030006,
       "Entries": [
-        "…おおおおおおおおっ！"
+        "...Hrgrraaaooogh!..."
       ]
     },
     {
       "ID": 10030100,
       "Entries": [
-        "…ああ、ダメだ…"
+        "...Ahh, it's over..."
       ]
     },
     {
       "ID": 10030101,
       "Entries": [
-        "…俺の、俺の太陽が、沈む…"
+        "...My Sun...it's setting..."
       ]
     },
     {
       "ID": 10030102,
       "Entries": [
-        "…暗い、まっくらだ…"
+        "...It's dark, so dark..."
       ]
     },
     {
       "ID": 10030200,
       "Entries": [
-        "グッ"
+        "Hrg!"
       ]
     },
     {
       "ID": 10030210,
       "Entries": [
-        "ウッ"
+        "Ooh!"
       ]
     },
     {
       "ID": 10030220,
       "Entries": [
-        "うおっ！"
+        "Whoa!"
       ]
     },
     {
       "ID": 10030230,
       "Entries": [
-        "何をっ！"
+        "What the...!"
       ]
     },
     {
       "ID": 10030240,
       "Entries": [
-        "むうう、貴公、どうしたのだ？"
+        "What's wrong with you?!"
       ]
     },
     {
       "ID": 10030300,
       "Entries": [
-        "言葉の通じぬ獣なら、仕方ない"
+        "If a stubborn beast you be, I have no choice!"
       ]
     },
     {
       "ID": 10030301,
       "Entries": [
-        "太陽の戦士の、責を果たそう！"
+        "A Warrior of the Sun will not just sit and take it!"
       ]
     },
     {
       "ID": 10030302,
       "Entries": [
-        "うおうりゃあああああっ！"
+        "Hrgraaah!"
       ]
     },
     {
       "ID": 10030400,
       "Entries": [
-        "き、貴公…"
+        "Why, you..."
       ]
     },
     {
       "ID": 10030401,
       "Entries": [
-        "こんなところで…"
+        "How could this...?"
       ]
     },
     {
       "ID": 10030402,
       "Entries": [
-        "俺の、太陽…"
+        "My...my sun..."
       ]
     },
     {
       "ID": 10040000,
       "Entries": [
-        "すべて、嘘だったのか…俺は、ずっと、ずっと、そのためだけに…"
+        "Was it all a lie? Have I done this all, for nothing?"
       ]
     },
     {
       "ID": 10040001,
       "Entries": [
-        "ああ、俺の太陽…どうしたらいいんだ…どうしたら…"
+        "Oh, my dear sun...What now, what should I do...?"
       ]
     },
     {
       "ID": 10040002,
       "Entries": [
-        "…太陽、俺の太陽よう…"
+        "...My sun, my dear, dear sun..."
       ]
     },
     {
       "ID": 10040010,
       "Entries": [
-        "…なぜだ…なぜだ？"
+        "...Why?...Why?..."
       ]
     },
     {
       "ID": 10040011,
       "Entries": [
-        "なぜ、これほどに探しても…見つからないんだ…"
+        "After all this searching, I still cannot find it..."
       ]
     },
     {
       "ID": 10040100,
       "Entries": [
-        "グッ"
+        "Hrg!"
       ]
     },
     {
       "ID": 10040110,
       "Entries": [
-        "ウッ"
+        "Ooh!"
       ]
     },
     {
       "ID": 10040120,
       "Entries": [
-        "うおっ！"
+        "Whoa!"
       ]
     },
     {
       "ID": 10040130,
       "Entries": [
-        "何をっ！"
+        "What the...!"
       ]
     },
     {
       "ID": 10040140,
       "Entries": [
-        "むうう、貴公、どうしたのだ？"
+        "What's wrong with you?!"
       ]
     },
     {
       "ID": 10040200,
       "Entries": [
-        "言葉の通じぬ獣なら、仕方ない"
+        "If a stubborn beast you be, I have no choice!"
       ]
     },
     {
       "ID": 10040201,
       "Entries": [
-        "太陽の戦士の、責を果たそう！"
+        "A Warrior of the Sun will not just sit and take it!"
       ]
     },
     {
       "ID": 10040202,
       "Entries": [
-        "うおうりゃあああああっ！"
+        "Hrgraaah!"
       ]
     },
     {
       "ID": 10040300,
       "Entries": [
-        "き、貴公…"
+        "Why, you..."
       ]
     },
     {
       "ID": 10040301,
       "Entries": [
-        "こんなところで…"
+        "How could this...?"
       ]
     },
     {
       "ID": 10040302,
       "Entries": [
-        "俺の、太陽…"
+        "My...my sun..."
       ]
     },
     {
       "ID": 11000000,
       "Entries": [
-        "ほう…久しぶりの巡礼者か"
+        "Well, you are a rare visitor."
       ]
     },
     {
       "ID": 11000001,
       "Entries": [
-        "棄てられたアノール・ロンドにようこそ。不死の勇者よ"
+        "Welcome to the lost city of Anor Londo, chosen Undead."
       ]
     },
     {
       "ID": 11000002,
       "Entries": [
-        "目当てなら、ここを出て、真っ直ぐ先にある"
+        "If you seek Lord Gwyn's old keep,"
       ]
     },
     {
       "ID": 11000003,
       "Entries": [
-        "大王グウィンの、かつての城館だ"
+        "exit here and head straight yonder."
       ]
     },
     {
       "ID": 11000004,
       "Entries": [
-        "貴公が本当の勇者なら、そこで天啓を得るも適うだろうさ"
+        "If you are the chosen one, a revelation shall visit thee."
       ]
     },
     {
       "ID": 11000005,
       "Entries": [
-        "…後は、貴公次第だ…"
+        "...What follows thereafter, depends upon you..."
       ]
     },
     {
       "ID": 11000020,
       "Entries": [
-        "棄てられたアノール・ロンドにようこそ。不死の勇者よ"
+        "Welcome to the lost city of Anor Londo, chosen Undead."
       ]
     },
     {
       "ID": 11000021,
       "Entries": [
-        "ほう…貴公、天啓を得たか"
+        "Hmm. So, you have received a revelation?"
       ]
     },
     {
       "ID": 11000022,
       "Entries": [
-        "よいことだな。では、私も期待していよう"
+        "Very auspicious. I hope for the best."
       ]
     },
     {
       "ID": 11000023,
       "Entries": [
-        "貴公が…彼女の望みを適えんことを"
+        "I pray that through you, Her wish will be granted."
       ]
     },
     {
       "ID": 11000100,
       "Entries": [
-        "ほう…貴公、まだ無事か。大したものだ"
+        "Hmm. You have survived. Impressive."
       ]
     },
     {
       "ID": 11000101,
       "Entries": [
-        "必要なら、ゆっくりと休むといい"
+        "If you require rest, now is the time."
       ]
     },
     {
       "ID": 11000102,
       "Entries": [
-        "そのための篝火なのだからな"
+        "That is, after all, what the bonfire is for."
       ]
     },
     {
       "ID": 11000120,
       "Entries": [
-        "必要なら、ゆっくりと休むといい"
+        "If you require rest, now is the time."
       ]
     },
     {
       "ID": 11000121,
       "Entries": [
-        "そのための篝火なのだからな"
+        "That is, after all, what the bonfire is for."
       ]
     },
     {
       "ID": 11000200,
       "Entries": [
-        "ほう…貴公、天啓を得たか"
+        "Hmm. So, you have received a revelation?"
       ]
     },
     {
       "ID": 11000201,
       "Entries": [
-        "よいことだな。では、私も期待していよう"
+        "Very auspicious. I hope for the best."
       ]
     },
     {
       "ID": 11000202,
       "Entries": [
-        "貴公が…彼女の望みを適えんことを"
+        "I pray that through you, Her wish will be granted."
       ]
     },
     {
       "ID": 11000300,
       "Entries": [
-        "ほう…戻ったか。よいことだな"
+        "Hmm. You have made it back. Very well."
       ]
     },
     {
       "ID": 11000301,
       "Entries": [
-        "まあ、ゆっくりと休むといい"
+        "Go ahead, you may rest here."
       ]
     },
     {
       "ID": 11000302,
       "Entries": [
-        "不死とて、休息の暖は必要だろう…"
+        "Even an Undead requires repose."
       ]
     },
     {
       "ID": 11000320,
       "Entries": [
-        "ほう…戻ったか。懐かしいな"
+        "Hmm. You have made it back. You were gone so long."
       ]
     },
     {
       "ID": 11000321,
       "Entries": [
-        "まあ、ゆっくりと休むといい"
+        "Go ahead, you may rest here."
       ]
     },
     {
       "ID": 11000322,
       "Entries": [
-        "不死とて、休息の暖は必要だろう…"
+        "Even an Undead requires repose."
       ]
     },
     {
       "ID": 11000340,
       "Entries": [
-        "まあ、ゆっくりと休むといい"
+        "Go ahead, you may rest here."
       ]
     },
     {
       "ID": 11000341,
       "Entries": [
-        "不死とて、休息の暖は必要だろう…"
+        "Even an Undead requires repose."
       ]
     },
     {
       "ID": 11000400,
       "Entries": [
-        "ん、なんだ？"
+        "Hm, what is it?"
       ]
     },
     {
       "ID": 11000401,
       "Entries": [
-        "私？私は…そうだな、この篝火の守人さ"
+        "What am I? Well...I am the Keeper of the bonfire."
       ]
     },
     {
       "ID": 11000402,
       "Entries": [
-        "棄てられた都とて、勇者に導きくらいは必要だろう？"
+        "If not for me, what beacon would there be in this lost city?"
       ]
     },
     {
       "ID": 11000403,
       "Entries": [
-        "貴公には分からないかもしれないが…背中を送るのも悪くないのさ"
+        "A gatekeeper, and a guide; that is my calling."
       ]
     },
     {
       "ID": 11000500,
       "Entries": [
-        "なっ！"
+        "What!"
       ]
     },
     {
       "ID": 11000510,
       "Entries": [
-        "貴公！なにを！"
+        "How dare you!"
       ]
     },
     {
       "ID": 11000520,
       "Entries": [
-        "クッ！"
+        "Hrk!"
       ]
     },
     {
       "ID": 11000530,
       "Entries": [
-        "ウッ！"
+        "Rrgh!"
       ]
     },
     {
       "ID": 11000600,
       "Entries": [
-        "よかろう。貴公がそのつもりなら"
+        "Very well. So be it."
       ]
     },
     {
       "ID": 11000601,
       "Entries": [
-        "馬鹿を切るのも、私の役目だ"
+        "Expunging fools like you is part of my charge."
       ]
     },
     {
       "ID": 11000700,
       "Entries": [
-        "…そんな…"
+        "...But, how..."
       ]
     },
     {
       "ID": 11000701,
       "Entries": [
-        "…この男は、危険です…"
+        "...This man is a threat..."
       ]
     },
     {
       "ID": 11000702,
       "Entries": [
-        "…グウィンドリン様…"
+        "...Master Gwyndolin..."
       ]
     },
     {
       "ID": 11000750,
       "Entries": [
-        "…そんな…"
+        "...But, how..."
       ]
     },
     {
       "ID": 11000751,
       "Entries": [
-        "…この女は、危険です…"
+        "...This woman is a threat..."
       ]
     },
     {
       "ID": 11000752,
       "Entries": [
-        "…グウェンドリン様…"
+        "...Master Gwyndolin..."
       ]
     },
     {
       "ID": 11000800,
       "Entries": [
-        "残念だよ。貴公、悪くないと思えたのだがな…"
+        "Tis a pity...To think I saw potential in you..."
       ]
     },
     {
       "ID": 11000900,
       "Entries": [
-        "ほう…まさか、貴公だったか"
+        "So...It was you, was it?"
       ]
     },
     {
       "ID": 11000901,
       "Entries": [
-        "神に刃するとは、なんとも思い上がりだが…よくぞここまで辿り着いた"
+        "How dare you produce a blade upon a deity? How did you ever get\nthis far?"
       ]
     },
     {
       "ID": 11000902,
       "Entries": [
-        "せめてもの褒美だ。私がここで終わりにしてやろう"
+        "I shall end your suffering here and now. It is the least that I\ncan do."
       ]
     },
     {
       "ID": 11001000,
       "Entries": [
-        "ゆっくりと悔いるがよい。暗月の夜に見えたことを"
+        "What you saw under light of the Darkmoon shall haunt you forever."
       ]
     },
     {
       "ID": 11001100,
       "Entries": [
-        "貴公…いくのだろう…"
+        "Will you be departing soon,"
       ]
     },
     {
       "ID": 11001101,
       "Entries": [
-        "大王グウィンの火を継ぐ者か"
+        "honourable heir to Gwyn's Flame..."
       ]
     },
     {
       "ID": 11001102,
       "Entries": [
-        "すまんな…"
+        "We are humbled..."
       ]
     },
     {
       "ID": 11001103,
       "Entries": [
-        "だが我等は、貴公によってあるしかないのだ…"
+        "For we exist only with your blessing."
       ]
     },
     {
       "ID": 11001200,
       "Entries": [
-        "ほう…貴公、我らの仲間か"
+        "Oh...You are one of us."
       ]
     },
     {
       "ID": 11001201,
       "Entries": [
-        "驚いたな。だが、嬉しいよ"
+        "That is a surprise. But a pleasant one."
       ]
     },
     {
       "ID": 11001202,
       "Entries": [
-        "お互い、暗月の剣だ。よろしく頼む"
+        "We are both Blades of the Darkmoon, now."
       ]
     },
     {
       "ID": 11001203,
       "Entries": [
-        "貴公と共に戦うのは、悪くない"
+        "I shall look forward to fighting alongside you."
       ]
     },
     {
       "ID": 11001300,
       "Entries": [
-        "そういえば、白竜シースを知っているか？"
+        "Have you heard of Seath the Scaleless?"
       ]
     },
     {
       "ID": 11001301,
       "Entries": [
-        "伝承に言う、古竜の裏切り者だ"
+        "In legend, he turned against the ancient dragons."
       ]
     },
     {
       "ID": 11001302,
       "Entries": [
-        "彼は、大王グウィンの盟友となり、公爵の名を得、探求の自由を与えられ"
+        "He became Lord Gwyn's confidant, was granted dukedom, and was\nallowed to pursue his research."
       ]
     },
     {
       "ID": 11001303,
       "Entries": [
-        "巨大な書庫で、彼にない、不死のウロコの研究に没頭した"
+        "At the Regal Archives, he immersed himself in research on scales\nof immortality, the one thing that he did not have."
       ]
     },
     {
       "ID": 11001304,
       "Entries": [
-        "…だが、その研究は、やがて彼に狂気をよび"
+        "...But his very research drove him mad... "
       ]
     },
     {
       "ID": 11001305,
       "Entries": [
-        "書庫は牢となり、陰惨な実験の地と化した…"
+        "The Archives became a dungeon, a place for sinister experiments."
       ]
     },
     {
       "ID": 11001306,
       "Entries": [
-        "今や公爵の書庫は、誰近づくものもない禁域だ"
+        "Now, nobody dares even approach the duke's forbidden Archives."
       ]
     },
     {
       "ID": 11001307,
       "Entries": [
-        "ここを出て、左に向かった山の上さ"
+        "It looms over this land, high atop the mountain."
       ]
     },
     {
       "ID": 11001308,
       "Entries": [
-        "くれぐれも、うかうかと近づくなよ…"
+        "But I should warn against even an approach..."
       ]
     },
     {
       "ID": 11001400,
       "Entries": [
-        "守人の篝火は、特別なものだ"
+        "The bonfires attended by the Keepers are special."
       ]
     },
     {
       "ID": 11001401,
       "Entries": [
-        "それは、決して消えず、お互いにつながっている"
+        "They are linked to one another, and their flames never die."
       ]
     },
     {
       "ID": 11001402,
       "Entries": [
-        "もっとも、守人同士、お互い顔も知らんのだがな…"
+        "Yet never shall the Keepers of these flames meet."
       ]
     },
     {
       "ID": 12000000,
       "Entries": [
-        "…おお、君は…亡者じゃあないんだな…"
+        "...Oh, you... You're no Hollow, eh?"
       ]
     },
     {
       "ID": 12000001,
       "Entries": [
-        "…よかった…"
+        "...Thank goodness..."
       ]
     },
     {
       "ID": 12000002,
       "Entries": [
-        "…私は、もうダメだ…"
+        "...I'm done for, I'm afraid..."
       ]
     },
     {
       "ID": 12000003,
       "Entries": [
-        "…もうすぐ死ぬ。死ねばもう、正気を保てない…"
+        "...I'll die soon, then lose my sanity..."
       ]
     },
     {
       "ID": 12000004,
       "Entries": [
-        "…だから、君に、願いがある…"
+        "...I wish to ask something of you..."
       ]
     },
     {
       "ID": 12000005,
       "Entries": [
-        "…同じ不死の身だ…観念して、聞いてくれよ…"
+        "...You and I, we're both Undead... Hear me out, will you?"
       ]
     },
     {
       "ID": 12000100,
       "Entries": [
-        "…恥ずかしい話だが、願いは、私の使命だ…"
+        "...Regrettably, I have failed in my mission..."
       ]
     },
     {
       "ID": 12000101,
       "Entries": [
-        "…それを、見ず知らずの君に、託したい…"
+        "...But perhaps you can keep the torch lit..."
       ]
     },
     {
       "ID": 12000102,
       "Entries": [
-        "…私の家に、伝わっている…"
+        "...There is an old saying in my family..."
       ]
     },
     {
       "ID": 12000103,
       "Entries": [
-        "…不死とは、使命の印である…"
+        "...Thou who art Undead, art chosen..."
       ]
     },
     {
       "ID": 12000104,
       "Entries": [
-        "…その印、あらわれし者は…不死院から…古い王たちの地にいたり…"
+        "...In thine exodus from the Undead Asylum, maketh pilgrimage to\nthe land of Ancient Lords..."
       ]
     },
     {
       "ID": 12000105,
       "Entries": [
-        "…目覚ましの鐘を鳴らし、不死の使命を知れ…"
+        "...When thou ringeth the Bell of Awakening, the fate of the\nUndead thou shalt know."
       ]
     },
     {
       "ID": 12000106,
       "Entries": [
-        "…よく、聞いてくれた…これで、希望をもって、死ねるよ…"
+        "...Well, now you know...And I can die with hope in my heart..."
       ]
     },
     {
       "ID": 12000107,
       "Entries": [
-        "…ああ、それと…これも、君に託しておこう…"
+        "...Oh, one more thing...Here, take this."
       ]
     },
     {
       "ID": 12000108,
       "Entries": [
-        "…不死者の宝、エスト瓶だ…"
+        "...An Estus Flask, an Undead favourite."
       ]
     },
     {
       "ID": 12000120,
       "Entries": [
-        "…それと、これも…"
+        "...Oh, and this..."
       ]
     },
     {
       "ID": 12000140,
       "Entries": [
-        "…じゃあ、もう、さよならだ…"
+        "...Now I must bid farewell..."
       ]
     },
     {
       "ID": 12000141,
       "Entries": [
-        "…死んだ後、君を襲いたくはない…いってくれ…"
+        "...I would hate to harm you after death...So, go now..."
       ]
     },
     {
       "ID": 12000142,
       "Entries": [
-        "…ありがとうな"
+        "...And thank you..."
       ]
     },
     {
       "ID": 12000200,
       "Entries": [
-        "…そうか…"
+        "...Yes, I see..."
       ]
     },
     {
       "ID": 12000201,
       "Entries": [
-        "…まあ、そうだろうな…"
+        "...Perhaps I was too hopeful..."
       ]
     },
     {
       "ID": 12000202,
       "Entries": [
-        "…ハハッ…"
+        "...Hah hah..."
       ]
     },
     {
       "ID": 12000203,
       "Entries": [
-        "…もう、いってくれ…"
+        "...Please, leave me be..."
       ]
     },
     {
       "ID": 12000204,
       "Entries": [
-        "…長くはない…死んだ後、君を襲うかもしれない…"
+        "...I have not long to live, and I may harm you after death."
       ]
     },
     {
       "ID": 12000205,
       "Entries": [
-        "…いってくれ…"
+        "...Now, go..."
       ]
     },
     {
       "ID": 12000300,
       "Entries": [
-        "グウッ…"
+        "Hrggkt..."
       ]
     },
     {
       "ID": 12000301,
       "Entries": [
-        "な…ぜ…"
+        "But...why..."
       ]
     },
     {
       "ID": 12000400,
       "Entries": [
-        "…鍵は、そこにある…"
+        "...The key is there..."
       ]
     },
     {
       "ID": 12000401,
       "Entries": [
-        "…はやく、きてくれ…"
+        "...Please, come quickly..."
       ]
     },
     {
       "ID": 12000402,
       "Entries": [
-        "…それが、君の運命だ…"
+        "...It is your fate..."
       ]
     },
     {
       "ID": 12000500,
       "Entries": [
-        "…恥ずかしい話だが、願いは、私の使命だ…"
+        "...Regrettably, I have failed in my mission..."
       ]
     },
     {
       "ID": 12000501,
       "Entries": [
-        "…それを、見ず知らずの君に、託したい…"
+        "...But perhaps you can keep the torch lit..."
       ]
     },
     {
       "ID": 12000502,
       "Entries": [
-        "…私の家に、伝わっている…"
+        "...There is an old saying in my family..."
       ]
     },
     {
       "ID": 12000503,
       "Entries": [
-        "…不死とは、使命の印である…"
+        "...Thou who art Undead, art chosen..."
       ]
     },
     {
       "ID": 12000504,
       "Entries": [
-        "…その印、あらわれし者は…不死院から…古い王たちの地にいたり…"
+        "...In thine exodus from the Undead Asylum, maketh pilgrimage to\nthe land of Ancient Lords..."
       ]
     },
     {
       "ID": 12000505,
       "Entries": [
-        "…目覚ましの鐘を鳴らし、不死の使命を知れ…"
+        "...When thou ringeth the Bell of Awakening, the fate of the\nUndead thou shalt know."
       ]
     },
     {
       "ID": 12000506,
       "Entries": [
-        "…よく、聞いてくれた…これで、希望をもって、死ねるよ…"
+        "...Well, now you know...And I can die with hope in my heart..."
       ]
     },
     {
       "ID": 12000507,
       "Entries": [
-        "…ああ、それと…これも、君に託しておこう…"
+        "...Oh, one more thing...Here, take this."
       ]
     },
     {
       "ID": 12000520,
       "Entries": [
-        "…じゃあ、もう、さよならだ…"
+        "...Now I must bid farewell..."
       ]
     },
     {
       "ID": 12000521,
       "Entries": [
-        "…死んだ後、君を襲いたくはない…いってくれ…"
+        "...I would hate to harm you after death...So, go now..."
       ]
     },
     {
       "ID": 12000522,
       "Entries": [
-        "…ありがとうな"
+        "...And thank you..."
       ]
     },
     {
       "ID": 12010000,
       "Entries": [
-        "はじめまして"
+        "A pleasure to meet you."
       ]
     },
     {
       "ID": 12010001,
       "Entries": [
-        "君のことは、老フラムトから聞いているよ"
+        "Sage Frampt has spoken to me about you."
       ]
     },
     {
       "ID": 12010002,
       "Entries": [
-        "私は、アストラのオスカル"
+        "I am Oscar of Astora."
       ]
     },
     {
       "ID": 12010003,
       "Entries": [
-        "目覚ましの鐘を鳴らした君に、礼が言いたかったんだ"
+        "I wish to thank you for ringing the Bell of Awakening."
       ]
     },
     {
       "ID": 12010004,
       "Entries": [
-        "老フラムトの使命は、私が受けた"
+        "I have received the word of Sage Frampt."
       ]
     },
     {
       "ID": 12010005,
       "Entries": [
-        "こちらはもう、大丈夫。君は、君の理由に集中してくれ"
+        "I will be fine. You ought to focus on yourself."
       ]
     },
     {
       "ID": 12010006,
       "Entries": [
-        "お互い、己の使命を果たそうじゃないか"
+        "May we each fulfil our respective purposes!"
       ]
     },
     {
       "ID": 12010100,
       "Entries": [
-        "私は、もうすぐ出発する"
+        "I am preparing to leave."
       ]
     },
     {
       "ID": 12010101,
       "Entries": [
-        "老フラムトの助言に従い、センの古城から、アノール・ロンドを目指すんだ"
+        "I will follow Sage Frampt's instructions, and will seek Anor\nLondo by way of Sen's Fortress."
       ]
     },
     {
       "ID": 12010102,
       "Entries": [
-        "君とは、また、どこかで会えるといいな"
+        "I hope that we meet again somewhere, one day."
       ]
     },
     {
       "ID": 12010200,
       "Entries": [
-        "はじめまして"
+        "A pleasure to meet you."
       ]
     },
     {
       "ID": 12010201,
       "Entries": [
-        "君のことは、老フラムトから聞いているよ"
+        "Sage Frampt has spoken to me about you."
       ]
     },
     {
       "ID": 12010202,
       "Entries": [
-        "私は、アストラのオスカル"
+        "I am Oscar of Astora."
       ]
     },
     {
       "ID": 12010203,
       "Entries": [
-        "目覚ましの鐘を鳴らし、老フラムトの使命を受けたのだろう？"
+        "I am told that you rang the Bell of Awakening, and received the\nword of Frampt."
       ]
     },
     {
       "ID": 12010204,
       "Entries": [
-        "素晴らしいことだ。期待しているよ"
+        "That is a wonderful thing. We are all counting on you."
       ]
     },
     {
       "ID": 12010205,
       "Entries": [
-        "私も、君のような使命に出会いたいものだ"
+        "I only wish that I had such a purpose."
       ]
     },
     {
       "ID": 12010300,
       "Entries": [
-        "私は、もうすぐ出発する"
+        "I am preparing to leave."
       ]
     },
     {
       "ID": 12010301,
       "Entries": [
-        "ずっとここにいても、仕方ないからな。自分の使命を探してみる"
+        "I cannot just stay here. I must find my own purpose."
       ]
     },
     {
       "ID": 12010302,
       "Entries": [
-        "君とは、また、どこかで会えるといいな"
+        "I hope that we meet again somewhere, one day."
       ]
     },
     {
       "ID": 12020000,
       "Entries": [
-        "おお、君か！久しぶりだな、無事でなによりだ"
+        "Well, how long has it been? Glad to see you safe."
       ]
     },
     {
       "ID": 12020001,
       "Entries": [
-        "だが、気をつけたまえ"
+        "You must be the same as I; in search of the grave of Sir\nArtorias."
       ]
     },
     {
       "ID": 12020002,
       "Entries": [
-        "ここにきたということは、目的は同じ、騎士アルトリウスの墓だろうが…"
+        "But, be careful."
       ]
     },
     {
       "ID": 12020003,
       "Entries": [
-        "この森は、手練の盗賊団の縄張りだ"
+        "This forest is the territory of a fierce band of thieves."
       ]
     },
     {
       "ID": 12020004,
       "Entries": [
-        "墓を目指す者は、すべて奴らに狩られてしまうんだ…"
+        "They assault any and all who seek the graves."
       ]
     },
     {
       "ID": 12020100,
       "Entries": [
-        "…どうだろう？私と組む気はないか？"
+        "...What if we were to join forces? How about that?"
       ]
     },
     {
       "ID": 12020101,
       "Entries": [
-        "君と私が協力すれば、あるいは、盗賊団を退けられるかもしれない"
+        "If we worked together, we may escape the bandits."
       ]
     },
     {
       "ID": 12020102,
       "Entries": [
-        "悪い話ではないと思うが？"
+        "Does that appeal to you?"
       ]
     },
     {
       "ID": 12020200,
       "Entries": [
-        "わかった"
+        "Very well."
       ]
     },
     {
       "ID": 12020201,
       "Entries": [
-        "では、お互い気を緩めずにいこう"
+        "Let us keep our wits about us."
       ]
     },
     {
       "ID": 12020202,
       "Entries": [
-        "誰かに背中を預けるなんて、久しぶりだ…"
+        "One can always do with another pair of eyes..."
       ]
     },
     {
       "ID": 12020300,
       "Entries": [
-        "そうか…"
+        "Yes, I see..."
       ]
     },
     {
       "ID": 12020301,
       "Entries": [
-        "まあ、仕方ない。またどこかで会おう"
+        "No matter. May we meet again."
       ]
     },
     {
       "ID": 12020302,
       "Entries": [
-        "君の幸運を祈るよ"
+        "I pray for your success."
       ]
     },
     {
       "ID": 12020400,
       "Entries": [
-        "どうやら、終わったようだな…"
+        "Things appear to have settled."
       ]
     },
     {
       "ID": 12020401,
       "Entries": [
-        "君と組んで正解だった。ありがとう"
+        "I was right to partner with you. Thank you."
       ]
     },
     {
       "ID": 12020402,
       "Entries": [
-        "もう、一緒に行動する必要もあるまい"
+        "We don't need to band together any more."
       ]
     },
     {
       "ID": 12020403,
       "Entries": [
-        "私は、少し休んでいくよ…"
+        "I will have a short rest here."
       ]
     },
     {
       "ID": 12020404,
       "Entries": [
-        "よければ、先に行くといい"
+        "Feel free to go on ahead."
       ]
     },
     {
       "ID": 12030000,
       "Entries": [
-        "…やっぱり君か…なんとなく、そんな気はしていた…"
+        "...So, it was you...I had a feeling..."
       ]
     },
     {
       "ID": 12030001,
       "Entries": [
-        "私は、使命により君を殺す…"
+        "I shall destroy you, as fate has commanded me..."
       ]
     },
     {
       "ID": 12030002,
       "Entries": [
-        "闇撫でカアスに従う愚か者…"
+        "Foolish pawn of Darkstalker Kaathe..."
       ]
     },
     {
       "ID": 12030003,
       "Entries": [
-        "闇の王よ…"
+        "And fiendish Dark Lord..."
       ]
     },
     {
       "ID": 12030100,
       "Entries": [
-        "…待っていたぞ…"
+        "...I have waited for thee..."
       ]
     },
     {
       "ID": 12030101,
       "Entries": [
-        "…フラムトに誑かされた、神の奴隷…"
+        "...Foolish slave of the Gods, and pawn of Frampt..."
       ]
     },
     {
       "ID": 12030102,
       "Entries": [
-        "…私は、君を殺して…"
+        "...I will kill you..."
       ]
     },
     {
       "ID": 12030103,
       "Entries": [
-        "…真実の、闇の王となろう…"
+        "...And become the true Dark Lord..."
       ]
     },
     {
       "ID": 13000000,
       "Entries": [
-        "ほう、貴公、まさかまともな人とは…珍しいことだ"
+        "Mm, you seem quite lucid! A rare thing in these times."
       ]
     },
     {
       "ID": 13000001,
       "Entries": [
-        "私はローガン。見ての通りの囚われの身だ"
+        "I am Logan. I'm a bit cooped up, as you can see."
       ]
     },
     {
       "ID": 13000002,
       "Entries": [
-        "どうだ、貴公、私を解放してくれぬか"
+        "I have a bright idea. Suppose you set me free?"
       ]
     },
     {
       "ID": 13000003,
       "Entries": [
-        "只の老人、碌な礼もできぬが…私の知識、魔術ならば、教授できよう"
+        "I'm old and empty-handed, but I could repay you with knowledge,\nand sorcery."
       ]
     },
     {
       "ID": 13000004,
       "Entries": [
-        "ここは退屈にすぎる。もう飽き飽きなのだよ"
+        "This place is melting my mind. The inactivity is repressive!"
       ]
     },
     {
       "ID": 13000100,
       "Entries": [
-        "おお、貴公、ありがとう。助かった"
+        "Oh, heavens, thank you. I'm saved."
       ]
     },
     {
       "ID": 13000101,
       "Entries": [
-        "さて、このまま旅を続けるもよいのだが…"
+        "And, I'd love to resume my travels,"
       ]
     },
     {
       "ID": 13000102,
       "Entries": [
-        "諸々記する時間も必要だし、貴公への礼もある。一旦、聖堂に戻るとしよう"
+        "but I must log a few things first, and I owe you a favour. I will\nreturn to Firelink Shrine."
       ]
     },
     {
       "ID": 13000103,
       "Entries": [
-        "そこで声をかけてくれ。約束どおり、魔術を教授しよう"
+        "Speak with me there, so that I may impart my sorcery."
       ]
     },
     {
       "ID": 13000200,
       "Entries": [
-        "おお、貴公か。気にせず先にいってくれ"
+        "Oh, hello. Don't mind me. Go on ahead."
       ]
     },
     {
       "ID": 13000201,
       "Entries": [
-        "私ももうすぐ出発する。なあに、小僧でもない、心配には及ばんよ"
+        "I'll be along later. Phoo-hah-hah, I'll be just fine, young one."
       ]
     },
     {
       "ID": 13000400,
       "Entries": [
-        "貴公、なんのつもりかは知らぬが"
+        "I fail to see your design,"
       ]
     },
     {
       "ID": 13000401,
       "Entries": [
-        "老いたりとて、あまりみくびらないことだな"
+        "but if you think I'm too old to defend myself,"
       ]
     },
     {
       "ID": 13000402,
       "Entries": [
-        "ローガンの魔術を見せてやろう！"
+        "perhaps some sorcery will change your mind!"
       ]
     },
     {
       "ID": 13000500,
       "Entries": [
-        "き、貴公…ばか者が…"
+        "Heavens...the folly of youth..."
       ]
     },
     {
       "ID": 13000501,
       "Entries": [
-        "老いた、ものだな…"
+        "...I'm too old for this..."
       ]
     },
     {
       "ID": 13010000,
       "Entries": [
-        "おお、貴公か。待っていたぞ"
+        "There you are. I was expecting you."
       ]
     },
     {
       "ID": 13010001,
       "Entries": [
-        "約束の礼だ。魔術を教授しようじゃないか"
+        "As promised, I will share my sorceries."
       ]
     },
     {
       "ID": 13010100,
       "Entries": [
-        "ああ、貴公か。熱心なことだな"
+        "Hello there. You really are very diligent."
       ]
     },
     {
       "ID": 13010101,
       "Entries": [
-        "だが、分からいではない。学びは快楽だからな"
+        "I quite understand. Study is invigorating!"
       ]
     },
     {
       "ID": 13010200,
       "Entries": [
-        "おお、貴公か"
+        "Hello there."
       ]
     },
     {
       "ID": 13010201,
       "Entries": [
-        "問題ない。魔術の教授をはじめようか"
+        "Very well indeed. I'm pleased to share my sorceries."
       ]
     },
     {
       "ID": 13010300,
       "Entries": [
-        "おお、貴公か。久しぶりだな"
+        "Hello there. What have you been up to?"
       ]
     },
     {
       "ID": 13010301,
       "Entries": [
-        "あまり顔を見せんから、亡者にでもなったかと思ったぞ"
+        "I thought that perhaps you'd gone Hollow on me."
       ]
     },
     {
       "ID": 13010302,
       "Entries": [
-        "それで、まだ魔術を学ぶ気はあるのかね？"
+        "So, have you come to further your study of sorcery?"
       ]
     },
     {
       "ID": 13010400,
       "Entries": [
-        "おお、貴公か。待っていたぞ"
+        "Hello there. I was expecting you."
       ]
     },
     {
       "ID": 13010401,
       "Entries": [
-        "約束の礼だ。早速、魔術を教授しようじゃないか"
+        "As promised, I will share my sorceries."
       ]
     },
     {
       "ID": 13010402,
       "Entries": [
-        "…"
+        "..."
       ]
     },
     {
       "ID": 13010403,
       "Entries": [
-        "いや、すまん。貴公に魔術は無理筋のようだ"
+        "I am afraid that you are unable to learn sorcery."
       ]
     },
     {
       "ID": 13010404,
       "Entries": [
-        "如何せん基礎知力がな…こればかりは、私にもどうしようもない"
+        "The basic framework, you see. It cannot be taught."
       ]
     },
     {
       "ID": 13010405,
       "Entries": [
-        "なあに、人生魔術ばかりじゃない。貴公には貴公の、生き方があろう"
+        "Oh, do not fret. Life isn't all about sorcery. You will find your\nown way."
       ]
     },
     {
       "ID": 13010406,
       "Entries": [
-        "気に病まず、貴公の道を行くことだな"
+        "Don't frown with regret; peer forward with your head high."
       ]
     },
     {
       "ID": 13010500,
       "Entries": [
-        "おお、貴公か。無事でなによりだな"
+        "Hello there. Glad to see you alive."
       ]
     },
     {
       "ID": 13010600,
       "Entries": [
-        "おお、貴公か。無事でなによりだが…"
+        "Hello there. Glad to see you alive."
       ]
     },
     {
       "ID": 13010601,
       "Entries": [
-        "…"
+        "Hmm..."
       ]
     },
     {
       "ID": 13010602,
       "Entries": [
-        "ふむ？貴公、努力したのだな…"
+        "It seems you've come quite a way..."
       ]
     },
     {
       "ID": 13010603,
       "Entries": [
-        "よろしい。今の貴公なら、無理筋でもない。魔術を教授しようじゃないか"
+        "Excellent. You are certainly ready. I shall teach you sorceries."
       ]
     },
     {
       "ID": 13010700,
       "Entries": [
-        "私は、まだしばらくここにいる"
+        "I will stay here for the time being."
       ]
     },
     {
       "ID": 13010701,
       "Entries": [
-        "学ぶ気があれば、また声をかけたまえ"
+        "Speak to me again to further your knowledge."
       ]
     },
     {
       "ID": 13010800,
       "Entries": [
-        "成果なしか…"
+        "No results, eh..."
       ]
     },
     {
       "ID": 13010801,
       "Entries": [
-        "まあ、魔術の道は長く険しい。焦らず、ゆっくりと学べばいいさ"
+        "Well, the way of sorceries is a long, hard road. Take it slowly."
       ]
     },
     {
       "ID": 13010900,
       "Entries": [
-        "さらばだ"
+        "Farewell."
       ]
     },
     {
       "ID": 13011000,
       "Entries": [
-        "いくのか、貴公"
+        "Heading out, are you?"
       ]
     },
     {
       "ID": 13011001,
       "Entries": [
-        "私も、もうすぐ旅立つ。いかに不死とて、これ以上の逗留は無為だからな"
+        "I, too, will leave soon. Undead or no, I shan't stay here\nforever."
       ]
     },
     {
       "ID": 13011002,
       "Entries": [
-        "…貴公は筋がいい。無駄死にするでないぞ"
+        "...You have great potential. Don't go and die over nothing."
       ]
     },
     {
       "ID": 13011100,
       "Entries": [
-        "貴公、なんのつもりかは知らぬが"
+        "I fail to see your design,"
       ]
     },
     {
       "ID": 13011101,
       "Entries": [
-        "老いたりとて、あまりみくびらないことだな"
+        "but if you think I'm too old to defend myself,"
       ]
     },
     {
       "ID": 13011102,
       "Entries": [
-        "ローガンの魔術を見せてやろう！"
+        "perhaps some sorcery will change your mind!"
       ]
     },
     {
       "ID": 13011200,
       "Entries": [
-        "き、貴公…ばか者が…"
+        "Heavens...the folly of youth..."
       ]
     },
     {
       "ID": 13011201,
       "Entries": [
-        "老いた、ものだな…"
+        "...I'm too old for this..."
       ]
     },
     {
       "ID": 13020000,
       "Entries": [
-        "おお、貴公か！妙なところで再会するものだ！"
+        "Hello again! What a chance meeting this is!"
       ]
     },
     {
       "ID": 13020001,
       "Entries": [
-        "恥ずかしいが、見ての通り、また囚われてしまってな。すまぬが、解放してくれぬか？"
+        "Alas, I'm imprisoned once again. I don't suppose you could stage\nme a getaway?"
       ]
     },
     {
       "ID": 13020002,
       "Entries": [
-        "あの書庫は、知識の山だ。あんなものを至近に、動けぬなど…"
+        "The Archives, such a storehouse of knowledge. So close, but just\nout of reach!"
       ]
     },
     {
       "ID": 13020003,
       "Entries": [
-        "もう悔しくて、悔しくて、憤死しそうなのだよ！"
+        "The thought offends me so, I could simply die!"
       ]
     },
     {
       "ID": 13020004,
       "Entries": [
-        "魔術の徒たる貴公なら、分かるだろう？"
+        "As a student of the arts, you understand me, yes?"
       ]
     },
     {
       "ID": 13020100,
       "Entries": [
-        "おお、貴公、ありがとう。助かった"
+        "Oh, thank you very much. I'm saved."
       ]
     },
     {
       "ID": 13020101,
       "Entries": [
-        "これで2度目だな。だが、この礼はきっとする"
+        "That makes twice. I must be sure to repay you."
       ]
     },
     {
       "ID": 13020102,
       "Entries": [
-        "私はあの書庫の向かう。そこで、新たな魔術を見出し…貴公に、それを教授するだろう"
+        "I will visit the Archives. If I discover any new spells, I shall\nshare them with you."
       ]
     },
     {
       "ID": 13020103,
       "Entries": [
-        "楽しみにしていてくれ。魔術はきっと進化するよ"
+        "Prepare to be impressed, by the onward march of sorcery!"
       ]
     },
     {
       "ID": 13020200,
       "Entries": [
-        "おお、貴公か。気にせず先にいってくれ"
+        "Hello. Don't mind me. Go on ahead."
       ]
     },
     {
       "ID": 13020201,
       "Entries": [
-        "私ももうすぐ出発する。あの書庫に入る前に、少し、思案しておきたくてな"
+        "I'll head out soon. I wish to lay down my plans before I visit\nthe Archives."
       ]
     },
     {
       "ID": 13020600,
       "Entries": [
-        "おお、貴公か。待っていたぞ"
+        "Hello there. I was expecting you."
       ]
     },
     {
       "ID": 13020601,
       "Entries": [
-        "思ったとおりだ、この書庫は、すばらしい。すばらしすぎる"
+        "This place is truly magnificent, more than expected, even."
       ]
     },
     {
       "ID": 13020602,
       "Entries": [
-        "約束どおり、貴公に、新たな魔術を教授できよう"
+        "As promised, I shall share the new sorceries with you."
       ]
     },
     {
       "ID": 13020603,
       "Entries": [
-        "それに、白竜シースの、不死の秘密もな…"
+        "And, the secret of Seath's immortality."
       ]
     },
     {
       "ID": 13020700,
       "Entries": [
-        "ああ、貴公か。熱心なことだな"
+        "Hello there. You really are very diligent."
       ]
     },
     {
       "ID": 13020701,
       "Entries": [
-        "だが、それも分かる。今まさに、魔術の進化に立ち会っているのだからな"
+        "Oh, I understand. We are in the midst of a revolution!"
       ]
     },
     {
       "ID": 13020750,
       "Entries": [
-        "おお、貴公か。しばらくぶりだな"
+        "Oh, hello there. Where have you been?"
       ]
     },
     {
       "ID": 13020751,
       "Entries": [
-        "時間が惜しい。早速、魔術の教授をはじめようか"
+        "Time is a resource. Let's delve in promptly."
       ]
     },
     {
       "ID": 13020800,
       "Entries": [
-        "おお、貴公か、久しいな"
+        "Oh, there you are, it has been a while."
       ]
     },
     {
       "ID": 13020801,
       "Entries": [
-        "それとも、ついさっきだったか？"
+        "Or, were you just here?"
       ]
     },
     {
       "ID": 13020802,
       "Entries": [
-        "ここにいると、時間など、どうでもよくなっていくのだよ…"
+        "This fascinating place defeats my sense of time..."
       ]
     },
     {
       "ID": 13020900,
       "Entries": [
-        "また、戻ってきたまえ"
+        "Come again."
       ]
     },
     {
       "ID": 13020901,
       "Entries": [
-        "ここには尽きぬ知識がある。私は学び、それを貴公に教授しよう"
+        "The knowledge here is limitless. I will absorb it, then share it\nwith you."
       ]
     },
     {
       "ID": 13021000,
       "Entries": [
-        "気にせず、またきたまえ"
+        "Come again, any time you please."
       ]
     },
     {
       "ID": 13021001,
       "Entries": [
-        "私とて、教授することではじめて見えるものもあるのだから"
+        "For I too, learn, whilst teaching a student."
       ]
     },
     {
       "ID": 13021100,
       "Entries": [
-        "さらばだ"
+        "Farewell."
       ]
     },
     {
       "ID": 13021200,
       "Entries": [
-        "ブツブツブツブツ…（意味不明なつぶやき）"
+        "Mm...mm..."
       ]
     },
     {
       "ID": 13021201,
       "Entries": [
-        "ブツブツブツブツ…（意味不明なつぶやき）"
+        "Mm...mm..."
       ]
     },
     {
       "ID": 13021300,
       "Entries": [
-        "白竜シースの、不死の秘密だったな"
+        "Ah, the secret of Seath's immortality?"
       ]
     },
     {
       "ID": 13021301,
       "Entries": [
-        "貴公も、あれと戦い、囚われたのであれば、分かっていると思うが、あれは、我々とは違う、本物の不死だ"
+        "If you have fought him, and were imprisoned, you must know that\nSeath is a true Undead, different from ourselves."
       ]
     },
     {
       "ID": 13021302,
       "Entries": [
-        "傷はすぐに塞がり、致命傷を負わず、決して死ぬことがない"
+        "His wounds close promptly, and no mortal blow affects him,\ngranting true insulation from death."
       ]
     },
     {
       "ID": 13021303,
       "Entries": [
-        "それは、シースが、古い竜たちを裏切って手に入れた秘宝、原始結晶の効果らしい"
+        "It is an effect of the Primordial Crystal, a sacred treasure\npillaged by Seath when he turned upon the ancient dragons."
       ]
     },
     {
       "ID": 13021304,
       "Entries": [
-        "だから、まず原始結晶を壊さなければ、シースを傷つけることはできない"
+        "So, only by destroying the Primordial Crystal can you so much as\nscratch his hide."
       ]
     },
     {
       "ID": 13021305,
       "Entries": [
-        "そして原始結晶は、この書庫の中庭、結晶の森にあるのだよ"
+        "And it so happens, the Primordial Crystal is in the inner garden\nof these very archives, the Crystal Forest."
       ]
     },
     {
       "ID": 13021400,
       "Entries": [
-        "しかし、この書庫の蔵書は、本当にすばらしい"
+        "The tomes stored in these Archives are truly magnificent."
       ]
     },
     {
       "ID": 13021401,
       "Entries": [
-        "優秀な知恵と、真摯な探究心の積み重ねが、知識として結晶する"
+        "A great pool of knowledge, the fruits of superior wisdom and an\nunquenchable desire for the truth."
       ]
     },
     {
       "ID": 13021402,
       "Entries": [
-        "それは、確かに、シースの妄執の結果かもしれないが…それでも、とても美しく、価値あるものだ"
+        "Some would say Seath had an unsound fixation ...But his work is a\nbeautiful, invaluable resource."
       ]
     },
     {
       "ID": 13021403,
       "Entries": [
-        "進化が犠牲を欲することもある"
+        "All progress demands sacrifice."
       ]
     },
     {
       "ID": 13021404,
       "Entries": [
-        "私には、あの白竜に憧れこそすれ、負の感情を抱くことはできんよ…"
+        "And I certainly bear no antipathy for that wonderful scaleless\nbeast."
       ]
     },
     {
       "ID": 13021500,
       "Entries": [
-        "…誰だ…"
+        "...Who are you..."
       ]
     },
     {
       "ID": 13021501,
       "Entries": [
-        "…私の研究…邪魔は、許さん…"
+        "...Stay clear...stay clear of my work..."
       ]
     },
     {
       "ID": 13021502,
       "Entries": [
-        "…許さんぞ…"
+        "...Curses upon you!"
       ]
     },
     {
       "ID": 13021503,
       "Entries": [
-        "…邪魔をするでないわ！"
+        "...How dare you disturb me!"
       ]
     },
     {
       "ID": 13021600,
       "Entries": [
-        "貴公、なんのつもりかは知らぬが"
+        "I fail to see your design,"
       ]
     },
     {
       "ID": 13021601,
       "Entries": [
-        "老いたりとて、あまりみくびらないことだな"
+        "but if you think I'm too old to defend myself,"
       ]
     },
     {
       "ID": 13021602,
       "Entries": [
-        "ローガンの魔術を見せてやろう！"
+        "perhaps some sorcery will change your mind!"
       ]
     },
     {
       "ID": 13021700,
       "Entries": [
-        "き、貴公…ばか者が…"
+        "Heavens...the folly of youth..."
       ]
     },
     {
       "ID": 13021701,
       "Entries": [
-        "老いた、ものだな…"
+        "...I'm too old for this..."
       ]
     },
     {
       "ID": 14000000,
       "Entries": [
-        "誰か！ここから出してくれ！"
+        "Somebody! Please, let me out of here!"
       ]
     },
     {
       "ID": 14000001,
       "Entries": [
-        "誰かいないか！"
+        "Somebody, anybody!"
       ]
     },
     {
       "ID": 14000002,
       "Entries": [
-        "助けてくれ！鍵を開けてくれ！"
+        "Help me! Unlock the door!"
       ]
     },
     {
       "ID": 14000003,
       "Entries": [
-        "…くそっ"
+        "...Damn..."
       ]
     },
     {
       "ID": 14000004,
       "Entries": [
-        "…誰もいないのか"
+        "...I'm finished..."
       ]
     },
     {
       "ID": 14000005,
       "Entries": [
-        "なんだってこんなことに…"
+        "How did this ever happen..."
       ]
     },
     {
       "ID": 14000020,
       "Entries": [
-        "おーい、おーい"
+        "Hello! Hello!"
       ]
     },
     {
       "ID": 14000021,
       "Entries": [
-        "そこの君、こっちだ、こっちだ"
+        "You, yes! You! I'm here, here!"
       ]
     },
     {
       "ID": 14000022,
       "Entries": [
-        "閉じこめられて、ここから動けないんだ"
+        "I'm trapped! Please! I require assistance!"
       ]
     },
     {
       "ID": 14000023,
       "Entries": [
-        "あっちに回って、扉を開けてくれないか"
+        "Try and open the door!"
       ]
     },
     {
@@ -2740,13723 +2740,13723 @@
     {
       "ID": 14000040,
       "Entries": [
-        "おお、あの扉を開けてくれたのか！"
+        "Brilliant! You opened the door for me!"
       ]
     },
     {
       "ID": 14000041,
       "Entries": [
-        "ありがとう、助かったよ。閉じこめられて、困っていたんだ"
+        "Thank you; I am saved. I thought I might never escape."
       ]
     },
     {
       "ID": 14000042,
       "Entries": [
-        "私はヴィンハイムのグリッグス。学院の魔術師だ"
+        "I am Griggs of Vinheim. A sorcerer of the school."
       ]
     },
     {
       "ID": 14000043,
       "Entries": [
-        "君には感謝するよ"
+        "I am much obliged for your assistance."
       ]
     },
     {
       "ID": 14000044,
       "Entries": [
-        "どうやらこれで、旅を続けることができそうだ"
+        "Thanks to you, I may now resume my travels."
       ]
     },
     {
       "ID": 14000100,
       "Entries": [
-        "おお、君か"
+        "Oh, hello."
       ]
     },
     {
       "ID": 14000101,
       "Entries": [
-        "私なら大丈夫。少し休んで、Firelink Shrineに戻るつもりだ"
+        "I am fine. I will rest a while, then return to Firelink Shrine."
       ]
     },
     {
       "ID": 14000102,
       "Entries": [
-        "魔術もある。今度はへまはしないさ"
+        "I have my sorcery. And I will be more cautious next time."
       ]
     },
     {
       "ID": 14000103,
       "Entries": [
-        "大切な使命もあることだしな"
+        "Besides, I have an important task at hand."
       ]
     },
     {
       "ID": 14000200,
       "Entries": [
-        "うおっ！"
+        "Ooph!"
       ]
     },
     {
       "ID": 14000220,
       "Entries": [
-        "うわっ！"
+        "Eeg!"
       ]
     },
     {
       "ID": 14000240,
       "Entries": [
-        "何をするんだ！"
+        "What on Earth are you...!"
       ]
     },
     {
       "ID": 14000260,
       "Entries": [
-        "やめたまえ！君！"
+        "Cease! I implore you!"
       ]
     },
     {
       "ID": 14000300,
       "Entries": [
-        "くそっ、仕方ないな"
+        "Curses, you leave me no choice!"
       ]
     },
     {
       "ID": 14000301,
       "Entries": [
-        "もうダメか"
+        "You aren't yourself any more."
       ]
     },
     {
       "ID": 14000302,
       "Entries": [
-        "恨むなよ！"
+        "Forgive me!"
       ]
     },
     {
       "ID": 14000400,
       "Entries": [
-        "うう…"
+        "Rrrg..."
       ]
     },
     {
       "ID": 14000401,
       "Entries": [
-        "こんなことなら…"
+        "How could this..."
       ]
     },
     {
       "ID": 14010000,
       "Entries": [
-        "おお、君か"
+        "Oh, hello."
       ]
     },
     {
       "ID": 14010001,
       "Entries": [
-        "あのときは不甲斐ないところを見せてしまったな"
+        "I regret meeting you under such compromising circumstances."
       ]
     },
     {
       "ID": 14010002,
       "Entries": [
-        "まあ、お互い無事でなによりだ"
+        "At least we both made it back unscathed."
       ]
     },
     {
       "ID": 14010003,
       "Entries": [
-        "それはそうと、君、魔術を学ぶ気はないか？"
+        "Incidentally, would you care to learn any sorceries?"
       ]
     },
     {
       "ID": 14010004,
       "Entries": [
-        "才能もあるようだし、助けられた恩も返しておきたい"
+        "You're clearly talented, and besides, I owe you."
       ]
     },
     {
       "ID": 14010005,
       "Entries": [
-        "もちろんそれなりの素材は必要だが、簡単なものなら、私にも教えられる。興味はないかい？"
+        "Of course, we will require some materials, but I am happy to\nteach you some elementary spells. Are you interested?"
       ]
     },
     {
       "ID": 14010010,
       "Entries": [
-        "おお、君か"
+        "Oh, hello."
       ]
     },
     {
       "ID": 14010011,
       "Entries": [
-        "あのときは不甲斐ないところを見せてしまったな"
+        "I regret meeting you under such compromising circumstances."
       ]
     },
     {
       "ID": 14010012,
       "Entries": [
-        "まあ、お互い無事でなによりだ"
+        "At least we both made it back unscathed."
       ]
     },
     {
       "ID": 14010020,
       "Entries": [
-        "そうか、よかった"
+        "Splendid! Very well!"
       ]
     },
     {
       "ID": 14010021,
       "Entries": [
-        "なんとか恩を返せるよ"
+        "I am pleased to have a chance to give something back."
       ]
     },
     {
       "ID": 14010022,
       "Entries": [
-        "じゃあ、すぐにでもはじめてみようじゃないか"
+        "Well, then let's get started straight away."
       ]
     },
     {
       "ID": 14010040,
       "Entries": [
-        "そうか…"
+        "Yes, I see..."
       ]
     },
     {
       "ID": 14010041,
       "Entries": [
-        "まあ、こればかりは個人の問題だからな"
+        "It is regrettable, but to each his own."
       ]
     },
     {
       "ID": 14010042,
       "Entries": [
-        "考えが変わったら言ってくれ"
+        "If you change your mind, do not be bashful."
       ]
     },
     {
       "ID": 14010100,
       "Entries": [
-        "おお、君か"
+        "Oh, hello."
       ]
     },
     {
       "ID": 14010101,
       "Entries": [
-        "お互い無事でなによりだ"
+        "Terrific to see us both in one piece."
       ]
     },
     {
       "ID": 14010102,
       "Entries": [
-        "それはそうと、君、魔術を学ぶ気はないか？"
+        "Incidentally, would you care to learn any sorceries?"
       ]
     },
     {
       "ID": 14010103,
       "Entries": [
-        "才能もあるようだし、助けられた恩も返しておきたい"
+        "You're clearly talented, and besides, I owe you."
       ]
     },
     {
       "ID": 14010104,
       "Entries": [
-        "もちろんそれなりの素材は必要だが、簡単なものなら、私にも教えられる。興味はないかい？"
+        "Of course, we will require some materials, but I am happy to\nteach you some elementary spells. Are you interested?"
       ]
     },
     {
       "ID": 14010200,
       "Entries": [
-        "おお、君か"
+        "Oh, hello."
       ]
     },
     {
       "ID": 14010201,
       "Entries": [
-        "随分と熱心じゃないか"
+        "Well, you certainly are keeping at it."
       ]
     },
     {
       "ID": 14010202,
       "Entries": [
-        "私のほうは大丈夫だ。すぐにでもはじめようじゃないか"
+        "Myself? I am fine. Let's get started straight away."
       ]
     },
     {
       "ID": 14010220,
       "Entries": [
-        "おお、君か"
+        "Oh, hello."
       ]
     },
     {
       "ID": 14010221,
       "Entries": [
-        "どうしたんだ？考えが変わったのかい？"
+        "What is it? Have you changed your mind?"
       ]
     },
     {
       "ID": 14010222,
       "Entries": [
-        "もしそうなら大歓迎さ。君は恩人だからな"
+        "I am praying that you will. For, I owe you my life."
       ]
     },
     {
       "ID": 14010300,
       "Entries": [
-        "おお、君か"
+        "Oh, hello."
       ]
     },
     {
       "ID": 14010301,
       "Entries": [
-        "お互い無事でなによりだ"
+        "Terrific to see us both in one piece."
       ]
     },
     {
       "ID": 14010302,
       "Entries": [
-        "恩人の亡者など、出会いたくもないからなあ"
+        "And pray that you never go Hollow! "
       ]
     },
     {
       "ID": 14010400,
       "Entries": [
-        "いくのか"
+        "Good-bye, then."
       ]
     },
     {
       "ID": 14010401,
       "Entries": [
-        "また、無事で会おう"
+        "Do stay safe."
       ]
     },
     {
       "ID": 14010500,
       "Entries": [
-        "よし、これで終わりだな"
+        "All right. That'll do it."
       ]
     },
     {
       "ID": 14010501,
       "Entries": [
-        "君の旅に役立ててくれよ"
+        "That should help you on your journey."
       ]
     },
     {
       "ID": 14010502,
       "Entries": [
-        "また、無事で会おう"
+        "May we meet again."
       ]
     },
     {
       "ID": 14010600,
       "Entries": [
-        "ん？どうした？"
-      ]
-    },
-    {
-      "ID": 14010700,
-      "Entries": [
-        "…まあいい。続けようか"
-      ]
-    },
-    {
-      "ID": 14010800,
-      "Entries": [
-        "「ビッグハット」ローガンの名を聞いたことはあるか？"
-      ]
-    },
-    {
-      "ID": 14010801,
-      "Entries": [
-        "偉大な魔術師であり、私の師でもある方だ"
-      ]
-    },
-    {
-      "ID": 14010802,
-      "Entries": [
-        "不死として、共にこの地にやってきたのだが"
-      ]
-    },
-    {
-      "ID": 14010803,
-      "Entries": [
-        "あるとき、書置きだけを残して、1人で行ってしまった"
-      ]
-    },
-    {
-      "ID": 14010804,
-      "Entries": [
-        "…未熟な私を危険に伴わない、配慮だったのだろう"
-      ]
-    },
-    {
-      "ID": 14010805,
-      "Entries": [
-        "だが、それではあまりに不甲斐ないじゃないか"
-      ]
-    },
-    {
-      "ID": 14010806,
-      "Entries": [
-        "これでも私は、ずっと、必死で魔術を学んできた"
-      ]
-    },
-    {
-      "ID": 14010807,
-      "Entries": [
-        "それなのに、師の役にも立たないなんて…"
-      ]
-    },
-    {
-      "ID": 14010900,
-      "Entries": [
-        "ああ、師の書置きの話か"
-      ]
-    },
-    {
-      "ID": 14010901,
-      "Entries": [
-        "センの古城から、アノール・ロンドを目指す、とだけあった"
-      ]
-    },
-    {
-      "ID": 14010902,
-      "Entries": [
-        "アノール・ロンドには、神の書庫があるというから、目的はそこだろう"
-      ]
-    },
-    {
-      "ID": 14010903,
-      "Entries": [
-        "師は探究心のかたまりだ"
-      ]
-    },
-    {
-      "ID": 14010904,
-      "Entries": [
-        "知がなにより優先され、それ以外に興味を示さない"
-      ]
-    },
-    {
-      "ID": 14010905,
-      "Entries": [
-        "呪われて不死となり、この地にいたるのも、きっと本望なのだろう"
-      ]
-    },
-    {
-      "ID": 14010906,
-      "Entries": [
-        "…残念だが、私には真似のできないことさ"
-      ]
-    },
-    {
-      "ID": 14011000,
-      "Entries": [
-        "…私は、師の後を追おうと思っているんだ"
-      ]
-    },
-    {
-      "ID": 14011001,
-      "Entries": [
-        "力不足は分かっているが、やはりこのままでは悔しいんだ"
-      ]
-    },
-    {
-      "ID": 14011002,
-      "Entries": [
-        "ああ、大丈夫。君に迷惑をかけるつもりはない"
-      ]
-    },
-    {
-      "ID": 14011003,
-      "Entries": [
-        "君に、私のすべての魔術を伝えたら、そのとき旅立つつもりさ"
-      ]
-    },
-    {
-      "ID": 14011004,
-      "Entries": [
-        "師に会えるも、また帰れるも、多分叶わぬのだろうからな…"
-      ]
-    },
-    {
-      "ID": 14011200,
-      "Entries": [
-        "おお、君か！"
-      ]
-    },
-    {
-      "ID": 14011201,
-      "Entries": [
-        "待っていたよ！先ほど、師が戻られたのだ！"
-      ]
-    },
-    {
-      "ID": 14011202,
-      "Entries": [
-        "聞けば、尽力してくれたそうじゃないか"
-      ]
-    },
-    {
-      "ID": 14011203,
-      "Entries": [
-        "私からも礼を言うよ。ありがとう"
-      ]
-    },
-    {
-      "ID": 14011204,
-      "Entries": [
-        "師はあちらにおられる。是非、話してみてくれ"
-      ]
-    },
-    {
-      "ID": 14011300,
-      "Entries": [
-        "おお、君か"
-      ]
-    },
-    {
-      "ID": 14011301,
-      "Entries": [
-        "話しかけてくれて嬉しいが、私などより、老ロガーンの話をきいてくれ"
-      ]
-    },
-    {
-      "ID": 14011302,
-      "Entries": [
-        "その方が、君のためというものだ"
-      ]
-    },
-    {
-      "ID": 14011400,
-      "Entries": [
-        "師とはもう話したか？"
-      ]
-    },
-    {
-      "ID": 14011401,
-      "Entries": [
-        "師は偉大な方だ。魔術の進歩は、あの方なくしては考えられない"
-      ]
-    },
-    {
-      "ID": 14011402,
-      "Entries": [
-        "にも関わらず無茶をされるからな。まったく困ったお人だよ"
-      ]
-    },
-    {
-      "ID": 14011403,
-      "Entries": [
-        "ハハハハッ"
-      ]
-    },
-    {
-      "ID": 14011500,
-      "Entries": [
-        "君は、師の魔術を体験したかい？"
-      ]
-    },
-    {
-      "ID": 14011501,
-      "Entries": [
-        "すばらしいだろう！"
-      ]
-    },
-    {
-      "ID": 14011502,
-      "Entries": [
-        "世に神はなく、神秘もなく、真理があり、知だけがそれを明らかにする…"
-      ]
-    },
-    {
-      "ID": 14011503,
-      "Entries": [
-        "師は、そういう異端のやり方で、魔術をあそこまで押し上げたんだ"
-      ]
-    },
-    {
-      "ID": 14011504,
-      "Entries": [
-        "英雄だよ。悪く言う向きも多いが、私はそう思っているし"
-      ]
-    },
-    {
-      "ID": 14011505,
-      "Entries": [
-        "歴史も何れ、それを追認するだろうさ"
-      ]
-    },
-    {
-      "ID": 14011600,
-      "Entries": [
-        "ああ、君か！聞いてくれ！"
-      ]
-    },
-    {
-      "ID": 14011601,
-      "Entries": [
-        "師が、また、1人で行ってしまったんだ"
-      ]
-    },
-    {
-      "ID": 14011602,
-      "Entries": [
-        "アノール・ロンドにあると言う、神の書庫を諦められなかったのだろう"
-      ]
-    },
-    {
-      "ID": 14011603,
-      "Entries": [
-        "私も後を追うつもりだが、その前に1つ、やり残しがあってな"
-      ]
-    },
-    {
-      "ID": 14011604,
-      "Entries": [
-        "今回、老ロガーンは、蔵書のほとんどを置いていかれた"
-      ]
-    },
-    {
-      "ID": 14011605,
-      "Entries": [
-        "それがあれば、私でも、師の魔術を教えることができる"
-      ]
-    },
-    {
-      "ID": 14011606,
-      "Entries": [
-        "…君には色々と助けられているからな"
-      ]
-    },
-    {
-      "ID": 14011607,
-      "Entries": [
-        "君に師の魔術をすべて伝えてから、私は旅立つことにするよ"
-      ]
-    },
-    {
-      "ID": 14011620,
-      "Entries": [
-        "ああ、君か！聞いてくれ！"
-      ]
-    },
-    {
-      "ID": 14011621,
-      "Entries": [
-        "師が、また、1人で行ってしまったんだ"
-      ]
-    },
-    {
-      "ID": 14011622,
-      "Entries": [
-        "アノール・ロンドにあると言う、神の書庫を諦められなかったのだろう"
-      ]
-    },
-    {
-      "ID": 14011623,
-      "Entries": [
-        "私も後を追うつもりだ"
+        "Hm? What's that?"
       ]
     },
     {
       "ID": 14010640,
       "Entries": [
-        "おお、君か"
+        "Oh, hello."
       ]
     },
     {
       "ID": 14010641,
       "Entries": [
-        "お互い無事でなによりだ"
+        "Terrific to see us both in one piece."
       ]
     },
     {
       "ID": 14010642,
       "Entries": [
-        "それはそうと、君、魔術を学ぶ気はないか？"
+        "Incidentally, would you care to learn any sorceries?"
       ]
     },
     {
       "ID": 14010643,
       "Entries": [
-        "今回、老ロガーンは、蔵書のほとんどを置いていかれた"
+        "You see, Master Logan has left most of his books."
       ]
     },
     {
       "ID": 14010644,
       "Entries": [
-        "それがあれば、私でも、師の魔術を教えることができる"
+        "With them, I could teach you Logan's sorcery."
       ]
     },
     {
       "ID": 14010645,
       "Entries": [
-        "才能もあるようだし、助けられた恩も返しておきたい"
+        "You're clearly talented, and besides, I owe you."
       ]
     },
     {
       "ID": 14010646,
       "Entries": [
-        "君に師の魔術をすべて伝えてから、私は旅立つことにするよ"
+        "Before I leave on this journey, I will teach you all that Logan\nhas to share."
+      ]
+    },
+    {
+      "ID": 14010700,
+      "Entries": [
+        "No matter. Let us continue."
+      ]
+    },
+    {
+      "ID": 14010800,
+      "Entries": [
+        "Have you heard of Big Hat Logan?"
+      ]
+    },
+    {
+      "ID": 14010801,
+      "Entries": [
+        "Master Logan is a great sorcerer, and my teacher."
+      ]
+    },
+    {
+      "ID": 14010802,
+      "Entries": [
+        "Both of us came to this land, as Undead."
+      ]
+    },
+    {
+      "ID": 14010803,
+      "Entries": [
+        "But one day, he departed, leaving only a note."
+      ]
+    },
+    {
+      "ID": 14010804,
+      "Entries": [
+        "...I suppose he wished to keep me out of harm's way."
+      ]
+    },
+    {
+      "ID": 14010805,
+      "Entries": [
+        "But where does that leave me?"
+      ]
+    },
+    {
+      "ID": 14010806,
+      "Entries": [
+        "I have dedicated myself to sorcery."
+      ]
+    },
+    {
+      "ID": 14010807,
+      "Entries": [
+        "But Master Logan could find no use for me..."
+      ]
+    },
+    {
+      "ID": 14010900,
+      "Entries": [
+        "Ahh, yes, the note that Master Logan left?"
+      ]
+    },
+    {
+      "ID": 14010901,
+      "Entries": [
+        "It only said he would travel to Anor Londo, by way of Sen's\nFortress."
+      ]
+    },
+    {
+      "ID": 14010902,
+      "Entries": [
+        "I can only guess that he seeks the Regal Archives."
+      ]
+    },
+    {
+      "ID": 14010903,
+      "Entries": [
+        "For Master Logan is a tireless pursuer of wisdom."
+      ]
+    },
+    {
+      "ID": 14010904,
+      "Entries": [
+        "Wisdom trumps all; everything else is hogwash."
+      ]
+    },
+    {
+      "ID": 14010905,
+      "Entries": [
+        "When the curse turned him Undead, I am certain that he only felt\nit was the perfect chance to visit this land."
+      ]
+    },
+    {
+      "ID": 14010906,
+      "Entries": [
+        "I only wish that I had his courage..."
+      ]
+    },
+    {
+      "ID": 14011000,
+      "Entries": [
+        "I wish to do what I can to locate Master Logan."
+      ]
+    },
+    {
+      "ID": 14011001,
+      "Entries": [
+        "I am aware of my shortcomings, but I cannot very well just sit\naround here and rot."
+      ]
+    },
+    {
+      "ID": 14011002,
+      "Entries": [
+        "Oh, do not worry. I have considered our relationship."
+      ]
+    },
+    {
+      "ID": 14011003,
+      "Entries": [
+        "I will only leave after I have taught you all the sorceries that\nI know."
+      ]
+    },
+    {
+      "ID": 14011004,
+      "Entries": [
+        "I shall count myself lucky if I manage to locate Logan, or even\nreturn here in one piece."
+      ]
+    },
+    {
+      "ID": 14011200,
+      "Entries": [
+        "Oh, hello again!"
+      ]
+    },
+    {
+      "ID": 14011201,
+      "Entries": [
+        "I was waiting to tell you...Master Logan has returned!"
+      ]
+    },
+    {
+      "ID": 14011202,
+      "Entries": [
+        "And he tells me that he has you to thank!"
+      ]
+    },
+    {
+      "ID": 14011203,
+      "Entries": [
+        "Well, we are both in your debt, now. Thank you, sincerely."
+      ]
+    },
+    {
+      "ID": 14011204,
+      "Entries": [
+        "He's just over there. Go along and have a chat."
+      ]
+    },
+    {
+      "ID": 14011300,
+      "Entries": [
+        "Oh, hello."
+      ]
+    },
+    {
+      "ID": 14011301,
+      "Entries": [
+        "I appreciate the attention, but you really should speak to Master\nLogan."
+      ]
+    },
+    {
+      "ID": 14011302,
+      "Entries": [
+        "That will certainly do you more good."
+      ]
+    },
+    {
+      "ID": 14011400,
+      "Entries": [
+        "Have you spoken to Master Logan?"
+      ]
+    },
+    {
+      "ID": 14011401,
+      "Entries": [
+        "He is an accomplished scholar. The arts of sorcery would never\nhave come this far without his contributions."
+      ]
+    },
+    {
+      "ID": 14011402,
+      "Entries": [
+        "And he has the nerve to go risking life and limb! What a stubborn\nold fellow."
+      ]
+    },
+    {
+      "ID": 14011403,
+      "Entries": [
+        "Hah hah hah hah!"
+      ]
+    },
+    {
+      "ID": 14011500,
+      "Entries": [
+        "Have you ever cast one of Logan's spells?"
+      ]
+    },
+    {
+      "ID": 14011501,
+      "Entries": [
+        "Isn't it exhilarating?"
+      ]
+    },
+    {
+      "ID": 14011502,
+      "Entries": [
+        "As he sees it, there are no gods, no transcendence, only truth,\nand Logan only wishes to elucidate it."
+      ]
+    },
+    {
+      "ID": 14011503,
+      "Entries": [
+        "It is this heretical methodology that allowed Logan to advance\nsorcery to the point that he has."
+      ]
+    },
+    {
+      "ID": 14011504,
+      "Entries": [
+        "In a word, he is a hero. Despite the awful rumours."
+      ]
+    },
+    {
+      "ID": 14011505,
+      "Entries": [
+        "Time will tell. The annals of history will prove dispassionate!"
+      ]
+    },
+    {
+      "ID": 14011600,
+      "Entries": [
+        "Oh, there you are! Just so you know..."
+      ]
+    },
+    {
+      "ID": 14011601,
+      "Entries": [
+        "Master Logan has left on his own again."
+      ]
+    },
+    {
+      "ID": 14011602,
+      "Entries": [
+        "It seems that he is still determined to find the famed Regal\nArchives in Anor Londo."
+      ]
+    },
+    {
+      "ID": 14011603,
+      "Entries": [
+        "I intend to search for him. Only, before I leave, there is one\nthing I wish to do."
+      ]
+    },
+    {
+      "ID": 14011604,
+      "Entries": [
+        "You see, Master Logan has left most of his books."
+      ]
+    },
+    {
+      "ID": 14011605,
+      "Entries": [
+        "With them, I could teach you Logan's sorcery."
+      ]
+    },
+    {
+      "ID": 14011606,
+      "Entries": [
+        "...You have done much to assist me."
+      ]
+    },
+    {
+      "ID": 14011607,
+      "Entries": [
+        "Before I leave on this journey, I will teach you all that Logan\nhas to share."
+      ]
+    },
+    {
+      "ID": 14011620,
+      "Entries": [
+        "Oh, there you are! Just so you know..."
+      ]
+    },
+    {
+      "ID": 14011621,
+      "Entries": [
+        "Master Logan has left on his own again."
+      ]
+    },
+    {
+      "ID": 14011622,
+      "Entries": [
+        "It seems that he is still determined to find the famed Regal\nArchives in Anor Londo."
+      ]
+    },
+    {
+      "ID": 14011623,
+      "Entries": [
+        "And I have decided that I must search for him."
       ]
     },
     {
       "ID": 14011700,
       "Entries": [
-        "おお、君か。よく戻ったな"
+        "Oh, hello, you made it!"
       ]
     },
     {
       "ID": 14011701,
       "Entries": [
-        "では、はじめようか"
+        "Then, let us begin."
       ]
     },
     {
       "ID": 14011702,
       "Entries": [
-        "約束どおり、師の魔術を君に教えよう"
+        "As promised, I shall bequeath Master Logan's sorcery to you."
       ]
     },
     {
       "ID": 14011800,
       "Entries": [
-        "私は、老ロガーンの身を案じているわけじゃあないんだ"
+        "It's not that I am concerned for Master Logan's welfare."
       ]
     },
     {
       "ID": 14011801,
       "Entries": [
-        "この地は危険だが、それでも、師の魔術はずぬけている。本物の英雄だ"
+        "Even in this treacherous land, Logan's skills are unmatched. He\nis a true hero."
       ]
     },
     {
       "ID": 14011802,
       "Entries": [
-        "…だから、私が師の後を追おうと思うのは"
+        "...No, the reason I seek Logan is..."
       ]
     },
     {
       "ID": 14011803,
       "Entries": [
-        "結局のところ、単に私の意地なんだよ"
+        "...Well, it's really my own conceit, now isn't it?"
       ]
     },
     {
       "ID": 14011900,
       "Entries": [
-        "おお！老ロガーンは書庫にいるのか！"
+        "Ohh! Master Logan is at the Archives?!"
       ]
     },
     {
       "ID": 14011901,
       "Entries": [
-        "よかった、積年の思いが叶ったのだな"
+        "Thank the heavens; finally his wish has been granted."
       ]
     },
     {
       "ID": 14011902,
       "Entries": [
-        "きっと、狂ったように読みふけっているのだろう"
+        "I suppose he has his head buried in those tomes?"
       ]
     },
     {
       "ID": 14011903,
       "Entries": [
-        "それが、師の至福なのだから"
+        "That is always what made Master Logan happiest..."
       ]
     },
     {
       "ID": 14011904,
       "Entries": [
-        "ああ、目に浮かぶようだ…"
+        "Ahh, I can just imagine him now!"
       ]
     },
     {
       "ID": 14012000,
       "Entries": [
-        "おお、君か"
+        "Oh, hello."
       ]
     },
     {
       "ID": 14012001,
       "Entries": [
-        "もちろん、魔術を教えるのは構わないが"
+        "Why, of course I don't mind teaching you sorceries..."
       ]
     },
     {
       "ID": 14012002,
       "Entries": [
-        "折角、老ロガーンの居所が分かったんだ"
+        "But now that you've located Master Logan,"
       ]
     },
     {
       "ID": 14012003,
       "Entries": [
-        "もう、私など用なしのはずだぞ…"
+        "I can't imagine that I can be of much help."
       ]
     },
     {
       "ID": 14012100,
       "Entries": [
-        "…やはり、私は、書庫に向かうよ"
+        "I have decided to seek the Regal Archives."
       ]
     },
     {
       "ID": 14012101,
       "Entries": [
-        "私に辿り着けない場所であることは、分かっている"
+        "I realize that I may never make it."
       ]
     },
     {
       "ID": 14012102,
       "Entries": [
-        "でも、そうしなければ、私に何の価値があると言うんだ"
+        "But I would feel worthless if I did not at least try."
       ]
     },
     {
       "ID": 14012103,
       "Entries": [
-        "そうでなければ、師も、私など一顧だになさるまい…"
+        "What other choice do I have to earn Logan's recognition?"
       ]
     },
     {
       "ID": 14012200,
       "Entries": [
-        "うわあっ！"
+        "Uwwah!"
       ]
     },
     {
       "ID": 14012220,
       "Entries": [
-        "どうした！"
+        "Heavens!"
       ]
     },
     {
       "ID": 14012240,
       "Entries": [
-        "何をする！"
+        "In the name of sanity!"
       ]
     },
     {
       "ID": 14012260,
       "Entries": [
-        "やめろ！気が触れたか！"
+        "Cease! Have you gone mad!"
       ]
     },
     {
       "ID": 14012300,
       "Entries": [
-        "くそっ、正気じゃないな"
+        "Damn...you've lost it, haven't you?"
       ]
     },
     {
       "ID": 14012301,
       "Entries": [
-        "だったら仕方ない"
+        "Then I have no choice."
       ]
     },
     {
       "ID": 14012302,
       "Entries": [
-        "覚悟しろ！"
+        "Prepare yourself!"
       ]
     },
     {
       "ID": 14012400,
       "Entries": [
-        "うう…"
+        "Rrrg..."
       ]
     },
     {
       "ID": 14012401,
       "Entries": [
-        "師よ…"
+        "Master Logan..."
       ]
     },
     {
       "ID": 14012500,
       "Entries": [
-        "そういえば、君もみただろう？"
+        "Did you see them?"
       ]
     },
     {
       "ID": 14012501,
       "Entries": [
-        "ついさっき、若い聖職者が三人もやってきたんだ"
+        "The three young clerics...\nheaded for the Catacombs, to seek Kindling."
       ]
     },
     {
       "ID": 14012502,
       "Entries": [
-        "なんでも、篝火を育てる業らしいが…"
+        "Kindling is the art of feeding bonfires."
       ]
     },
     {
       "ID": 14012503,
       "Entries": [
-        "可愛そうに、まだ若いお嬢さんに墓場とは"
+        "The poor young girl, sent down into a tomb."
       ]
     },
     {
       "ID": 14012504,
       "Entries": [
-        "いかにも酷な使命じゃあないか…"
+        "What a terrible mission she is burdened with."
       ]
     },
     {
       "ID": 14012600,
       "Entries": [
-        "魔術を使うには、幾つか準備が必要だ"
+        "Two things are required for sorcery."
       ]
     },
     {
       "ID": 14012601,
       "Entries": [
-        "まず、触媒を装備する"
+        "First, you must equip a wand."
       ]
     },
     {
       "ID": 14012602,
       "Entries": [
-        "それから、魔術を記憶する"
+        "Second, you must attune a sorcery."
       ]
     },
     {
       "ID": 14012603,
       "Entries": [
-        "そうしてはじめて、魔術が使えるんだ"
+        "Then you will be ready to fire away."
       ]
     },
     {
       "ID": 14012604,
       "Entries": [
-        "よく覚えておいてくれよ"
+        "Oh and don't forget to aim!"
       ]
     },
     {
       "ID": 15000000,
       "Entries": [
-        "…貴方が、助けてくれたのですね…"
+        "So, it is thou who rescueth me?"
       ]
     },
     {
       "ID": 15000001,
       "Entries": [
-        "ありがとうございました。深く、感謝します"
+        "Most gracious. I am deeply obliged."
       ]
     },
     {
       "ID": 15000002,
       "Entries": [
-        "私はウーラシールの宵闇"
+        "I am Dusk of Oolacile."
       ]
     },
     {
       "ID": 15000003,
       "Entries": [
-        "貴方とは違う時代、とても古い時代の人間なのです。…ここに長く留まることはできません"
+        "I cometh from an age long before thine...I can not stay here for\nlong."
       ]
     },
     {
       "ID": 15000004,
       "Entries": [
-        "ですから、このまま消えてしまう前に、1つだけ聞かせてください"
+        "So, before I disappear, allow me to ask one thing."
       ]
     },
     {
       "ID": 15000005,
       "Entries": [
-        "私の故郷、ウーラシールは古い魔術の地です"
+        "My home, Oolacile, is the home of ancient sorceries."
       ]
     },
     {
       "ID": 15000006,
       "Entries": [
-        "その知識を、よろしければ、恩人たる貴方のお役に立てたいのですが…"
+        "My hope is to pass this profound knowledge to thee, with thine\napproval."
       ]
     },
     {
       "ID": 15000007,
       "Entries": [
-        "それは貴方に必要でしょうか？"
+        "Would this be of assistance to thee?"
       ]
     },
     {
       "ID": 15000020,
       "Entries": [
-        "戻られましたか。よかったです…"
+        "Thou hast return'd. Bless thee."
       ]
     },
     {
       "ID": 15000021,
       "Entries": [
-        "私の故郷、ウーラシールは古い魔術の地です"
+        "My home, Oolacile, is the home of ancient sorceries."
       ]
     },
     {
       "ID": 15000022,
       "Entries": [
-        "その知識を、よろしければ、恩人たる貴方のお役に立てたいのですが…"
+        "My hope is to pass this profound knowledge to thee, with thine\napproval."
       ]
     },
     {
       "ID": 15000023,
       "Entries": [
-        "それは貴方に必要でしょうか？"
+        "Would this be of assistance to thee?"
       ]
     },
     {
       "ID": 15000050,
       "Entries": [
-        "そうですか！…それは嬉しいことです"
+        "My heartfelt thanks. I am pleased beyond words."
       ]
     },
     {
       "ID": 15000051,
       "Entries": [
-        "それでは、私は、この森の入り口にサインを残していきましょう"
+        "Then, I shalt engrave my signature."
       ]
     },
     {
       "ID": 15000052,
       "Entries": [
-        "必要なときは、サインから私を召喚してください"
+        "If thou art in need, pray summon me from my signature."
       ]
     },
     {
       "ID": 15000053,
       "Entries": [
-        "…もう時間のようです。貴方に炎の導きのあらんことを"
+        "It seems that my time is done. May the great flames guide thee."
       ]
     },
     {
       "ID": 15000100,
       "Entries": [
-        "そうですか…わかりました"
+        "Yes, of course...I understand well."
       ]
     },
     {
       "ID": 15000101,
       "Entries": [
-        "出過ぎた言をお許しください"
+        "Pray forgive me. I have overstepped my boundaries."
       ]
     },
     {
       "ID": 15000102,
       "Entries": [
-        "それでは、私は、私の時代、私の国に帰ります"
+        "Farewell; another age, another land, beckons me to return."
       ]
     },
     {
       "ID": 15000103,
       "Entries": [
-        "貴方に炎の導きのあらんことを"
+        "May the flames guide thee."
       ]
     },
     {
       "ID": 15000220,
       "Entries": [
-        "何を…"
+        "What dost thou..."
       ]
     },
     {
       "ID": 15000240,
       "Entries": [
-        "どうして…"
+        "Whatever for..."
       ]
     },
     {
       "ID": 15000260,
       "Entries": [
-        "やめてください…"
+        "Cease this barbarism..."
       ]
     },
     {
       "ID": 15000300,
       "Entries": [
-        "ああ…"
+        "Ahh..."
       ]
     },
     {
       "ID": 15000301,
       "Entries": [
-        "お別れですね、貴方…"
+        "Farewell, my rescuer..."
       ]
     },
     {
       "ID": 15000500,
       "Entries": [
-        "ウーラシールの宵闇、参りました"
+        "I am Dusk of Oolacile."
       ]
     },
     {
       "ID": 15000501,
       "Entries": [
-        "また貴方にお会いできて光栄です"
+        "It is an honour to see thee again."
       ]
     },
     {
       "ID": 15000502,
       "Entries": [
-        "何なりと、私に仰ってください"
+        "I shall follow thine wishes."
       ]
     },
     {
       "ID": 15000600,
       "Entries": [
-        "必要でしたら、また召喚してください"
+        "If thou art in need, pray summon me again."
       ]
     },
     {
       "ID": 15000601,
       "Entries": [
-        "貴方のお役に立ちたいのです…"
+        "I wish to be of assistance..."
       ]
     },
     {
       "ID": 15000602,
       "Entries": [
-        "貴方に炎の導きのあらんことを"
+        "May the flames guide thee."
       ]
     },
     {
       "ID": 15000700,
       "Entries": [
-        "必要でしたら、また召喚してください"
+        "If thou art in need, pray summon me again."
       ]
     },
     {
       "ID": 15000701,
       "Entries": [
-        "貴方のお役に立っていればよいのですが…"
+        "I only wish to be of some genuine assistance..."
       ]
     },
     {
       "ID": 15000702,
       "Entries": [
-        "貴方に炎の導きのあらんことを"
+        "May the flames guide thee."
       ]
     },
     {
       "ID": 15000800,
       "Entries": [
-        "あ、どこへ…"
+        "Wait, where... are..."
       ]
     },
     {
       "ID": 15000900,
       "Entries": [
-        "戻られましたか。よかったです…"
+        "Thou hast return'd. Bless thee."
       ]
     },
     {
       "ID": 15001100,
       "Entries": [
-        "私は、ずっと永い間、あのクリスタルゴレムに囚われていました"
+        "For a very long time, I was trapped within the Crystal Golem."
       ]
     },
     {
       "ID": 15001101,
       "Entries": [
-        "あれと共に、故郷を離れ、世界の歪をさまよっていたのです"
+        "From my home I was taken, and banish'd to a plane of distortion."
       ]
     },
     {
       "ID": 15001102,
       "Entries": [
-        "それを、貴方に助けて頂きました"
+        "It was there, that thou came to my rescue."
       ]
     },
     {
       "ID": 15001103,
       "Entries": [
-        "もう、ずっと前に、そんな希望は棄てていました"
+        "Long after I had relinquished all hope."
       ]
     },
     {
       "ID": 15001104,
       "Entries": [
-        "だから私は、嬉しくて、とても信じられなかったのです…"
+        "So gleeful was I, my faith reneweth."
       ]
     },
     {
       "ID": 15001200,
       "Entries": [
-        "ウーラシールの魔術は、この時代のそれとは、少し違うようです"
+        "The sorceries of Oolacile differ from the magic of thine age."
       ]
     },
     {
       "ID": 15001201,
       "Entries": [
-        "私にもうまく言えないのですが…"
+        "It is difficult to explain..."
       ]
     },
     {
       "ID": 15001202,
       "Entries": [
-        "ウーラシールの魔術は、なんというか、寛容で、クスッ、少しいい加減なところがあるのですが"
+        "Oolacile sorceries are, what doth one say? They are somewhat...\nof an approximation."
       ]
     },
     {
       "ID": 15001203,
       "Entries": [
-        "貴方の時代の魔術は、もっと真摯で、自己以外を拒絶するように見えるのです"
+        "Thine sorceries are more straight forward, negating all but thy\nself."
       ]
     },
     {
       "ID": 15001204,
       "Entries": [
-        "思えば、とても興味深いことですね…"
+        "Dost thou not find some fascination in these discrepancies?"
       ]
     },
     {
       "ID": 15001300,
       "Entries": [
-        "私の故郷、ウーラシールは、私の時代でも、既に亡んでいました"
+        "My home of Oolacile was reduced to ashes, long ago, in my time."
       ]
     },
     {
       "ID": 15001301,
       "Entries": [
-        "だから、やっぱり私は1人で…"
+        "I have been alone ever since..."
       ]
     },
     {
       "ID": 15001302,
       "Entries": [
-        "貴方に召喚されて、こうしてお話しするのが…その、嬉しかったりするんです…"
+        "But to be summon'd thus, and to be of service to thee...\nIt is... most rewarding..."
       ]
     },
     {
       "ID": 15001303,
       "Entries": [
-        "ああ、すみません、貴方にお聞かせするような話ではありませんでしたね…"
+        "Oh, forgive me, such a long-past time is none of thine concern..."
       ]
     },
     {
       "ID": 16000000,
       "Entries": [
-        "…"
+        "..."
       ]
     },
     {
       "ID": 16000010,
       "Entries": [
-        "…"
+        "..."
       ]
     },
     {
       "ID": 16000020,
       "Entries": [
-        "…"
+        "..."
       ]
     },
     {
       "ID": 16000030,
       "Entries": [
-        "…"
+        "..."
       ]
     },
     {
       "ID": 16000040,
       "Entries": [
-        "…"
+        "..."
       ]
     },
     {
       "ID": 16000050,
       "Entries": [
-        "…"
+        "..."
       ]
     },
     {
       "ID": 16000060,
       "Entries": [
-        "…"
+        "..."
       ]
     },
     {
       "ID": 16000070,
       "Entries": [
-        "…"
+        "..."
       ]
     },
     {
       "ID": 16000080,
       "Entries": [
-        "…"
+        "..."
       ]
     },
     {
       "ID": 16000090,
       "Entries": [
-        "…"
+        "..."
       ]
     },
     {
       "ID": 16000100,
       "Entries": [
-        "…あ、ありがとう、ございました"
+        "...Th, thank you..."
       ]
     },
     {
       "ID": 16000101,
       "Entries": [
-        "…私は、アストラのアナスタシア"
+        "...I am Anastacia of Astora."
       ]
     },
     {
       "ID": 16000102,
       "Entries": [
-        "…あなたのお陰で、火防の任を、続けることができます"
+        "...Now I can continue my duty as a Keeper."
       ]
     },
     {
       "ID": 16000103,
       "Entries": [
-        "…そして"
+        "...But..."
       ]
     },
     {
       "ID": 16000104,
       "Entries": [
-        "…汚れた声をお聞かせしたことを、お許しください"
+        "...I only hope that my impure tongue does not offend."
       ]
     },
     {
       "ID": 16000200,
       "Entries": [
-        "…すみません"
+        "...Forgive me..."
       ]
     },
     {
       "ID": 16000201,
       "Entries": [
-        "…私は汚れ、声を出すべきではありません"
+        "...I am impure, my tongue never intended for restoration."
       ]
     },
     {
       "ID": 16000202,
       "Entries": [
-        "…ですから、もう…"
+        "...Please, if you have any heart..."
       ]
     },
     {
       "ID": 16000203,
       "Entries": [
-        "…話しかけるのは"
+        "...Leave me be..."
       ]
     },
     {
       "ID": 16000204,
       "Entries": [
-        "…やめてください。お願いします"
+        "...I wish not to speak..."
       ]
     },
     {
       "ID": 16000300,
       "Entries": [
-        "…フラムトさんから、聞きました"
+        "...Frampt has told me of you..."
       ]
     },
     {
       "ID": 16000301,
       "Entries": [
-        "…あなたが、火を継いでくださるのですね"
+        "...That you have agreed to link the Fire."
       ]
     },
     {
       "ID": 16000302,
       "Entries": [
-        "…ありがとう、ございます"
+        "...I thank you, sincerely."
       ]
     },
     {
       "ID": 16000303,
       "Entries": [
-        "…これで、不死の呪いも消え、私も、人として死んでいけます"
+        "...Finally, the curse of the Undead will be lifted, and I can die\nhuman."
       ]
     },
     {
       "ID": 16000304,
       "Entries": [
-        "…私では、何もできませんが…すべてを、あなたのために捧げましょう"
+        "...I am powerless, but I will do all that I can."
       ]
     },
     {
       "ID": 16000305,
       "Entries": [
-        "…どうか、皆を、救ってください…"
+        "...Please, save us all..."
       ]
     },
     {
       "ID": 16000306,
       "Entries": [
-        "…お願いします"
+        "...Please..."
       ]
     },
     {
       "ID": 16000320,
       "Entries": [
-        "…あなたが、火を継いでくださるのですね"
+        "...That you have agreed to link the Fire."
       ]
     },
     {
       "ID": 16000321,
       "Entries": [
-        "…ありがとう、ございます"
+        "...I thank you, sincerely."
       ]
     },
     {
       "ID": 16000322,
       "Entries": [
-        "…これで、不死の呪いも消え、私も、人として死んでいけます"
+        "...Finally, the curse of the Undead will be lifted, and I can die\nhuman."
       ]
     },
     {
       "ID": 16000323,
       "Entries": [
-        "…私では、何もできませんが…すべてを、あなたのために捧げましょう"
+        "...I am powerless, but I will do all that I can."
       ]
     },
     {
       "ID": 16000324,
       "Entries": [
-        "…どうか、皆を、救ってください…"
+        "...Please, save us all..."
       ]
     },
     {
       "ID": 16000325,
       "Entries": [
-        "…お願いします"
+        "...Please..."
       ]
     },
     {
       "ID": 16000400,
       "Entries": [
-        "ッ…"
+        "Mm..."
       ]
     },
     {
       "ID": 16000410,
       "Entries": [
-        "ッ…"
+        "Mm..."
       ]
     },
     {
       "ID": 16000420,
       "Entries": [
-        "ッ…"
+        "Mm..."
       ]
     },
     {
       "ID": 16000430,
       "Entries": [
-        "ッ…"
+        "Mm..."
       ]
     },
     {
       "ID": 16000440,
       "Entries": [
-        "ッ…"
+        "Mm..."
       ]
     },
     {
       "ID": 16000450,
       "Entries": [
-        "ッ…"
+        "Mm..."
       ]
     },
     {
       "ID": 16000500,
       "Entries": [
-        "アッ…"
+        "Ah..."
       ]
     },
     {
       "ID": 16000501,
       "Entries": [
-        "（祈りの言葉）"
+        "Vereor Nox"
       ]
     },
     {
       "ID": 17000000,
       "Entries": [
-        "…あなたも、不死なのでしょう？"
+        "You are Undead, as well?"
       ]
     },
     {
       "ID": 17000001,
       "Entries": [
-        "ならば、馴れ合いは不要です。お互い、己の使命を果たしましょう"
+        "Then we've no time to fraternize. I have my mission, and you no\ndoubt have yours."
       ]
     },
     {
       "ID": 17000002,
       "Entries": [
-        "…さもなくば、我々はただの呪われ人です"
+        "We must not let this curse overcome us."
       ]
     },
     {
       "ID": 17000100,
       "Entries": [
-        "…馴れ合いは不要と、申し上げませんでしたか？"
+        "Did I not explain the urgency of our tasks?"
       ]
     },
     {
       "ID": 17000101,
       "Entries": [
-        "礼を弁えぬは、愚か者の振る舞いでしょう"
+        "Who are you so uncouth as to lack such judgement?"
       ]
     },
     {
       "ID": 17000102,
       "Entries": [
-        "あなたがそうだとは…思えませんが"
+        "By the looks of you...I should think not."
       ]
     },
     {
       "ID": 17000230,
       "Entries": [
-        "痛いッ！"
+        "Ow!"
       ]
     },
     {
       "ID": 17000240,
       "Entries": [
-        "何をするんですか！"
+        "Horrors!"
       ]
     },
     {
       "ID": 17000250,
       "Entries": [
-        "無礼者！"
+        "The nerve!"
       ]
     },
     {
       "ID": 17000300,
       "Entries": [
-        "…不敬者か！それとも既に亡者ですか！"
+        "Are you a heretic, or just plain Hollow?"
       ]
     },
     {
       "ID": 17000301,
       "Entries": [
-        "どちらとて、許すわけにはいきません！"
+        "It matters not, for you shall not escape!"
       ]
     },
     {
       "ID": 17000302,
       "Entries": [
-        "神に唾する愚か者よ！"
+        "You will offend the Gods no longer!"
       ]
     },
     {
       "ID": 17000400,
       "Entries": [
-        "ウッ！クウウッ…"
+        "Hrgkt! Eeg..."
       ]
     },
     {
       "ID": 17000401,
       "Entries": [
-        "お父様…"
+        "Father..."
       ]
     },
     {
       "ID": 17000500,
       "Entries": [
-        "悲しい人…"
+        "O piteous soul..."
       ]
     },
     {
       "ID": 17000501,
       "Entries": [
-        "でも…私も…何れこうなってしまうのかしら…"
+        "But...perhaps...this was a fate unyielding..."
       ]
     },
     {
       "ID": 17000800,
       "Entries": [
-        "あなたは…あの時の方ですね"
+        "Hello...I will never forget what you did."
       ]
     },
     {
       "ID": 17000801,
       "Entries": [
-        "その節は、ありがとうございました"
+        "I am deeply indebted,"
       ]
     },
     {
       "ID": 17000802,
       "Entries": [
-        "あなたがいなければ、私では、ヴィンスも、ニコも、救ってあげられなかった…"
+        "for it was not within my power to save Vince or Nico."
       ]
     },
     {
       "ID": 17000803,
       "Entries": [
-        "ほんとうに、感謝しています"
+        "I cannot thank you enough."
       ]
     },
     {
       "ID": 17000804,
       "Entries": [
-        "申し遅れましたが、私は、ソルロンドのレア"
+        "In case you have not heard, I am Reah of Thorolund."
       ]
     },
     {
       "ID": 17000805,
       "Entries": [
-        "何か、あなたの助けになれればよいのですが"
+        "I only wish there were some way I could help you,"
       ]
     },
     {
       "ID": 17000806,
       "Entries": [
-        "不出来な身で、奇跡の他は何も知りません"
+        "but I am inexperienced, and I only know the art of Miracles."
       ]
     },
     {
       "ID": 17000807,
       "Entries": [
-        "それで宜しければ、また、お声をかけてください"
+        "If that could be of any help, speak to me again."
       ]
     },
     {
       "ID": 17000900,
       "Entries": [
-        "奇跡が、あなたのお役に立ちそうですか？"
+        "Would a Miracle be of any help to you?"
       ]
     },
     {
       "ID": 17000901,
       "Entries": [
-        "もしそうなら、よかった。嬉しいことです"
+        "I would be most pleased if that were so."
       ]
     },
     {
       "ID": 17000902,
       "Entries": [
-        "それでは、奇跡の話をしましょうか"
+        "May we discuss Miracles, then?"
       ]
     },
     {
       "ID": 17001000,
       "Entries": [
-        "またお会いできるとは、ご無事で何よりです"
+        "I am most pleased to find you in good health."
       ]
     },
     {
       "ID": 17001001,
       "Entries": [
-        "私の用意はできています。奇跡の話をはじめましょう"
+        "I am ready. Let us speak of Miracles."
       ]
     },
     {
       "ID": 17001100,
       "Entries": [
-        "お久しぶりです。お待ちしておりました"
+        "I was wondering when you might return."
       ]
     },
     {
       "ID": 17001101,
       "Entries": [
-        "あなたがご無事で何よりです。それでは、奇跡の話をしましょうか"
+        "It is a great relief to see you. Now, let us speak of Miracles."
       ]
     },
     {
       "ID": 17001200,
       "Entries": [
-        "…あ！ああ、すみません。祈りに没頭しておりました"
+        "Oh! Please, forgive me. I was absorbed in prayer."
       ]
     },
     {
       "ID": 17001201,
       "Entries": [
-        "奇跡の話ですよね？すぐにご用意します"
+        "The Miracles, I presume? I will be ready immediately."
       ]
     },
     {
       "ID": 17001300,
       "Entries": [
-        "それでは、ご無事で"
+        "Then, be safe."
       ]
     },
     {
       "ID": 17001301,
       "Entries": [
-        "さようなら"
+        "Farewell."
       ]
     },
     {
       "ID": 17001302,
       "Entries": [
-        "（祈りの言葉）"
+        "Vereor Nox"
       ]
     },
     {
       "ID": 17001400,
       "Entries": [
-        "あの時…パッチという男に突き落とされて、ヴィンスとニコが亡者になってしまった時に"
+        "Vince and Nico were fooled by a lout named Patches, and turned\ninto Hollows."
       ]
     },
     {
       "ID": 17001401,
       "Entries": [
-        "私は、私の祈りも、何の役にも立ちませんでした"
+        "My prayers did them no good."
       ]
     },
     {
       "ID": 17001402,
       "Entries": [
-        "私は、無力で、愚か者なのです。けれども、それを知らず、あの2人を巻き込んでしまった…"
+        "It is my ignorance, my frailty that has sealed their fates."
       ]
     },
     {
       "ID": 17001403,
       "Entries": [
-        "あるいは、ペトルスは、昔から私を見て、そうと知っていたのかもしれません"
+        "Perhaps Petrus realized my weakness all along,"
       ]
     },
     {
       "ID": 17001404,
       "Entries": [
-        "だから、私を捨て、逃げてしまったのでしょう…"
+        "and thus made the decision to abandon me."
       ]
     },
     {
       "ID": 17001405,
       "Entries": [
-        "仕方のないことだと思います"
+        "I can hardly blame him now."
       ]
     },
     {
       "ID": 17001500,
       "Entries": [
-        "…私は、知らない人が苦手なんです"
+        "I do not warm easily to unfamiliar faces."
       ]
     },
     {
       "ID": 17001501,
       "Entries": [
-        "だから、下の篝火は少し賑やかで…いたたまれないのです"
+        "The bonfire below is so very frequented, it makes it difficult..."
       ]
     },
     {
       "ID": 17001502,
       "Entries": [
-        "知っていた人は、すべて失ってしまいましたし…"
+        "I have lost all those who were close to me."
       ]
     },
     {
       "ID": 17001700,
       "Entries": [
-        "どうして、あなたが…"
+        "Why on earth would you..."
       ]
     },
     {
       "ID": 17001701,
       "Entries": [
-        "それとも、これが罰でしょうか？"
+        "Perhaps this is my punishment?"
       ]
     },
     {
       "ID": 17001702,
       "Entries": [
-        "私が、あなたに手向かうなど無益なこと。ただ、1つ、お願いです"
+        "Clearly, I am no threat to you. But please, I ask just one thing."
       ]
     },
     {
       "ID": 17001703,
       "Entries": [
-        "私が亡者となったら、どうか、それを鎮めてください"
+        "If I do go Hollow, then finish me off."
       ]
     },
     {
       "ID": 17001704,
       "Entries": [
-        "お願いします"
+        "I beg of you."
       ]
     },
     {
       "ID": 17001800,
       "Entries": [
-        "ああ、ヴィンス、ニコ…"
+        "Dear Vince, dear Nico..."
       ]
     },
     {
       "ID": 17001801,
       "Entries": [
-        "ごめんなさい…"
+        "Forgive me..."
       ]
     },
     {
       "ID": 17010000,
       "Entries": [
-        "…あなたは、亡者ではありませんね？"
+        "You're no Hollow, are you?"
       ]
     },
     {
       "ID": 17010001,
       "Entries": [
-        "…よかった"
+        "Thank goodness."
       ]
     },
     {
       "ID": 17010002,
       "Entries": [
-        "でも、気をつけてください。この先に、恐ろしい亡者が、2人います"
+        "Please be careful. There are two fierce Hollows not far from\nhere."
       ]
     },
     {
       "ID": 17010003,
       "Entries": [
-        "どちらも優れた騎士で…私の、供だった者です"
+        "They were once brave knights...my former escorts."
       ]
     },
     {
       "ID": 17010004,
       "Entries": [
-        "あの者たちが亡者となり、神に背くなど、酷いことですが…"
+        "Who would let such strong spirits be Hollowed so?"
       ]
     },
     {
       "ID": 17010005,
       "Entries": [
-        "私には…どうしても…どうすることもできないのです…"
+        "Heavens...Is there nothing...Nothing at all to be done?"
       ]
     },
     {
       "ID": 17010100,
       "Entries": [
-        "…2人の亡者を、鎮めてくれたのですね"
+        "You banished those two Hollows, did you?"
       ]
     },
     {
       "ID": 17010101,
       "Entries": [
-        "私たちの不始末で、あなたにご迷惑をおかけしました"
+        "It pains me to think of the trouble my failings have caused."
       ]
     },
     {
       "ID": 17010102,
       "Entries": [
-        "あの2人、ヴィンスも、ニコも、きっとあなたに感謝していると思います"
+        "I am certain that both Vince and Nico are grateful to you."
       ]
     },
     {
       "ID": 17010103,
       "Entries": [
-        "ありがとうございました"
+        "Thank you so very much."
       ]
     },
     {
       "ID": 17010104,
       "Entries": [
-        "これは彼らの形見です。私などより、あなたが持っているべきでしょう"
+        "Here, these belonged to them. You deserve them more than I."
       ]
     },
     {
       "ID": 17010110,
       "Entries": [
-        "あの2人、ヴィンスも、ニコも、きっとあなたに感謝していると思います"
+        "I am certain that both Vince and Nico are grateful to you."
       ]
     },
     {
       "ID": 17010111,
       "Entries": [
-        "ありがとうございました"
+        "Thank you so very much."
       ]
     },
     {
       "ID": 17010200,
       "Entries": [
-        "痛いッ！"
+        "Ow!"
       ]
     },
     {
       "ID": 17010210,
       "Entries": [
-        "何をするんですか！"
+        "Horrors!"
       ]
     },
     {
       "ID": 17010220,
       "Entries": [
-        "無礼者！"
+        "The nerve!"
       ]
     },
     {
       "ID": 17010300,
       "Entries": [
-        "…不敬者か！それとも既に亡者ですか！"
+        "Are you a heretic, or just plain Hollow?"
       ]
     },
     {
       "ID": 17010301,
       "Entries": [
-        "どちらとて、許すわけにはいきません！"
+        "It matters not, for you shall not escape!"
       ]
     },
     {
       "ID": 17010302,
       "Entries": [
-        "神に唾する愚か者よ！"
+        "You will offend the Gods no longer!"
       ]
     },
     {
       "ID": 17010400,
       "Entries": [
-        "ウッ！クウウッ…"
+        "Hrgkt! Eeg..."
       ]
     },
     {
       "ID": 17010401,
       "Entries": [
-        "お父様…"
+        "Father..."
       ]
     },
     {
       "ID": 17010500,
       "Entries": [
-        "悲しい人…"
+        "O piteous soul..."
       ]
     },
     {
       "ID": 17010501,
       "Entries": [
-        "でも…私も…何れこうなってしまうのかしら…"
+        "But...perhaps...this was a fate unyielding..."
       ]
     },
     {
       "ID": 17010600,
       "Entries": [
-        "どうして、あなたが…"
+        "Why on earth would you..."
       ]
     },
     {
       "ID": 17010601,
       "Entries": [
-        "それとも、これが罰でしょうか？"
+        "Perhaps this is my punishment?"
       ]
     },
     {
       "ID": 17010602,
       "Entries": [
-        "私が、あなたに手向かうなど無益なこと。ただ、1つ、お願いです"
+        "Clearly, I am no threat to you. But please, I ask just one thing."
       ]
     },
     {
       "ID": 17010603,
       "Entries": [
-        "私が亡者となったら、どうか、それを鎮めてください"
+        "If I do go Hollow, then finish me off."
       ]
     },
     {
       "ID": 17010604,
       "Entries": [
-        "お願いします"
+        "I beg of you."
       ]
     },
     {
       "ID": 17010700,
       "Entries": [
-        "ああ、ヴィンス、ニコ…"
+        "Dear Vince, dear Nico..."
       ]
     },
     {
       "ID": 17010701,
       "Entries": [
-        "ごめんなさい…"
+        "Forgive me..."
       ]
     },
     {
       "ID": 18000000,
       "Entries": [
-        "ああ、こんにちは。はじめまして、ですな"
+        "Hello there. I believe we are not acquainted?"
       ]
     },
     {
       "ID": 18000001,
       "Entries": [
-        "ソルロンドのペトルスと申しますが、何か御用ですかな？"
+        "I am Petrus of Thorolund. Have you business with us?"
       ]
     },
     {
       "ID": 18000002,
       "Entries": [
-        "…御用がなければ、お互い、あまり関わらない方が宜しいでしょう"
+        "...If not, I'd prefer to keep a distance, if possible."
       ]
     },
     {
       "ID": 18000100,
       "Entries": [
-        "ああ、貴方ですか"
+        "Hello there."
       ]
     },
     {
       "ID": 18000101,
       "Entries": [
-        "関わらない方が宜しいと、申し上げたはずですが…"
+        "I realize that I have requested that we retain our distance,"
       ]
     },
     {
       "ID": 18000102,
       "Entries": [
-        "…まあ、貴方のお気持ちも分かります。私としても、無碍は好きではありません"
+        "But I also want you to know that it is not meant in ill-will."
       ]
     },
     {
       "ID": 18000103,
       "Entries": [
-        "これは、私どもの気持ちです。どうか、とっておいてください"
+        "Here, take this. As a token of peace."
       ]
     },
     {
       "ID": 18000104,
       "Entries": [
-        "さあ、いいのです。遠慮なんてなさらずに"
+        "No, go ahead. It's for you."
       ]
     },
     {
       "ID": 18000200,
       "Entries": [
-        "ああ、また貴方ですか"
+        "Oh, my... you again?"
       ]
     },
     {
       "ID": 18000201,
       "Entries": [
-        "憐れみも、過ぎれば罪悪となります"
+        "Empathy, in excess, becomes a sin."
       ]
     },
     {
       "ID": 18000202,
       "Entries": [
-        "貴方は賢いお方だ。お分かりになるでしょう？"
+        "But you already knew that...I should hope?"
       ]
     },
     {
       "ID": 18000250,
       "Entries": [
-        "ああ、また貴方ですか"
+        "Oh, my... you again?"
       ]
     },
     {
       "ID": 18000251,
       "Entries": [
-        "ああ、そうです。こうしましょう"
+        "Oh, I know. How about this..."
       ]
     },
     {
       "ID": 18000252,
       "Entries": [
-        "私は、ここで少し人を待たなければならないのですが"
+        "I have to await my companions here anyway,"
       ]
     },
     {
       "ID": 18000253,
       "Entries": [
-        "宜しければ、その間、貴方に奇跡をお教えしましょう"
+        "so, what if I were to teach you some miracles?"
       ]
     },
     {
       "ID": 18000254,
       "Entries": [
-        "どうですか？"
+        "Would that please you?"
       ]
     },
     {
       "ID": 18000300,
       "Entries": [
-        "ああ、貴方ですか"
+        "Oh, you yet again?"
       ]
     },
     {
       "ID": 18000301,
       "Entries": [
-        "私どもは、もうすぐ使命に旅立ちます"
+        "We shall depart on our mission soon,"
       ]
     },
     {
       "ID": 18000302,
       "Entries": [
-        "やっと、お嬢様が決心なされたのです"
+        "for M'lady has made her final decision."
       ]
     },
     {
       "ID": 18000303,
       "Entries": [
-        "貴方とも、お別れですね。ほんとうに、名残惜しいことです"
+        "So, I must say farewell, although with great regret."
       ]
     },
     {
       "ID": 18000304,
       "Entries": [
-        "（祈りの言葉）"
+        "Vereor Nox"
       ]
     },
     {
       "ID": 18000400,
       "Entries": [
-        "グッ！"
+        "Hrg!"
       ]
     },
     {
       "ID": 18000410,
       "Entries": [
-        "ウッ！"
+        "Ooh!"
       ]
     },
     {
       "ID": 18000420,
       "Entries": [
-        "ムウッ！"
+        "Mrgm!"
       ]
     },
     {
       "ID": 18000430,
       "Entries": [
-        "グワッ！"
+        "Ooph!"
       ]
     },
     {
       "ID": 18000500,
       "Entries": [
-        "何のつもりだ、ばか者が！"
+        "By the Lords! You damn fool!"
       ]
     },
     {
       "ID": 18000501,
       "Entries": [
-        "もう許さんぞ！神の威を知るがいい！"
+        "Enough of you! Feel the wrath of the gods!"
       ]
     },
     {
       "ID": 18000600,
       "Entries": [
-        "そ、そんな…いやだ…"
+        "N...no...this can't be..."
       ]
     },
     {
       "ID": 18000601,
       "Entries": [
-        "なんだって、こんなところで…"
+        "It can't end like this..."
       ]
     },
     {
       "ID": 18010000,
       "Entries": [
-        "…あ、ああ、貴方でしたか"
+        "Uh, oh, you again?"
       ]
     },
     {
       "ID": 18010001,
       "Entries": [
-        "いや、それが、お嬢様とはぐれてしまいまして…"
+        "Me? Er, I've become separated from M'lady."
       ]
     },
     {
       "ID": 18010002,
       "Entries": [
-        "八方手を尽くしているのですが、見つかりません"
+        "I've scoured near and far, but no sight of her..."
       ]
     },
     {
       "ID": 18010003,
       "Entries": [
-        "どこにいってしまったのか…"
+        "Where could she have gone?"
       ]
     },
     {
       "ID": 18010004,
       "Entries": [
-        "お嬢様…私が命をかけてお守りすると、誓っておりましたものを…"
+        "M'lady...To think I swore to protect you with my life..."
       ]
     },
     {
       "ID": 18010100,
       "Entries": [
-        "ああ、お嬢様…どこにいってしまったのか…"
+        "Your Highness...where have you gone?"
       ]
     },
     {
       "ID": 18010101,
       "Entries": [
-        "私がついていながら、こんなことになるなんて…"
+        "I am entirely to blame for this..."
       ]
     },
     {
       "ID": 18010102,
       "Entries": [
-        "ああっ、情けない。すべてこのペトルスの不徳なのです…"
+        "Oh woe is me. I am unworthy, deathly so..."
       ]
     },
     {
       "ID": 18010200,
       "Entries": [
-        "…ああ、貴方ですか"
+        "Oh, hello there."
       ]
     },
     {
       "ID": 18010201,
       "Entries": [
-        "ロートレク殿の、お仲間なのでしょう？"
+        "Have you spoken with Sir Lautrec?"
       ]
     },
     {
       "ID": 18010202,
       "Entries": [
-        "でしたら話は早い。お嬢様は、地下墓地の奥、巨人の棺を滑り降りた先にある、穴倉の中にいます"
+        "Splendid. In the depths of the Catacombs, M'lady slipped off the\ngiant's coffin and into a hole."
       ]
     },
     {
       "ID": 18010203,
       "Entries": [
-        "お供の2人も今や人でなく、お1人で泣いていらっしゃるでしょう"
+        "Her two companions are no longer human; and the lass weeps in\nsolitude."
       ]
     },
     {
       "ID": 18010204,
       "Entries": [
-        "貴方なら、簡単に自由にできますよ。血筋ばかりの小娘に、何ができるはずもありませんからねえ…"
+        "Right now, you could do as you please with her. The poor little\npurebred is entirely helpless."
       ]
     },
     {
       "ID": 18010205,
       "Entries": [
-        "クックックックッ…"
+        "Keh heh heh heh..."
       ]
     },
     {
       "ID": 18010300,
       "Entries": [
-        "お嬢様は、地下墓地の奥、巨人の棺を滑り降りた先にある、穴倉の中にいます"
+        "In the depths of the Catacombs, M'lady slipped off the giant's\ncoffin and into a hole."
       ]
     },
     {
       "ID": 18010301,
       "Entries": [
-        "お供の2人も今や人でなく、お1人で泣いていらっしゃるでしょう"
+        "Her two companions are no longer human; and the lady weeps in\nsolitude."
       ]
     },
     {
       "ID": 18010302,
       "Entries": [
-        "クックックックッ…"
+        "Keh heh heh heh..."
       ]
     },
     {
       "ID": 18010400,
       "Entries": [
-        "…あ、ああ、貴方。私のお嬢様を存じませんか？"
+        "...Ah, oh, you. Have you seen M'lady?"
       ]
     },
     {
       "ID": 18010401,
       "Entries": [
-        "ああ、今頃、どこでどうしていらっしゃるのか…"
+        "Oh, blast, where might she be, and would she be safe..."
       ]
     },
     {
       "ID": 18010500,
       "Entries": [
-        "な、なんですと！で、では、お嬢様は、もう…"
+        "Are, are you sure?! Then M'lady..."
       ]
     },
     {
       "ID": 18010501,
       "Entries": [
-        "なんということでしょう！おいたわしいことです…"
+        "What terrifying news! What am I to do..."
       ]
     },
     {
       "ID": 18010502,
       "Entries": [
-        "私の力が及ばないばかりに…こんなことに…"
+        "All because of my shortcomings...it is my fault..."
       ]
     },
     {
       "ID": 18010503,
       "Entries": [
-        "ククーッ（泣き）"
+        "Sob..."
       ]
     },
     {
       "ID": 18010600,
       "Entries": [
-        "…ああ、貴方ですか"
+        "...Oh, it's you..."
       ]
     },
     {
       "ID": 18010601,
       "Entries": [
-        "…お嬢様を、助けられたのですな"
+        "...You rescued M'lady?"
       ]
     },
     {
       "ID": 18010602,
       "Entries": [
-        "何のつもりか分かりませんが、無駄なことでしたな"
+        "Well, a pity that is, for it will amount to nothing."
       ]
     },
     {
       "ID": 18010603,
       "Entries": [
-        "あんな小娘、家柄でもなければ、生きて役立つこともありませんからねえ…"
+        "For the little madam is not worth her salt without her family\nname."
       ]
     },
     {
       "ID": 18010604,
       "Entries": [
-        "クックックックッ…"
+        "Keh heh heh heh..."
       ]
     },
     {
       "ID": 18010700,
       "Entries": [
-        "グッ！"
+        "Hrgkt!"
       ]
     },
     {
       "ID": 18010710,
       "Entries": [
-        "ウッ！"
+        "Ooph!"
       ]
     },
     {
       "ID": 18010720,
       "Entries": [
-        "ムウッ！"
+        "Mnph!"
       ]
     },
     {
       "ID": 18010730,
       "Entries": [
-        "グワッ！"
+        "Argh!"
       ]
     },
     {
       "ID": 18010800,
       "Entries": [
-        "何のつもりだ、愚か者が。下らん情にでも絆されたか"
+        "What is it, fool? Driven to madness by emotion?"
       ]
     },
     {
       "ID": 18010801,
       "Entries": [
-        "まあいい。貴様も亡者に落としてやる！"
+        "So be it. You'll make a fine Hollow!"
       ]
     },
     {
       "ID": 18010802,
       "Entries": [
-        "仲良く腐れダンスでも踊るがいい！"
+        "You can waltz in the infernal depths together!"
       ]
     },
     {
       "ID": 18010900,
       "Entries": [
-        "クッ、なぜだ…なぜ私が…"
+        "Rrk! Why...how could I..."
       ]
     },
     {
       "ID": 18010901,
       "Entries": [
-        "私が何をしたって…いうんだ…"
+        "What the...what did I do wrong..."
       ]
     },
     {
       "ID": 18011000,
       "Entries": [
-        "狼は羊の中にいる。亡者では、気をつけることだな…"
+        "Too bad for you, I'm a wolf in sheep's clothing. Best of luck as\na Hollow!"
       ]
     },
     {
       "ID": 18011001,
       "Entries": [
-        "ウェーハッハッハッ！"
+        "Gah hah hah hah hah!"
       ]
     },
     {
       "ID": 18011100,
       "Entries": [
-        "ああ、貴方ですか"
+        "Oh, hello..."
       ]
     },
     {
       "ID": 18011101,
       "Entries": [
-        "勿論、お礼は差し上げますよ。約束ですからね"
+        "Of course I will repay you. I gave you my word."
       ]
     },
     {
       "ID": 18011102,
       "Entries": [
-        "でも、何がよろしいでしょうか…"
+        "I'm just not sure what would do..."
       ]
     },
     {
       "ID": 18011103,
       "Entries": [
-        "ああ、そうです。こうしましょう"
+        "Oh, I know. How about this..."
       ]
     },
     {
       "ID": 18011104,
       "Entries": [
-        "私は、ここで少し人を待たなければならないのですが"
+        "I have to await my companions here anyway,"
       ]
     },
     {
       "ID": 18011105,
       "Entries": [
-        "宜しければ、その間、貴方に奇跡をお教えしましょう"
+        "so, what if I were to teach you some miracles?"
       ]
     },
     {
       "ID": 18011106,
       "Entries": [
-        "どうですか？"
+        "Would that please you?"
       ]
     },
     {
       "ID": 18011200,
       "Entries": [
-        "宜しい。それでは、まず神の誓約を…"
+        "Very well. Then first, a Covenant with the Gods."
       ]
     },
     {
       "ID": 18011210,
       "Entries": [
-        "では、貴方に奇跡をお教えしましょう"
+        "Now, let me share my Miracles."
       ]
     },
     {
       "ID": 18011211,
       "Entries": [
-        "もっとも…成果は、貴方の努力と、誠意次第ですよ"
+        "Only, their ultimate effectiveness will be determined by your\nefforts, and your faith."
       ]
     },
     {
       "ID": 18011300,
       "Entries": [
-        "それは残念だ。でも仕方ありませんね"
+        "That is a shame. But each to their own."
       ]
     },
     {
       "ID": 18011301,
       "Entries": [
-        "気が変わったら声をかけてください"
+        "Speak to me if you have a change of heart."
       ]
     },
     {
       "ID": 18011400,
       "Entries": [
-        "ああ、貴方ですか"
+        "Oh, hello."
       ]
     },
     {
       "ID": 18011401,
       "Entries": [
-        "勿論、奇跡をお教えしますよ。約束ですからね"
+        "I will teach you Miracles. A promise is a promise, after all."
       ]
     },
     {
       "ID": 18011500,
       "Entries": [
-        "ああ、貴方ですか"
+        "Oh, hello."
       ]
     },
     {
       "ID": 18011501,
       "Entries": [
-        "奇跡ですね。分かっていますよ"
+        "Miracles, I presume? Yes, I know."
       ]
     },
     {
       "ID": 18011600,
       "Entries": [
-        "ああ、貴方ですか"
+        "Oh, hello."
       ]
     },
     {
       "ID": 18011601,
       "Entries": [
-        "どうしました？気が変わったのですか？"
+        "What is it? Have you changed your mind?"
       ]
     },
     {
       "ID": 18011700,
       "Entries": [
-        "またいらっしゃい"
+        "Come again."
       ]
     },
     {
       "ID": 18011701,
       "Entries": [
-        "教えの成果は、なにより誠意次第ですよ"
+        "The effectiveness of the teachings depend upon your faith."
       ]
     },
     {
       "ID": 18011800,
       "Entries": [
-        "ああ、貴方ですか"
+        "Oh, hello."
       ]
     },
     {
       "ID": 18011801,
       "Entries": [
-        "やっと、待ち人たちがきました"
+        "My guests have finally arrived."
       ]
     },
     {
       "ID": 18011802,
       "Entries": [
-        "もうすぐ、彼らと旅立つでしょう"
+        "I will be departing with them shortly."
       ]
     },
     {
       "ID": 18011803,
       "Entries": [
-        "貴方とも、もう、あまり長くはありませんね"
+        "So, I'm afraid I will be saying good-bye soon."
       ]
     },
     {
       "ID": 18011804,
       "Entries": [
-        "残念です"
+        "It was a pleasure."
       ]
     },
     {
       "ID": 18011900,
       "Entries": [
-        "待ち人は、私の主人の、お嬢様と、若い騎士たちなのです"
+        "My companions are M'lady and her young knights."
       ]
     },
     {
       "ID": 18011901,
       "Entries": [
-        "若くして、不死の使命を背負っていらっしゃる"
+        "She is young, but burdened by an Undead mission."
       ]
     },
     {
       "ID": 18011902,
       "Entries": [
-        "私は、彼らの守護、お目付け役というわけです"
+        "We are her defences, to keep her from harm."
       ]
     },
     {
       "ID": 18012000,
       "Entries": [
-        "不死の使命、ですか？"
+        "An Undead mission?"
       ]
     },
     {
       "ID": 18012001,
       "Entries": [
-        "残念ですが、それは、申し上げられません"
+        "Regrettably, I cannot share that with you."
       ]
     },
     {
       "ID": 18012002,
       "Entries": [
-        "ただ、貴方は、私の教え子ですから、誠意次第では…"
+        "But you are my pupil, perhaps if you show your faith..."
       ]
     },
     {
       "ID": 18012100,
       "Entries": [
-        "そうですね、他ならぬ貴方です。お話しましょう"
+        "Very well. I can surely tell you, of all people..."
       ]
     },
     {
       "ID": 18012101,
       "Entries": [
-        "聖職における不死の使命とは、まず「継ぎ火」の探索です"
+        "Undead clerics are given a mission to seek Kindling."
       ]
     },
     {
       "ID": 18012102,
       "Entries": [
-        "「継ぎ火」は、人間性により、不死の篝火を育てる業"
+        "Kindling is the art of feeding bonfires with humanity."
       ]
     },
     {
       "ID": 18012103,
       "Entries": [
-        "それにより、我らは英雄の力を得るのです"
+        "Through Kindling, we shall one day be granted magnificent powers."
       ]
     },
     {
       "ID": 18012200,
       "Entries": [
-        "まあ、でも、難しいですね。使命は秘匿されるべきですから…"
+        "I am afraid that may be difficult. For our missions are sacred."
       ]
     },
     {
       "ID": 18012300,
       "Entries": [
-        "レア様は、ソルロンドの名家のご息女です"
+        "Reah is the youngest daughter of the good house of Thorolund."
       ]
     },
     {
       "ID": 18012301,
       "Entries": [
-        "若い騎士たちは、いわゆるご学友ですか…"
+        "Those young knights are her old schoolmates,"
       ]
     },
     {
       "ID": 18012302,
       "Entries": [
-        "でも、どうなんでしょうね"
+        "But I'm not sure what to make of them..."
       ]
     },
     {
       "ID": 18012303,
       "Entries": [
-        "私などから見ると、あまりよい友人には思えませんねえ…"
+        "I'm afraid they may be a bad influence..."
       ]
     },
     {
       "ID": 18012400,
       "Entries": [
-        "ああ、すみません。奇跡ですね"
+        "Oh, I'm sorry. Miracles, was it?"
       ]
     },
     {
       "ID": 18012401,
       "Entries": [
-        "…悲しんでいるばかりで、お恥ずかしい"
+        "...I'm distracted by grief; pay me no mind!"
       ]
     },
     {
       "ID": 18012410,
       "Entries": [
-        "ああ、すみません。奇跡ですね"
+        "Oh, I'm sorry. Miracles, was it?"
       ]
     },
     {
       "ID": 18012411,
       "Entries": [
-        "…気が焦るばかりで、お恥ずかしい"
+        "...Sometimes I lose myself; pay me no mind!"
       ]
     },
     {
       "ID": 18020000,
       "Entries": [
-        "助けてください！"
+        "Help me!"
       ]
     },
     {
       "ID": 18020001,
       "Entries": [
-        "誰か！助けてください！"
+        "Somebody! Help me!"
       ]
     },
     {
       "ID": 18020002,
       "Entries": [
-        "動けないんです！"
+        "I am trapped!"
       ]
     },
     {
       "ID": 18020100,
       "Entries": [
-        "ああ、貴方…助けてください…"
+        "You there, please, help me..."
       ]
     },
     {
       "ID": 18020101,
       "Entries": [
-        "見ての通り捕らわれて、動けないんです"
+        "As you can see I am captured, immobilized."
       ]
     },
     {
       "ID": 18020102,
       "Entries": [
-        "このままでは、屍術の贄にされてしまいます"
+        "Soon to be a sacrifice to necromancy."
       ]
     },
     {
       "ID": 18020103,
       "Entries": [
-        "お願いです…助けてください…"
+        "I implore you...please help..."
       ]
     },
     {
       "ID": 18020104,
       "Entries": [
-        "ウッ…"
+        "Ooh..."
       ]
     },
     {
       "ID": 18020200,
       "Entries": [
-        "ふう…助かりました"
+        "Phew...I am saved."
       ]
     },
     {
       "ID": 18020201,
       "Entries": [
-        "ありがとう。貴方は恩人です"
+        "Thank you. I owe you my life."
       ]
     },
     {
       "ID": 18020202,
       "Entries": [
-        "私はソルロンドのペトルスと申します"
+        "I am Petrus of Thorolund."
       ]
     },
     {
       "ID": 18020203,
       "Entries": [
-        "拠点に戻ったら、是非、お礼をしましょう"
+        "I will be sure to repay you, back at Firelink Shrine."
       ]
     },
     {
       "ID": 18020204,
       "Entries": [
-        "遠慮なんて必要ありませんよ"
+        "Please, no, it's the least that I can do."
       ]
     },
     {
       "ID": 18020300,
       "Entries": [
-        "焦らないでください"
+        "Please, rest assured."
       ]
     },
     {
       "ID": 18020301,
       "Entries": [
-        "お礼は、拠点に戻ってからです"
+        "I shall repay you, but back at Firelink Shrine."
       ]
     },
     {
       "ID": 18020302,
       "Entries": [
-        "貪欲は、神が厳に戒めるところですよ"
+        "The Gods do not look favourably upon haste!"
       ]
     },
     {
       "ID": 18020400,
       "Entries": [
-        "グッ！"
+        "Hrg!"
       ]
     },
     {
       "ID": 18020410,
       "Entries": [
-        "ウッ！"
+        "Ooh!"
       ]
     },
     {
       "ID": 18020420,
       "Entries": [
-        "ムウッ！"
+        "Mrgm!"
       ]
     },
     {
       "ID": 18020430,
       "Entries": [
-        "グワッ！"
+        "Ooph!"
       ]
     },
     {
       "ID": 18020500,
       "Entries": [
-        "何のつもりだ、ばか者が！"
+        "By the Lords! You damn fool!"
       ]
     },
     {
       "ID": 18020501,
       "Entries": [
-        "もう許さんぞ！神の威を知るがいい！"
+        "Enough of you! Feel the wrath of the gods!"
       ]
     },
     {
       "ID": 18020600,
       "Entries": [
-        "そ、そんな…いやだ…"
+        "N...no...this can't be..."
       ]
     },
     {
       "ID": 18020601,
       "Entries": [
-        "なんだって、こんなところで…"
+        "It can't end like this..."
       ]
     },
     {
       "ID": 19000000,
       "Entries": [
-        "ん？なんだ君は？"
+        "Hm? What have we here?"
       ]
     },
     {
       "ID": 19000001,
       "Entries": [
-        "随分と汚れた身なりだが…"
+        "You look awfully raggedy..."
       ]
     },
     {
       "ID": 19000002,
       "Entries": [
-        "こんな場所だからって、あんまりじゃないか"
+        "Times are grim; the least you can do is look sharp."
       ]
     },
     {
       "ID": 19000003,
       "Entries": [
-        "少なくとも、そんな形で、お嬢様に近づかないでくれよ"
+        "Don't you dare meet M'lady like that."
       ]
     },
     {
       "ID": 19000004,
       "Entries": [
-        "きっとびっくりしちまうからな"
+        "You might scare her off for good!"
       ]
     },
     {
       "ID": 19000100,
       "Entries": [
-        "おう、また君か。何か用でもあるのか？"
+        "Oh, you again. What business have you?"
       ]
     },
     {
       "ID": 19000101,
       "Entries": [
-        "だが、多分助けにはなれないぜ"
+        "I don't suppose we can help, though."
       ]
     },
     {
       "ID": 19000102,
       "Entries": [
-        "俺たちは、お嬢様と使命を共にしている"
+        "We accompany M'lady on her righteous mission."
       ]
     },
     {
       "ID": 19000103,
       "Entries": [
-        "面倒だが、まあ、お嬢様もニコも、腐れ縁だからな"
+        "It is quite a chore, but I'm stuck with her, and Nico, too."
       ]
     },
     {
       "ID": 19000104,
       "Entries": [
-        "今更、放り出すわけにもいかないのさ"
+        "I can't very well abandon them now."
       ]
     },
     {
       "ID": 19000200,
       "Entries": [
-        "おう、また君か。意外としつこいな。ハハハ"
+        "Oh, you yet again. You're a persistent one, aren't you? Hah hah\nhah."
       ]
     },
     {
       "ID": 19000201,
       "Entries": [
-        "個人的には、君みたいなのも嫌いじゃないんだが"
+        "Honestly, I don't have a problem with your kind."
       ]
     },
     {
       "ID": 19000202,
       "Entries": [
-        "こればかりは、まあ、どうしようもない"
+        "But there's not very much that I can do."
       ]
     },
     {
       "ID": 19000203,
       "Entries": [
-        "俺はソルロンドのヴィンス"
+        "I am Vince of Thorolund."
       ]
     },
     {
       "ID": 19000204,
       "Entries": [
-        "お互い、無事を祈ろうぜ"
+        "Let's say a word, for our safety."
       ]
     },
     {
       "ID": 19000205,
       "Entries": [
-        "俺たちの偉大な神様にさ"
+        "A prayer to our marvellous Lord."
       ]
     },
     {
       "ID": 19000206,
       "Entries": [
-        "（祈りの言葉）"
+        "Vereor Nox"
       ]
     },
     {
       "ID": 19000300,
       "Entries": [
-        "ああ、君か"
+        "Oh, it's you?"
       ]
     },
     {
       "ID": 19000301,
       "Entries": [
-        "どうやら、もうすぐ出発らしい"
+        "We are to leave momentarily."
       ]
     },
     {
       "ID": 19000302,
       "Entries": [
-        "地下墓地なんて、あんまり愉快な話じゃないが…"
+        "The Catacombs aren't exactly my idea of a good time, but..."
       ]
     },
     {
       "ID": 19000303,
       "Entries": [
-        "まあ、仕方ない。お互い、できればまた会おうぜ"
+        "What can one do? I do hope we meet again."
       ]
     },
     {
       "ID": 19000304,
       "Entries": [
-        "（祈りの言葉）"
+        "Vereor Nox"
       ]
     },
     {
       "ID": 19000420,
       "Entries": [
-        "うわっ！"
+        "Egads!"
       ]
     },
     {
       "ID": 19000430,
       "Entries": [
-        "何だ！"
+        "What the!"
       ]
     },
     {
       "ID": 19000500,
       "Entries": [
-        "クソッ！何だってんだ、おかしいのか？"
+        "Curses! What the devil's wrong with you?"
       ]
     },
     {
       "ID": 19000501,
       "Entries": [
-        "まあ、どっちでも、お嬢様の敵！"
+        "I cannot overlook a threat to M'lady!"
       ]
     },
     {
       "ID": 19000502,
       "Entries": [
-        "叩きふせるまでだ！"
+        "I'll grind you into dust!"
       ]
     },
     {
       "ID": 19000600,
       "Entries": [
-        "ば、ばかな…"
+        "By the Gods..."
       ]
     },
     {
       "ID": 19000601,
       "Entries": [
-        "レア…お嬢様…"
+        "...My...dear lady..."
       ]
     },
     {
       "ID": 20000000,
       "Entries": [
-        "むーん…"
+        "Mnnn..."
       ]
     },
     {
       "ID": 20000100,
       "Entries": [
-        "むーん…"
+        "Mnnn..."
       ]
     },
     {
       "ID": 20000200,
       "Entries": [
-        "むーん…"
+        "Mnnn..."
       ]
     },
     {
       "ID": 20000300,
       "Entries": [
-        "むーん…"
+        "Mnnn..."
       ]
     },
     {
       "ID": 20000400,
       "Entries": [
-        "むーん…"
+        "Mnnn..."
       ]
     },
     {
       "ID": 20000500,
       "Entries": [
-        "むーん…"
+        "Mnnn..."
       ]
     },
     {
       "ID": 20000600,
       "Entries": [
-        "むーん…"
+        "Mnnn..."
       ]
     },
     {
       "ID": 20000700,
       "Entries": [
-        "むーん…"
+        "Mnnn..."
       ]
     },
     {
       "ID": 20000800,
       "Entries": [
-        "むーん…"
+        "Mnnn..."
       ]
     },
     {
       "ID": 20000900,
       "Entries": [
-        "むーん…"
+        "Mnnn..."
       ]
     },
     {
       "ID": 21000000,
       "Entries": [
-        "よく参りました、試練をこえた、不死の英雄よ"
+        "Thou hast journey'd far, and overcome much, chosen Undead."
       ]
     },
     {
       "ID": 21000001,
       "Entries": [
-        "さあ、私の側に…"
+        "Come hither, child..."
       ]
     },
     {
       "ID": 21000100,
       "Entries": [
-        "不死の英雄よ"
+        "O chosen Undead."
       ]
     },
     {
       "ID": 21000101,
       "Entries": [
-        "私の名はグウィネヴィア"
+        "I am Gwynevere."
       ]
     },
     {
       "ID": 21000102,
       "Entries": [
-        "大王グウィンの娘、太陽の光の王女です"
+        "Daughter of Lord Gwyn; and Queen of Sunlight."
       ]
     },
     {
       "ID": 21000103,
       "Entries": [
-        "父が隠れてより後、貴方を待っておりました"
+        "Since the day Father his form did obscureth, I have await'd thee."
       ]
     },
     {
       "ID": 21000104,
       "Entries": [
-        "貴方に、王の器を授けます"
+        "I bequeath the Lordvessel to thee."
       ]
     },
     {
       "ID": 21000110,
       "Entries": [
-        "お願いです。大王グウィンの後継として、世界の火を継いでください"
+        "And beseech thee. Succeed Lord Gwyn, and inheriteth the Fire of\nour world."
       ]
     },
     {
       "ID": 21000111,
       "Entries": [
-        "そうすれば、人の世の夜も終わり、不死の現れもなくなるでしょう"
+        "Thou shall endeth this eternal twilight, and avert further Undead\nsacrifices."
       ]
     },
     {
       "ID": 21000200,
       "Entries": [
-        "不死の英雄よ"
+        "O Chosen Undead."
       ]
     },
     {
       "ID": 21000201,
       "Entries": [
-        "よく再び参りました"
+        "Thou hath journey'd far."
       ]
     },
     {
       "ID": 21000300,
       "Entries": [
-        "いくのですね、不死の英雄よ"
+        "Now thou shalt go forth, chosen Undead."
       ]
     },
     {
       "ID": 21000301,
       "Entries": [
-        "貴方が、常に太陽の光と共にあらんことを"
+        "May thou be one with the sunlight for evermore."
       ]
     },
     {
       "ID": 21000500,
       "Entries": [
-        "アーーーーッ"
+        "Aieegh..."
       ]
     },
     {
       "ID": 21000600,
       "Entries": [
-        "おお…王の器を満たしたのですね…"
+        "Magnificent...Thou hast filled the Lordvessel."
       ]
     },
     {
       "ID": 21000601,
       "Entries": [
-        "やはり、貴方は偉大な英雄です"
+        "Indeed, a worthy successor, thou shalt be."
       ]
     },
     {
       "ID": 21000602,
       "Entries": [
-        "ずっと、待っていたかいがありました…"
+        "My patience was not for nil..."
       ]
     },
     {
       "ID": 21000603,
       "Entries": [
-        "お願いです。大王グウィンの後継として、世界の火を継いでください"
+        "I beg of thee. Succeed Lord Gwyn, and inheriteth the world's\nFire."
       ]
     },
     {
       "ID": 21000604,
       "Entries": [
-        "それは、貴方にしか、できないことなのです"
+        "We have only thee."
       ]
     },
     {
       "ID": 21000700,
       "Entries": [
-        "父が隠れてより後、貴方を待っておりました"
+        "Since the day Father his form did obscureth, I have await'd thee."
       ]
     },
     {
       "ID": 21000701,
       "Entries": [
-        "すなわち、人として不死となり、不死として英雄となる、父の後継者を"
+        "Once living, now Undead, and a fitting heir to father Gwyn thou\nart,"
       ]
     },
     {
       "ID": 21000702,
       "Entries": [
-        "お願いです。大王グウィンの後継として、世界の火を継いでください"
+        "And beseech thee. Succeed Lord Gwyn, and inheriteth the Fire of\nour world."
       ]
     },
     {
       "ID": 21000703,
       "Entries": [
-        "それは、英雄たる貴方にさえ、辛く、厳しい試練となるでしょう"
+        "A grave and arduous test of mettle, yea, it shall be."
       ]
     },
     {
       "ID": 21000704,
       "Entries": [
-        "ですが、私たちはもう、火の明るさを知り、熱を知り、生命の営みを知っています"
+        "Indeed we had felt the warmth of Fire, its radiance, and the life\nit sustaineth."
       ]
     },
     {
       "ID": 21000705,
       "Entries": [
-        "もう、世界の火を失えば、残るのは、冷たい暗闇と、恐ればかりなのです"
+        "Without Fire, all shall be a frigid and frightful Dark."
       ]
     },
     {
       "ID": 21000800,
       "Entries": [
-        "お願いです。大王グウィンの後継として、世界の火を継いでください"
+        "Please. Father's role thou should assume, and inheriteth the Fire\nof our world."
       ]
     },
     {
       "ID": 21000801,
       "Entries": [
-        "そうすれば、人の世の夜も終わり、不死の現れもなくなるでしょう"
+        "Thou shall endeth this eternal twilight, and avert further Undead\nsacrifices."
       ]
     },
     {
       "ID": 21000802,
       "Entries": [
-        "世界の蛇、王の探索者フラムトが、貴方を導いてくれるはずです"
+        "Kingseeker Frampt, the primordial serpent, shall guideth thee."
       ]
     },
     {
       "ID": 21000850,
       "Entries": [
-        "お願いです。大王グウィンの後継として、世界の火を継いでください"
+        "Please. Father's role thou should assume, and inheriteth the Fire\nof our world."
       ]
     },
     {
       "ID": 21000851,
       "Entries": [
-        "そうすれば、人の世の夜も終わり、不死の現れもなくなるでしょう"
+        "Thou shall endeth this eternal twilight, and avert further Undead\nsacrifices."
       ]
     },
     {
       "ID": 21000900,
       "Entries": [
-        "これより後、グウィネヴィアは、貴方の守護者です"
+        "Hereafter, I, Gwynevere, shall serveth as thine guardian."
       ]
     },
     {
       "ID": 21000901,
       "Entries": [
-        "貴方が望めば、私のすべてを助けとするでしょう"
+        "If thou so needest, I shalt devote all to thine safety."
       ]
     },
     {
       "ID": 21000902,
       "Entries": [
-        "貴方が、常に太陽の光と共にあらんことを"
+        "May thou be one with the sunlight for evermore."
       ]
     },
     {
       "ID": 22000000,
       "Entries": [
-        "神の姿に刃するものよ"
+        "Thou that tarnisheth the Godmother's image."
       ]
     },
     {
       "ID": 22000001,
       "Entries": [
-        "我が名はグウィンドリン"
+        "I am Gwyndolin."
       ]
     },
     {
       "ID": 22000002,
       "Entries": [
-        "汝の不敬は、決して許されるものではない"
+        "And thy transgression shall not go unpunished."
       ]
     },
     {
       "ID": 22000003,
       "Entries": [
-        "アノール・ロンドの夜に果てるがよい"
+        "Thou shalt perish in the twilight of Anor Londo."
       ]
     },
     {
       "ID": 22000100,
       "Entries": [
-        "不敬者が…"
+        "Heretic..."
       ]
     },
     {
       "ID": 22000101,
       "Entries": [
-        "王女の姿のみならず、大王の墓所まで穢すとは…"
+        "First thou offendeth the Godmother, and now thou see fit to\ntrample upon the tomb of the Great Lord."
       ]
     },
     {
       "ID": 22000102,
       "Entries": [
-        "陰の太陽、グウィンドリンの名において"
+        "I am the Dark Sun, Gwyndolin!"
       ]
     },
     {
       "ID": 22000103,
       "Entries": [
-        "決して、許されるものと思うなよ！"
+        "Let the atonement for thy felonies commenceth!"
       ]
     },
     {
       "ID": 22000200,
       "Entries": [
-        "闇に生まれた不敬者が…"
+        "O Heretic, swathed in Dark..."
       ]
     },
     {
       "ID": 22000201,
       "Entries": [
-        "貴様に、永遠の呪いを…"
+        "An eternal curse upon thee..."
       ]
     },
     {
       "ID": 22000300,
       "Entries": [
-        "止まりなさい"
+        "Halt!"
       ]
     },
     {
       "ID": 22000301,
       "Entries": [
-        "これより先は、大王グウィンの墓所"
+        "This is the tomb of the Great Lord Gwyn."
       ]
     },
     {
       "ID": 22000302,
       "Entries": [
-        "何人であれ、これを穢すことは許されない"
+        "Tarnished, it shall not be, by the feet of men."
       ]
     },
     {
       "ID": 22000303,
       "Entries": [
-        "汝、不敬の意思なく、正しく陰の太陽の信徒ならば"
+        "If thou art a true disciple of the Dark Sun, cast aside thine\nire, "
       ]
     },
     {
       "ID": 22000304,
       "Entries": [
-        "我グウィンドリンの声を聞き、そこで跪くがよい"
+        "hear the voice of mineself, Gwyndolin, and kneel before me."
       ]
     },
     {
       "ID": 22000500,
       "Entries": [
-        "よくぞ戻った。暗月の剣よ"
+        "Welcome back, Blade of the Darkmoon."
       ]
     },
     {
       "ID": 22000501,
       "Entries": [
-        "我の力が必要であれば、汝の助けとするがよい"
+        "If mine power be need'st, I shall assist thee."
       ]
     },
     {
       "ID": 22000600,
       "Entries": [
-        "よいだろう、暗月の剣よ"
+        "Very well, Blade of the Darkmoon."
       ]
     },
     {
       "ID": 22000601,
       "Entries": [
-        "なんなりと、汝の希望を述べるがよい"
+        "Please state thy wish."
       ]
     },
     {
       "ID": 22000800,
       "Entries": [
-        "愚かな…"
+        "What foolishness..."
       ]
     },
     {
       "ID": 22000801,
       "Entries": [
-        "陰の太陽の信徒でありながら、大王の墓所を穢すとは…"
+        "Why trespasseth upon the Great Lord's tomb, whilst thou art a\ndisciple of the Dark Sun?"
       ]
     },
     {
       "ID": 22000802,
       "Entries": [
-        "我グウィンドリンの名において"
+        "Mark the words of mineself, Gwyndolin!"
       ]
     },
     {
       "ID": 22000803,
       "Entries": [
-        "もはや、汝は許されん！"
+        "Thou shalt not go unpunished!"
       ]
     },
     {
       "ID": 22000850,
       "Entries": [
-        "愚かな…"
+        "What foolishness..."
       ]
     },
     {
       "ID": 22000851,
       "Entries": [
-        "暗月の剣となりながら、大王の墓所を穢すとは…"
+        "Why would a Blade of the Darkmoon trespasseth upon the Great\nLord's tomb?"
       ]
     },
     {
       "ID": 22000852,
       "Entries": [
-        "我グウィンドリンの名において"
+        "Mark the words of mineself, Gwyndolin!"
       ]
     },
     {
       "ID": 22000853,
       "Entries": [
-        "もはや、汝は許されん！"
+        "Thou shalt not go unpunished!"
       ]
     },
     {
       "ID": 22000900,
       "Entries": [
-        "陰の太陽の信徒よ"
+        "O Disciple of the Dark Sun."
       ]
     },
     {
       "ID": 22000901,
       "Entries": [
-        "よくぞここに至り、我の声を聞いた"
+        "Thou hast journeyed far; hear my voice."
       ]
     },
     {
       "ID": 22000902,
       "Entries": [
-        "汝、我の誓約者となり神の敵を狩る剣となる"
+        "If thou shalt swear by the Covenant, to become"
       ]
     },
     {
       "ID": 22000903,
       "Entries": [
-        "我が父グウィンと、姉グウィネヴィアの陰となり"
+        "A shadow of Father Gwyn and Sister Gwynevere,"
       ]
     },
     {
       "ID": 22000904,
       "Entries": [
-        "神の敵を狩る、剣となる覚悟があるならば"
+        "A blade that shall hunt the foes of our Lords;"
       ]
     },
     {
       "ID": 22000905,
       "Entries": [
-        "我は汝を守護し、陰の太陽、暗月の力を、汝の助けとするだろう"
+        "Then I shalt protect thee, safeguarding thy person with the power\nof the Darkmoon."
       ]
     },
     {
       "ID": 22001000,
       "Entries": [
-        "よろしい。ならば、汝はこれより暗月の剣となる"
+        "Very well. Now thou art a Blade of the Darkmoon."
       ]
     },
     {
       "ID": 22001001,
       "Entries": [
-        "陰の太陽、暗月の力もて、神の敵を狩るがよい"
+        "Hunteth the enemies of the Lords, by the power of the Dark Sun."
       ]
     },
     {
       "ID": 22001100,
       "Entries": [
-        "それもよい"
+        "Very well."
       ]
     },
     {
       "ID": 22001101,
       "Entries": [
-        "だが、ならば我らは交わらぬ"
+        "We shall not need speech."
       ]
     },
     {
       "ID": 22001102,
       "Entries": [
-        "ここを去り、汝のつとめを果たすがよい"
+        "Exit here, and follow thine own design."
       ]
     },
     {
       "ID": 23000000,
       "Entries": [
-        "…うう…うう…"
+        "...Hrr...rrgg..."
       ]
     },
     {
       "ID": 23000001,
       "Entries": [
-        "…誰か…"
+        "...somebody..."
       ]
     },
     {
       "ID": 23000002,
       "Entries": [
-        "…助けて、くれ…"
+        "...please...help me..."
       ]
     },
     {
       "ID": 23000003,
       "Entries": [
-        "…嫌だ…"
+        "...please..."
       ]
     },
     {
       "ID": 23000004,
       "Entries": [
-        "…食われるのは、嫌だ…"
+        "...before she eats me..."
       ]
     },
     {
       "ID": 23000020,
       "Entries": [
-        "…おい"
+        "...You"
       ]
     },
     {
       "ID": 23000021,
       "Entries": [
-        "…おい、あんた…"
+        "...Yes, you!"
       ]
     },
     {
       "ID": 23000022,
       "Entries": [
-        "…こっちだ、こっちだよ…"
+        "...Here, over here!"
       ]
     },
     {
       "ID": 23000023,
       "Entries": [
-        "…助けてくれよ…"
+        "...Please..."
       ]
     },
     {
       "ID": 23000024,
       "Entries": [
-        "…頼む…"
+        "...You must help me..."
       ]
     },
     {
       "ID": 23000040,
       "Entries": [
-        "…おお、あんた…"
+        "...Oh, there you are..."
       ]
     },
     {
       "ID": 23000041,
       "Entries": [
-        "…頼む、俺を助けてくれ…"
+        "...You must help me..."
       ]
     },
     {
       "ID": 23000042,
       "Entries": [
-        "…でないと、俺はあいつに…"
+        "...Or else..."
       ]
     },
     {
       "ID": 23000043,
       "Entries": [
-        "…あいつに、食われちまうんだ…"
+        "...She'll have me for lunch!"
       ]
     },
     {
       "ID": 23000044,
       "Entries": [
-        "…なあ、頼むよ、あんた…"
+        "...You're my only hope..."
       ]
     },
     {
       "ID": 23000045,
       "Entries": [
-        "…頼むよ…"
+        "...Oh, please..."
       ]
     },
     {
       "ID": 23000100,
       "Entries": [
-        "…あ、ありがとうよ"
+        "...Th-thank you."
       ]
     },
     {
       "ID": 23000101,
       "Entries": [
-        "おかげで、あいつに食われずにすんだ…"
+        "I would have been her supper without you."
       ]
     },
     {
       "ID": 23000102,
       "Entries": [
-        "死ねずに料理されるなんて、考えるだけぞっとすらあ…"
+        "Being eaten alive! I shudder to think..."
       ]
     },
     {
       "ID": 23000103,
       "Entries": [
-        "ほんとに、ありがとうよ"
+        "Thank you, thank you dearly."
       ]
     },
     {
       "ID": 23000104,
       "Entries": [
-        "俺は大沼のラレンティウス"
+        "I am Laurentius, of the Great Swamp."
       ]
     },
     {
       "ID": 23000105,
       "Entries": [
-        "この借りは、きっと返すぜ"
+        "I will not forget my debt to you."
       ]
     },
     {
       "ID": 23000200,
       "Entries": [
-        "おお、あんたか"
+        "Oh, hello there."
       ]
     },
     {
       "ID": 23000201,
       "Entries": [
-        "俺ならもう大丈夫だ"
+        "I'm fine, thanks to you."
       ]
     },
     {
       "ID": 23000300,
       "Entries": [
-        "うわっ！"
+        "Whoa!"
       ]
     },
     {
       "ID": 23000320,
       "Entries": [
-        "あんた、何するんだ！"
+        "What are you doing?!"
       ]
     },
     {
       "ID": 23000340,
       "Entries": [
-        "俺だ！ラレンティウスだ！"
+        "It is I, Laurentius!"
       ]
     },
     {
       "ID": 23000360,
       "Entries": [
-        "あんたの敵じゃねえ！"
+        "I have no bone to pick with you!"
       ]
     },
     {
       "ID": 23000400,
       "Entries": [
-        "畜生！なんだってんだ！"
+        "Curse the heavens! Are you mad!"
       ]
     },
     {
       "ID": 23000401,
       "Entries": [
-        "感謝してたのに！"
+        "I owe my life to you!"
       ]
     },
     {
       "ID": 23000402,
       "Entries": [
-        "あんたには、感謝してたのに！"
+        "This is wrong! You were my friend!"
       ]
     },
     {
       "ID": 23000450,
       "Entries": [
-        "畜生！なんだってんだ！"
+        "Curse the heavens! Are you mad!"
       ]
     },
     {
       "ID": 23000500,
       "Entries": [
-        "畜生…"
+        "Curses..."
       ]
     },
     {
       "ID": 23010000,
       "Entries": [
-        "おお、あんた、無事だったか"
+        "Well, I see you made it out!"
       ]
     },
     {
       "ID": 23010001,
       "Entries": [
-        "ああ、こっちもなんとか無事さ"
+        "Yeah, I made it out safely, too."
       ]
     },
     {
       "ID": 23010002,
       "Entries": [
-        "俺には大沼の呪術があるからな。油断さえしなけりゃ、なんとかなるんだ"
+        "I have my Pyromancy of the Great Swamp, so I can usually manage,\nwith a bit of care."
       ]
     },
     {
       "ID": 23010003,
       "Entries": [
-        "おお、そうだ。あんたになら、呪術を伝授してやってもいいぜ？"
+        "Oh, yeah, by the way, er, I can share my spells with you."
       ]
     },
     {
       "ID": 23010004,
       "Entries": [
-        "あんたには素質がある。材料さえあれば、何とでもなるからな"
+        "I think you have a knack for it. All you need are the materials."
       ]
     },
     {
       "ID": 23010005,
       "Entries": [
-        "俺の感謝の気持ちだ"
+        "I'd be pleased to help you."
       ]
     },
     {
       "ID": 23010006,
       "Entries": [
-        "…それとも、あんたも、呪術は気色悪い口か？"
+        "...Ah, unless you find the magics unsavoury?"
       ]
     },
     {
       "ID": 23010010,
       "Entries": [
-        "おお、あんた、無事だったか"
+        "Well, I see you made it out!"
       ]
     },
     {
       "ID": 23010011,
       "Entries": [
-        "ああ、こっちもなんとか無事さ"
+        "Yeah, I made it out safely, too."
       ]
     },
     {
       "ID": 23010012,
       "Entries": [
-        "俺には大沼の呪術があるからな。油断さえしなけりゃ、なんとかなるんだ"
+        "I have my Pyromancy of the Great Swamp, so I can usually manage,\nwith a bit of care."
       ]
     },
     {
       "ID": 23010020,
       "Entries": [
-        "おお、そうか！"
+        "Yeah, wonderful!"
       ]
     },
     {
       "ID": 23010021,
       "Entries": [
-        "あんたの役に立てそうだ！"
+        "I'm sure they'll be of some use, some assistance."
       ]
     },
     {
       "ID": 23010022,
       "Entries": [
-        "じゃあ、まずこれを渡しておくぜ"
+        "Here, first, take this."
       ]
     },
     {
       "ID": 23010030,
       "Entries": [
-        "大沼の火だ。これであんたも、呪術師ってわけだ"
+        "A flame from the Great Swamp. Now you're a fully-fledged\npyromancer."
       ]
     },
     {
       "ID": 23010031,
       "Entries": [
-        "じゃあ、早速はじめるとしようか"
+        "Why, let's get started right now."
       ]
     },
     {
       "ID": 23010040,
       "Entries": [
-        "ああ、そうか…残念だ…"
+        "Oh, really...Well, that's a shame."
       ]
     },
     {
       "ID": 23010041,
       "Entries": [
-        "だが、仕方ないな…"
+        "But it is your choice."
       ]
     },
     {
       "ID": 23010042,
       "Entries": [
-        "俺は異端だ、そんなことはわかってる。不死になっても、それは変わらないさ"
+        "I'm on the fringe; yeah, I know. Undead or not, that's who I am."
       ]
     },
     {
       "ID": 23010043,
       "Entries": [
-        "ただ、あんたの役に立てなくて残念だよ…"
+        "I only wish that I could have repaid you somehow."
       ]
     },
     {
       "ID": 23010050,
       "Entries": [
-        "おお、そうか！"
+        "Yeah, wonderful!"
       ]
     },
     {
       "ID": 23010051,
       "Entries": [
-        "あんたの役に立てそうだ！"
+        "I'm sure they'll be of some use, some assistance."
       ]
     },
     {
       "ID": 23010052,
       "Entries": [
-        "じゃあ、早速はじめるとしようか"
+        "Why, let's get started right now."
       ]
     },
     {
       "ID": 23010100,
       "Entries": [
-        "おお、あんたか"
+        "Oh, hello, there."
       ]
     },
     {
       "ID": 23010101,
       "Entries": [
-        "無事でなによりだ"
+        "I am pleased to see you safe."
       ]
     },
     {
       "ID": 23010102,
       "Entries": [
-        "約束どおり、材料があれば、呪術を伝授するぜ"
+        "As always, if you provide the materials, I can teach you\npyromancy."
       ]
     },
     {
       "ID": 23010120,
       "Entries": [
-        "おお、あんたか"
+        "Oh, hello, there."
       ]
     },
     {
       "ID": 23010121,
       "Entries": [
-        "無事でなによりだ"
+        "I am pleased to see you safe."
       ]
     },
     {
       "ID": 23010122,
       "Entries": [
-        "それと…万が一、気が変わったら言ってくれ"
+        "Oh, and er...if by chance you've had a change of heart,"
       ]
     },
     {
       "ID": 23010123,
       "Entries": [
-        "俺があんたの役に立てるとしたら、呪術しかなさそうだからな…"
+        "I'll be pleased to assist you by sharing my spells."
       ]
     },
     {
       "ID": 23010250,
       "Entries": [
-        "おお、あんたか"
+        "Oh, hello there."
       ]
     },
     {
       "ID": 23010251,
       "Entries": [
-        "無事でなによりだ"
+        "I'm pleased to see you safe."
       ]
     },
     {
       "ID": 23010252,
       "Entries": [
-        "俺はしばらくここで休むことにした"
+        "I have decided to rest here for a while."
       ]
     },
     {
       "ID": 23010253,
       "Entries": [
-        "どうせ死にもしないのだからな…"
+        "It's not as if we'll be dying anytime soon."
       ]
     },
     {
       "ID": 23010300,
       "Entries": [
-        "じゃあな"
+        "Good-bye, then."
       ]
     },
     {
       "ID": 23010301,
       "Entries": [
-        "無事でいろよ、あんた"
+        "Be safe, friend."
       ]
     },
     {
       "ID": 23010302,
       "Entries": [
-        "亡者になんてなるんじゃねえぜ"
+        "Don't you dare go Hollow."
       ]
     },
     {
       "ID": 23010400,
       "Entries": [
-        "じゃあな"
+        "Good-bye, then."
       ]
     },
     {
       "ID": 23010401,
       "Entries": [
-        "何か見つけたら、またこいよ"
+        "Come back if you find anything new."
       ]
     },
     {
       "ID": 23010500,
       "Entries": [
-        "おい、あんた！"
+        "Wait, friend!"
       ]
     },
     {
       "ID": 23010501,
       "Entries": [
-        "どこいくんだ？"
+        "Where are you off to?"
       ]
     },
     {
       "ID": 23010600,
       "Entries": [
-        "さっきはどうしたんだ？"
+        "That was rather abrupt."
       ]
     },
     {
       "ID": 23010601,
       "Entries": [
-        "変な奴だな"
+        "You are an odd one."
       ]
     },
     {
       "ID": 23010602,
       "Entries": [
-        "ハハハハッ"
+        "Hah hah hah hah."
       ]
     },
     {
       "ID": 23010700,
       "Entries": [
-        "うわっ！"
+        "Whoa!"
       ]
     },
     {
       "ID": 23010720,
       "Entries": [
-        "あんた、どうしたんだ！"
+        "What's wrong with you!"
       ]
     },
     {
       "ID": 23010740,
       "Entries": [
-        "やめてくれよ！"
+        "Stop that, please!"
       ]
     },
     {
       "ID": 23010800,
       "Entries": [
-        "呪術師だからか！畜生！"
+        "You detest my pyromancy! That must be it!"
       ]
     },
     {
       "ID": 23010801,
       "Entries": [
-        "だったらやってやる！"
+        "Then, I'll give you a taste of it!"
       ]
     },
     {
       "ID": 23010802,
       "Entries": [
-        "あんただって、容赦しないぞ！"
+        "And it will not be pleasant, I assure you!"
       ]
     },
     {
       "ID": 23010900,
       "Entries": [
-        "あああ…"
+        "Aaahhhh..."
       ]
     },
     {
       "ID": 23011000,
       "Entries": [
-        "呪術ってのは、つまり火の業だ"
+        "Pyromancy is the art of casting fire."
       ]
     },
     {
       "ID": 23011001,
       "Entries": [
-        "火を熾し、利用する、原初の命の業だ"
+        "Produce flame, then channel it; just as our ancestors did."
       ]
     },
     {
       "ID": 23011002,
       "Entries": [
-        "だから呪術師は、自然であろうとする"
+        "A pyromancer must be in tune with nature herself."
       ]
     },
     {
       "ID": 23011003,
       "Entries": [
-        "俺のいた大沼も、そういう場所だった"
+        "My home, the Great Swamp, is an abundant store of nature."
       ]
     },
     {
       "ID": 23011004,
       "Entries": [
-        "いつかあんたにも、分かってもらえるだろう"
+        "You will understand, one day; it only takes time."
       ]
     },
     {
       "ID": 23011100,
       "Entries": [
-        "呪術には、ある種原初的な面があってな"
+        "Pyromancy has a, well, rather primitive aspect to it."
       ]
     },
     {
       "ID": 23011101,
       "Entries": [
-        "どうしても、文明みたいなものと相容れないことがある"
+        "It meshes poorly with advanced culture,"
       ]
     },
     {
       "ID": 23011102,
       "Entries": [
-        "だから、大抵、呪術師は嫌われ者だ"
+        "and pyromancers are considered rather unsavoury."
       ]
     },
     {
       "ID": 23011103,
       "Entries": [
-        "まあ、俺は人嫌いだから、ちょうどよかったさ"
+        "Which is fine, as I never got along with anybody anyway."
       ]
     },
     {
       "ID": 23011104,
       "Entries": [
-        "不死になっても、何も変わらなかったしな"
+        "So, for me, turning Undead didn't change a thing!"
       ]
     },
     {
       "ID": 23011105,
       "Entries": [
-        "ハハハハッ"
+        "Hah hah hah hah."
       ]
     },
     {
       "ID": 23011200,
       "Entries": [
-        "俺の師匠ってのが、多分今でも大沼にいるんだが"
+        "My teacher, whom I imagine still resides in the Great Swamp,"
       ]
     },
     {
       "ID": 23011201,
       "Entries": [
-        "その師匠の口癖ってのがあってな"
+        "had a funny way of putting it."
       ]
     },
     {
       "ID": 23011202,
       "Entries": [
-        "呪術ってのは、とどのつまり憧憬なんだと"
+        "He said that \"Pyromancy is the ultimate fantasy...."
       ]
     },
     {
       "ID": 23011203,
       "Entries": [
-        "闇に生きて、火に惹かれて、でも触れることすらできなくて"
+        "\"We are born into Dark, and warmed by Fire, but this Fire we\ncannot touch.\""
       ]
     },
     {
       "ID": 23011204,
       "Entries": [
-        "そんな憧れが強いものだけが、火の力の一端を手にできるんだど"
+        "\"Those whose fascination with Fire persists, learn to hold it in\ntheir own hand.\""
       ]
     },
     {
       "ID": 23011205,
       "Entries": [
-        "干からびたようなジジイの癖に、妙に格好をつけたがるんだよ…"
+        "He rather had a way with words, the old withering frog!"
       ]
     },
     {
       "ID": 23011300,
       "Entries": [
-        "この地は、呪術師には特別な意味があってな"
+        "In this land, pyromancers earn a certain respect."
       ]
     },
     {
       "ID": 23011301,
       "Entries": [
-        "伝承にある最初の王の1人、イザリスの魔女ってのが"
+        "The Witch of Izalith, one of the legendary Lords,"
       ]
     },
     {
       "ID": 23011302,
       "Entries": [
-        "そもそもの呪術の祖だと言われているんだ"
+        "is the godmother of pyromancy."
       ]
     },
     {
       "ID": 23011303,
       "Entries": [
-        "だから、不死になったときは、いっそ嬉しかったもんだ"
+        "So, the day I became Undead, I was ecstatic."
       ]
     },
     {
       "ID": 23011304,
       "Entries": [
-        "俺は選ばれたんだ、原初の呪術に触れるんだ、ってな"
+        "I felt as if I'd been chosen to attune myself to the ancient\narts."
       ]
     },
     {
       "ID": 23011305,
       "Entries": [
-        "…まあ、そんな甘いものじゃなかったがね…"
+        "...Of course, it wasn't all that romantic in the end..."
       ]
     },
     {
       "ID": 23011400,
       "Entries": [
-        "おお、あんたか"
+        "Ah, hello, there."
       ]
     },
     {
       "ID": 23011401,
       "Entries": [
-        "久しぶりじゃない…"
+        "You've been a stranger these days."
       ]
     },
     {
       "ID": 23011402,
       "Entries": [
-        "！あんた、その呪術はどうしたんだ？"
+        "Why, what spectacular pyromancy."
       ]
     },
     {
       "ID": 23011403,
       "Entries": [
-        "教えてくれ！俺は、そんな呪術見たことがない！"
+        "Tell me about it. I have never seen anything like it."
       ]
     },
     {
       "ID": 23011500,
       "Entries": [
-        "…そうか。やはりそうか！"
+        "Why, yes, of course!"
       ]
     },
     {
       "ID": 23011501,
       "Entries": [
-        "教えてくれてありがとう"
+        "Thank you for sharing."
       ]
     },
     {
       "ID": 23011502,
       "Entries": [
-        "俺も呪術師のはしくれだ。自力で彼女を見つけてみせる"
+        "I'm still an able pyromancer. I shall locate her myself."
       ]
     },
     {
       "ID": 23011503,
       "Entries": [
-        "あんたには、また借りができちまったな"
+        "I am in your debt, once again."
       ]
     },
     {
       "ID": 23011600,
       "Entries": [
-        "…そうか。俺の勘違いか…"
+        "...I see. I suppose I was mistaken."
       ]
     },
     {
       "ID": 23011601,
       "Entries": [
-        "…いや、あんたがそう言うんだ、そうなんだろう"
+        "In any case, I definitely trust you."
       ]
     },
     {
       "ID": 23011602,
       "Entries": [
-        "変なこと言って、悪かったな"
+        "Apologies, my friend."
       ]
     },
     {
       "ID": 23011603,
       "Entries": [
-        "忘れてくれ…"
+        "Forget that I said anything."
       ]
     },
     {
       "ID": 23011700,
       "Entries": [
-        "呪術の火ってのは、呪術師の体の一部なんだ"
+        "A pyromancer's flame is a part of his own body."
       ]
     },
     {
       "ID": 23011701,
       "Entries": [
-        "皆、これを大事に育て、自分の術を高めていく"
+        "The flame develops right along with his skill."
       ]
     },
     {
       "ID": 23011702,
       "Entries": [
-        "…すまん。あんたも呪術師なんだ、分かりきったことだったな"
+        "...Sorry. You're a pyromancer yourself. You already know this."
       ]
     },
     {
       "ID": 23011720,
       "Entries": [
-        "呪術の火ってのは、呪術師の体の一部なんだ"
+        "A pyromancer's flame is a part of his own body."
       ]
     },
     {
       "ID": 23011721,
       "Entries": [
-        "皆、これを大事に育て、自分の術を高めていく"
+        "The flame develops right along with his skill."
       ]
     },
     {
       "ID": 23011722,
       "Entries": [
-        "だから、あんたに渡した火は、俺の一部でもある"
+        "When I gave you that flame, I gave you a part of myself."
       ]
     },
     {
       "ID": 23011723,
       "Entries": [
-        "せいぜい大事にしてくれよな"
+        "Please take good care of it."
       ]
     },
     {
       "ID": 24000000,
       "Entries": [
-        "戻れ"
+        "Go back."
       ]
     },
     {
       "ID": 24000001,
       "Entries": [
-        "これより先は約定の禁域。混沌の生命の地"
+        "Forbidden be, these parts. The realm of the creatures of chaos."
       ]
     },
     {
       "ID": 24000002,
       "Entries": [
-        "我等は封印を受け容れている"
+        "They accept their banished fate."
       ]
     },
     {
       "ID": 24000003,
       "Entries": [
-        "戻れ"
+        "Go back."
       ]
     },
     {
       "ID": 24000004,
       "Entries": [
-        "さもなくば、すべて炎の餌食となり"
+        "Lest the flames devour all,"
       ]
     },
     {
       "ID": 24000005,
       "Entries": [
-        "混沌の生命の苗床となろう"
+        "and the children of chaos feed upon your charred ashes."
       ]
     },
     {
       "ID": 24000100,
       "Entries": [
-        "約定に従わぬ愚か者が…"
+        "Those who defy the pact..."
       ]
     },
     {
       "ID": 24000101,
       "Entries": [
-        "クラーグの地を侵した者がどうなるか"
+        "Those who trespass Quelaag's domain..."
       ]
     },
     {
       "ID": 24000102,
       "Entries": [
-        "その身で思い知るがいい！"
+        "May you feel the depth of our wrath!"
       ]
     },
     {
       "ID": 24000200,
       "Entries": [
-        "ああ、新しい生贄よ"
+        "Ahh, a precious new sacrifice!"
       ]
     },
     {
       "ID": 24000201,
       "Entries": [
-        "これより先は約定の禁域。混沌の生命の地"
+        "Forbidden be, these parts. The realm of the creatures of chaos."
       ]
     },
     {
       "ID": 24000202,
       "Entries": [
-        "そのまま前に進むがよい"
+        "Go on, go on ahead..."
       ]
     },
     {
       "ID": 24000300,
       "Entries": [
-        "ようこそ、生贄よ"
+        "Welcome, bringer of meat."
       ]
     },
     {
       "ID": 24000301,
       "Entries": [
-        "クラーグの炎に焼かれ、混沌の苗床となるがいい！"
+        "The children of chaos are hungry; give yourself to Quelaag's\nflame!"
       ]
     },
     {
       "ID": 25000000,
       "Entries": [
-        "…姉さん？"
+        "Quelaag?"
       ]
     },
     {
       "ID": 25000001,
       "Entries": [
-        "どうしたの？"
+        "My dear sister."
       ]
     },
     {
       "ID": 25000100,
       "Entries": [
-        "姉さん、どうしたの？"
+        "Quelaag, what is it?"
       ]
     },
     {
       "ID": 25000150,
       "Entries": [
-        "あ、姉さん"
+        "Oh, my dear sister."
       ]
     },
     {
       "ID": 25000151,
       "Entries": [
-        "私なら大丈夫。なんだかあまり痛くないの"
+        "Don't mind me. It does not hurt terribly."
       ]
     },
     {
       "ID": 25000300,
       "Entries": [
-        "さよなら、姉さん"
+        "Good-bye, Quelaag."
       ]
     },
     {
       "ID": 25000301,
       "Entries": [
-        "お話できて嬉しかった"
+        "It was so very nice to chat."
       ]
     },
     {
       "ID": 25000400,
       "Entries": [
-        "さよなら、姉さん"
+        "Good-bye, Quelaag."
       ]
     },
     {
       "ID": 25000401,
       "Entries": [
-        "危ないことはしないでね…"
+        "Do be safe."
       ]
     },
     {
       "ID": 25000500,
       "Entries": [
-        "あ、姉さん！"
+        "Why, Quelaag!"
       ]
     },
     {
       "ID": 25000501,
       "Entries": [
-        "どこへ…？"
+        "Where..."
       ]
     },
     {
       "ID": 25000600,
       "Entries": [
-        "姉さん、さっきはどうしたの？"
+        "Quelaag, what was that?"
       ]
     },
     {
       "ID": 25000601,
       "Entries": [
-        "何かあったの？"
+        "Is something troubling you?"
       ]
     },
     {
       "ID": 25000700,
       "Entries": [
-        "誓約…？もう一度…？"
+        "Enter a Covenant? Again?"
       ]
     },
     {
       "ID": 25000701,
       "Entries": [
-        "分かった、やってみるね"
+        "Of course. Let me try..."
       ]
     },
     {
       "ID": 25001000,
       "Entries": [
-        "アッ…"
+        "Ah..."
       ]
     },
     {
       "ID": 25001020,
       "Entries": [
-        "アアッ…"
+        "Ahh!"
       ]
     },
     {
       "ID": 25001040,
       "Entries": [
-        "キャアッ！"
+        "Eek!"
       ]
     },
     {
       "ID": 25001200,
       "Entries": [
-        "姉さん…"
+        "Quelaag..."
       ]
     },
     {
       "ID": 25001201,
       "Entries": [
-        "どうして…？"
+        "But, why...?"
       ]
     },
     {
       "ID": 25001300,
       "Entries": [
-        "ねえ、姉さん"
+        "Quelaag, my dear sister..."
       ]
     },
     {
       "ID": 25001301,
       "Entries": [
-        "ずっと、卵が痛いの。動かないの"
+        "The eggs...it hurts. They've gone still..."
       ]
     },
     {
       "ID": 25001302,
       "Entries": [
-        "だから、今度も、ダメ、だと思う"
+        "I am afraid...it may be too late..."
       ]
     },
     {
       "ID": 25001303,
       "Entries": [
-        "…ごめんね、姉さん"
+        "...I am so sorry, dear sister..."
       ]
     },
     {
       "ID": 25001400,
       "Entries": [
-        "ねえ、姉さん"
+        "Quelaag, my dear sister..."
       ]
     },
     {
       "ID": 25001401,
       "Entries": [
-        "私、時々思い出すの"
+        "You know, I still remember..."
       ]
     },
     {
       "ID": 25001402,
       "Entries": [
-        "姉さんの顔。とっても綺麗だった"
+        "Your beautiful, silky face..."
       ]
     },
     {
       "ID": 25001403,
       "Entries": [
-        "いつかもう一度、見れるといいな…"
+        "If only I could gaze upon it once more..."
       ]
     },
     {
       "ID": 25001500,
       "Entries": [
-        "私なら大丈夫、姉さんがいるもの"
+        "I'll be fine, I have you, dear sister."
       ]
     },
     {
       "ID": 25001501,
       "Entries": [
-        "だから姉さん"
+        "But promise me..."
       ]
     },
     {
       "ID": 25001502,
       "Entries": [
-        "あんまり無理しないで…"
+        "That you will take care of yourself."
       ]
     },
     {
       "ID": 25001600,
       "Entries": [
-        "姉さん？"
+        "Quelaag?"
       ]
     },
     {
       "ID": 25001601,
       "Entries": [
-        "ねえ、姉さん、泣かないで"
+        "Please, sister, do not cry."
       ]
     },
     {
       "ID": 25001602,
       "Entries": [
-        "私はずっと幸せよ。姉さんがいてくれるから…"
+        "I am happy, really. I have you, don't I?"
       ]
     },
     {
       "ID": 25001700,
       "Entries": [
-        "…ああ！"
+        "...Ooh!"
       ]
     },
     {
       "ID": 25001701,
       "Entries": [
-        "ありがとう、姉さん"
+        "Thank you, Quelaag."
       ]
     },
     {
       "ID": 25001800,
       "Entries": [
-        "ああ…"
+        "Ahh..."
       ]
     },
     {
       "ID": 25001801,
       "Entries": [
-        "ありがとう…姉さん…"
+        "Thank you...Dear sister..."
       ]
     },
     {
       "ID": 25001900,
       "Entries": [
-        "…？"
+        "...?"
       ]
     },
     {
       "ID": 26000000,
       "Entries": [
-        "…怪しい奴め…お主、何者だ？新しい従者か？"
+        "...Oh dear...What have we here? Are you a new servant?"
       ]
     },
     {
       "ID": 26000020,
       "Entries": [
-        "…ふん、卵も背負わぬ半端者がな"
+        "...Hmph. But you have no eggs?"
       ]
     },
     {
       "ID": 26000021,
       "Entries": [
-        "まあいい。ならば、進んで姫様に見えるがいい"
+        "Bah, no matter. Go along and have audience with Our Fair Lady."
       ]
     },
     {
       "ID": 26000022,
       "Entries": [
-        "くれぐれも、粗相のないようにな！"
+        "I pray that you will mind your manners!"
       ]
     },
     {
       "ID": 26000040,
       "Entries": [
-        "だったら、ここは通せん。とっとと帰れ！"
+        "Then you shall not pass. Away with you!"
       ]
     },
     {
       "ID": 26000100,
       "Entries": [
-        "どうした？はやく進んで、姫様に見えんか"
+        "What is it? Go along, and meet Our Fair Lady."
       ]
     },
     {
       "ID": 26000200,
       "Entries": [
-        "ええい、しつこいな！帰れ！帰らんか！"
+        "The nerve of you! Be gone, be gone at once!"
       ]
     },
     {
       "ID": 26000300,
       "Entries": [
-        "…お主、姫様の言葉が分かるのだな…"
+        "...You, you speak the tongue of the Fair Lady?"
       ]
     },
     {
       "ID": 26000301,
       "Entries": [
-        "…"
+        "..."
       ]
     },
     {
       "ID": 26000302,
       "Entries": [
-        "だが、調子にのるなよ。わしはまだ、お主を信用しとらんでな"
+        "Well, do not be rash with your pride. You have yet to earn my\ntrust."
       ]
     },
     {
       "ID": 26000303,
       "Entries": [
-        "姫様を傷つけでもしたら、わしが許さんぞ…"
+        "If you try anything funny with the Fair Lady, there will be hell\nto pay."
       ]
     },
     {
       "ID": 26000400,
       "Entries": [
-        "…まあ、お主も姫様の従者には違いないからな"
+        "Are you prepared to dedicate yourself to Our Fair Lady?"
       ]
     },
     {
       "ID": 26000401,
       "Entries": [
-        "姫様のために、必要なものがあれば、わしが用立ててやる"
+        "Then I will make available whatever you require."
       ]
     },
     {
       "ID": 26000402,
       "Entries": [
-        "入用があれば、遠慮して言うがいい"
+        "If you need something, ask me first."
       ]
     },
     {
       "ID": 26000500,
       "Entries": [
-        "またお主か…"
+        "You again..."
       ]
     },
     {
       "ID": 26000600,
       "Entries": [
-        "お主か…"
+        "Are you in need already?"
       ]
     },
     {
       "ID": 26000601,
       "Entries": [
-        "まあ、姫様のためだ。何が入用だ？"
+        "Well, anything for the Fair Lady...What do you want?"
       ]
     },
     {
       "ID": 26000700,
       "Entries": [
-        "…お主と話すことなど、何もない"
+        "There is no time for idle chat."
       ]
     },
     {
       "ID": 26000701,
       "Entries": [
-        "お主はただ、姫様のことだけ考えていればいいんだ"
+        "Think only of Our Fair Lady, and what she may need."
       ]
     },
     {
       "ID": 26000800,
       "Entries": [
-        "…お主と話すことなど、何もない"
+        "...There is nothing to say to you..."
       ]
     },
     {
       "ID": 26000801,
       "Entries": [
-        "ただ、これだけは言っておく。姫様を傷つけるな"
+        "Except...If you lay a hand on the Fair Lady,"
       ]
     },
     {
       "ID": 26000802,
       "Entries": [
-        "さもなければ、わしが許さんぞ…"
+        "you should be prepared to face my wrath."
       ]
     },
     {
       "ID": 26000900,
       "Entries": [
-        "うお！"
+        "Well!"
       ]
     },
     {
       "ID": 26000901,
       "Entries": [
-        "…お主…我らと同じになったのだな…"
+        "...Now...you're just like me..."
       ]
     },
     {
       "ID": 26000902,
       "Entries": [
-        "お主の誠意はよくわかった。だが、あれだ…さすがに頭はきつかろう…"
+        "Your dedication is fully apparent. Only, well...Your head looks\nawful..."
       ]
     },
     {
       "ID": 26000903,
       "Entries": [
-        "よければ、これを使うといい。もはや、わしには必要の無いものだからな"
+        "Why not try this? I've no use for it any longer."
       ]
     },
     {
       "ID": 26001000,
       "Entries": [
-        "うお！"
+        "Well!"
       ]
     },
     {
       "ID": 26001001,
       "Entries": [
-        "お主、また顔か…どうにもうまくいかないものだな…"
+        "That head of yours...Nothing seems to help, does it?"
       ]
     },
     {
       "ID": 26001002,
       "Entries": [
-        "薬はまだある。よければ使ってくれ"
+        "I still have medicine. Go ahead and use it."
       ]
     },
     {
       "ID": 26001003,
       "Entries": [
-        "まあ、なんだ。気を落とすなよ…"
+        "Now, now, no need to fret about it."
       ]
     },
     {
       "ID": 26001004,
       "Entries": [
-        "いつかきっとうまくいくさ…"
+        "Things will be fine, one day..."
       ]
     },
     {
       "ID": 26001100,
       "Entries": [
-        "おお、お主か"
+        "Oh, hello."
       ]
     },
     {
       "ID": 26001101,
       "Entries": [
-        "何か入用なのか？"
+        "What is it that you need?"
       ]
     },
     {
       "ID": 26001200,
       "Entries": [
-        "おお、お主か。久しぶりだな"
+        "Oh, hello...A pleasure to see you again."
       ]
     },
     {
       "ID": 26001201,
       "Entries": [
-        "わしもいいが、姫様も寂しがってるだろう。後で話していってくれよ"
+        "But don't neglect the Fair Lady. She needs some company."
       ]
     },
     {
       "ID": 26001300,
       "Entries": [
-        "わしは、正直お主が羨ましい"
+        "In all honesty, I am envious."
       ]
     },
     {
       "ID": 26001301,
       "Entries": [
-        "わしらなど、言葉も分からず…姫様の慰めにも、なれないのだからな…"
+        "What comfort can I offer, without speaking her tongue?"
       ]
     },
     {
       "ID": 26001400,
       "Entries": [
-        "わしらは皆、不死だって、病にまで侵された、厄介者さ"
+        "Worse than Undead, we are diseased, and unwanted."
       ]
     },
     {
       "ID": 26001401,
       "Entries": [
-        "大沼の大クソみたいなもんだ"
+        "Like the grime of the Great Swamp."
       ]
     },
     {
       "ID": 26001402,
       "Entries": [
-        "だが、だがなあ、姫様は、そんなわしらのために、泣いてくれた…"
+        "But my dear, Fair Lady! She cried for me..."
       ]
     },
     {
       "ID": 26001403,
       "Entries": [
-        "そして、クラーグ様の言うことも聞かず、病の膿を飲み込んだんだ…"
+        "And swallowed the great Blightpus, despite Mistress Quelaag's\norders to the contrary."
       ]
     },
     {
       "ID": 26001500,
       "Entries": [
-        "グウッ"
+        "Hrgkt!"
       ]
     },
     {
       "ID": 26001510,
       "Entries": [
-        "グオッ"
+        "Erggkt!"
       ]
     },
     {
       "ID": 26001520,
       "Entries": [
-        "グッ"
+        "Oog!"
       ]
     },
     {
       "ID": 26001530,
       "Entries": [
-        "ゲエッ"
+        "Hagkt!"
       ]
     },
     {
       "ID": 26001600,
       "Entries": [
-        "お主、やはりそうかっ！"
+        "I knew it! I knew it!"
       ]
     },
     {
       "ID": 26001601,
       "Entries": [
-        "許さんぞっ！"
+        "You will not get away with this!"
       ]
     },
     {
       "ID": 26001650,
       "Entries": [
-        "なぜお主が…まさか…"
+        "You...you would betray us?!"
       ]
     },
     {
       "ID": 26001651,
       "Entries": [
-        "所詮そうなのかっ！"
+        "I should have known!"
       ]
     },
     {
       "ID": 26001700,
       "Entries": [
-        "グッ…グウッ…"
+        "Hrg...rgggkt..."
       ]
     },
     {
       "ID": 26001701,
       "Entries": [
-        "姫様…どうか、健やかに…"
+        "My dear Fair Lady...You are in danger..."
       ]
     },
     {
       "ID": 26001800,
       "Entries": [
-        "お主ぃぃぃぃぃ！"
+        "Why, youuuuu monster...!"
       ]
     },
     {
       "ID": 26001801,
       "Entries": [
-        "よくも姫様を！許さん、許さんぞぉぉぉぉぉぉ！"
+        "The Fair Lady! What have you done, what have you done!"
       ]
     },
     {
       "ID": 26001802,
       "Entries": [
-        "うおおおおぉぉぉぉぉ！"
+        "Hrggreeeeeeeeeeh!"
       ]
     },
     {
       "ID": 26001900,
       "Entries": [
-        "この遺跡の下に、伝承の廃都、イザリスがある"
+        "Below us lies the ruins of the legendary city of Izalith."
       ]
     },
     {
       "ID": 26001901,
       "Entries": [
-        "溶岩の巨人に守られた、混沌の炎の遺跡だ"
+        "There, the Molten Giant watches over the Flame of Chaos."
       ]
     },
     {
       "ID": 26001902,
       "Entries": [
-        "姫様は、クラーグ様と一緒に、そこから逃げてきたのだ"
+        "Our Fair Lady, and Mistress Quelaag, fled from the ruins."
       ]
     },
     {
       "ID": 26001903,
       "Entries": [
-        "詳しい事情は知らんし…知りたいとも思わんがな…"
+        "I do not know the details...And I do not ask..."
       ]
     },
     {
       "ID": 26002000,
       "Entries": [
-        "お主、「さまよえるクラーナ」を知っているか？"
+        "Have you heard of Lost Quelana?"
       ]
     },
     {
       "ID": 26002001,
       "Entries": [
-        "あの毒沼のどこかに、人でない魔女がいるという"
+        "An inhuman witch, who wanders the Poison Swamp."
       ]
     },
     {
       "ID": 26002002,
       "Entries": [
-        "確かに見た者とてない、下らん噂話だが…"
+        "Only no one has ever seen her, so who really knows?"
       ]
     },
     {
       "ID": 26002003,
       "Entries": [
-        "姫様とクラーグ様の、姉妹だという者もいる"
+        "But what if she is another of the Quelaag sisters?"
       ]
     },
     {
       "ID": 26002004,
       "Entries": [
-        "もしそうなら、姫様の慰めになるのだろうか…"
+        "Our Fair Lady would be greatly comforted by her presence."
       ]
     },
     {
       "ID": 26002100,
       "Entries": [
-        "そういえば、お主。呪術に興味はないか？"
+        "Incidentally, do you have an interest in pyromancy?"
       ]
     },
     {
       "ID": 26002101,
       "Entries": [
-        "もし興味があるなら、わしの火を分けてやろう"
+        "If you have, I shall share my flame with you."
       ]
     },
     {
       "ID": 26002110,
       "Entries": [
-        "そういえば、お主。呪術に興味はでたか？"
+        "Have you developed an interest in pyromancy?"
       ]
     },
     {
       "ID": 26002111,
       "Entries": [
-        "もし興味があるなら、わしの火を分けてやろう"
+        "If you have, I shall share my flame with you."
       ]
     },
     {
       "ID": 26002200,
       "Entries": [
-        "お主も、姫様の従者だからな"
+        "You have served our Fair Lady well."
       ]
     },
     {
       "ID": 26002201,
       "Entries": [
-        "力を持っていたほうがよい…"
+        "Now, let this strength be yours."
       ]
     },
     {
       "ID": 26002300,
       "Entries": [
-        "…そうか。まあ、無理にとは言わんさ"
+        "...Well, fine. I will not force you."
       ]
     },
     {
       "ID": 27000000,
       "Entries": [
-        "ほう…不死者が、私の姿が見えるのか？おもしろい…"
+        "Hmm...A mere Undead, yet you can see me? Fascinating..."
       ]
     },
     {
       "ID": 27000001,
       "Entries": [
-        "私はイザリスのクラーナ"
+        "I am Quelana of Izalith."
       ]
     },
     {
       "ID": 27000002,
       "Entries": [
-        "人の身で私の姿を見る者は久しぶりだ。…才もある"
+        "I am not often revealed to walkers of flesh. You have a gift."
       ]
     },
     {
       "ID": 27000003,
       "Entries": [
-        "お前も、私の呪術が目当てなのか？"
+        "Are you, too, one who seeks my pyromancy?"
       ]
     },
     {
       "ID": 27000004,
       "Entries": [
-        "あのザラマンのように"
+        "Like Salaman."
       ]
     },
     {
       "ID": 27000020,
       "Entries": [
-        "ふうん、そうか。そうだろうな"
+        "Yes, of course. It should be expected."
       ]
     },
     {
       "ID": 27000021,
       "Entries": [
-        "だったら、お前を私の弟子にしてやろう"
+        "Very well. You shall be my pupil."
       ]
     },
     {
       "ID": 27000022,
       "Entries": [
-        "だが、私の呪術は、それなりの糧を要求するぞ"
+        "But to pursue my pyromancy, you must give something up."
       ]
     },
     {
       "ID": 27000023,
       "Entries": [
-        "お前に応えられるものかな？"
+        "Are you prepared to do this?"
       ]
     },
     {
       "ID": 27000040,
       "Entries": [
-        "ふうん、そうか。それでは用もないな"
+        "Hmm, very well. Then we are done."
       ]
     },
     {
       "ID": 27000041,
       "Entries": [
-        "故も無い。どこへなりと去るがいい"
+        "You have spoken. Now away with you."
       ]
     },
     {
       "ID": 27000060,
       "Entries": [
-        "どうした？私の呪術に興味がでてきたのか？"
+        "What? Considering my pyromancy?"
       ]
     },
     {
       "ID": 27000100,
       "Entries": [
-        "ああ、お前か"
+        "Ah, there you are."
       ]
     },
     {
       "ID": 27000101,
       "Entries": [
-        "待っていたぞ。早速はじめようか"
+        "I was expecting you. Let us begin."
       ]
     },
     {
       "ID": 27000120,
       "Entries": [
-        "ああ、またお前か"
+        "Ah, you again."
       ]
     },
     {
       "ID": 27000121,
       "Entries": [
-        "熱心なのはよいことだが、糧は用意してきたんだろうな？"
+        "I applaud your diligence, but what have you brought for me?"
       ]
     },
     {
       "ID": 27000130,
       "Entries": [
-        "ああ、またお前か"
+        "Ah, you again."
       ]
     },
     {
       "ID": 27000131,
       "Entries": [
-        "熱心なのはよいことだ"
+        "I applaud your diligence."
       ]
     },
     {
       "ID": 27000140,
       "Entries": [
-        "ああ、お前か。久しぶりだな"
+        "Ah. It has been some time."
       ]
     },
     {
       "ID": 27000141,
       "Entries": [
-        "よく無事でいたな。もうダメなのかと思っていたぞ"
+        "Truth be told, I thought you had perished."
       ]
     },
     {
       "ID": 27000200,
       "Entries": [
-        "成果なしか…"
+        "No luck, hmm..."
       ]
     },
     {
       "ID": 27000201,
       "Entries": [
-        "まあ、馬鹿弟子には、忍耐も必要というものさ"
+        "Well, young pupil, you must have patience."
       ]
     },
     {
       "ID": 27000202,
       "Entries": [
-        "少しは気にしろよ"
+        "But do not keep me waiting much longer."
       ]
     },
     {
       "ID": 27000250,
       "Entries": [
-        "成果なしか…"
+        "No luck, hmm..."
       ]
     },
     {
       "ID": 27000251,
       "Entries": [
-        "あまり気にするなよ"
+        "Do not let it bother you."
       ]
     },
     {
       "ID": 27000300,
       "Entries": [
-        "よし、いってこい"
+        "Now, go."
       ]
     },
     {
       "ID": 27000301,
       "Entries": [
-        "馬鹿弟子が、亡者になんてなるんじゃないぞ"
+        "Whatever you do, do not crack and go Hollow."
       ]
     },
     {
       "ID": 27000302,
       "Entries": [
-        "かけた時間が無駄になる"
+        "Lest my time spent on you be wasted."
       ]
     },
     {
       "ID": 27000320,
       "Entries": [
-        "…いくのか"
+        "Ah, very well."
       ]
     },
     {
       "ID": 27000321,
       "Entries": [
-        "もう、お前には何も教えることはないな"
+        "There is nothing left for me to teach you."
       ]
     },
     {
       "ID": 27000322,
       "Entries": [
-        "そろそろお別れだ。短い間だったが、楽しかったよ"
+        "Our time together is done. It was short, but sweet."
       ]
     },
     {
       "ID": 27000340,
       "Entries": [
-        "馬鹿者が。はやくいかんか"
+        "Fool. Hurry along."
       ]
     },
     {
       "ID": 27000341,
       "Entries": [
-        "…私では、もうなにもしてやれんぞ…"
+        "I can do nothing more for you."
       ]
     },
     {
       "ID": 27000350,
       "Entries": [
-        "よし、いってこい"
+        "Now, go."
       ]
     },
     {
       "ID": 27000351,
       "Entries": [
-        "亡者になんてなるんじゃないぞ"
+        "Don't you dare let yourself go Hollow."
       ]
     },
     {
       "ID": 27000352,
       "Entries": [
-        "かけた時間が無駄になる"
+        "Lest my time spent on you be wasted."
       ]
     },
     {
       "ID": 27000400,
       "Entries": [
-        "ん？どこへ行くんだ？"
+        "Hm? What's the rush?"
       ]
     },
     {
       "ID": 27000500,
       "Entries": [
-        "突然どうした？どうにも変な奴だな"
+        "What was that? You are a peculiar one."
       ]
     },
     {
       "ID": 27000640,
       "Entries": [
-        "なんのつもりだ！お前！"
+        "What is it! Fool!"
       ]
     },
     {
       "ID": 27000660,
       "Entries": [
-        "やめんか！"
+        "Stop that!"
       ]
     },
     {
       "ID": 27000700,
       "Entries": [
-        "ほう…言っても分からんか"
+        "Hmm...The voice of reason fails?"
       ]
     },
     {
       "ID": 27000701,
       "Entries": [
-        "ならば、思い知らせてやる"
+        "Then here is a lesson for you..."
       ]
     },
     {
       "ID": 27000702,
       "Entries": [
-        "お前の未熟さをな！"
+        "That you can only learn once!"
       ]
     },
     {
       "ID": 27000800,
       "Entries": [
-        "ああ、母様、みんな…"
+        "Farewell, my mother, my sisters..."
       ]
     },
     {
       "ID": 27000801,
       "Entries": [
-        "お前、どうして…"
+        "What have you done..."
       ]
     },
     {
       "ID": 27000900,
       "Entries": [
-        "昔、お前の他に1人だけ、弟子をとった"
+        "Long ago, I accepted another pupil, like yourself."
       ]
     },
     {
       "ID": 27000901,
       "Entries": [
-        "と言っても、200年以上前の話だが…お前と同じくらい、できの悪い男だった"
+        "Over two-hundred years ago, there was a man, almost as bungling\nas you..."
       ]
     },
     {
       "ID": 27000902,
       "Entries": [
-        "お前たちの世界では、呪術王ザラマンなどと呼ばれているかな"
+        "In your world he was called Salaman the Master Pyromancer."
       ]
     },
     {
       "ID": 27000903,
       "Entries": [
-        "あの小僧が、まったく偉そうになったものだよ…"
+        "The little rascal really made something of himself."
       ]
     },
     {
       "ID": 27001000,
       "Entries": [
-        "呪術とは、炎の業、炎を熾し、それを御する業だ"
+        "Pyromancy is the art of invoking and manipulating fire."
       ]
     },
     {
       "ID": 27001001,
       "Entries": [
-        "だが、いいか。これだけは覚えておけ"
+        "But remember one thing."
       ]
     },
     {
       "ID": 27001002,
       "Entries": [
-        "炎を畏れろ。その畏れを忘れた者は、炎に飲まれ、すべてを失う"
+        "Always fear the flame, lest you be devoured by it, and lose\nyourself."
       ]
     },
     {
       "ID": 27001003,
       "Entries": [
-        "もう、そんなものは見たくないんだ…"
+        "I would hate to see that happen again..."
       ]
     },
     {
       "ID": 27001100,
       "Entries": [
-        "…イザリスの魔女か…"
+        "The Witch of Izalith?"
       ]
     },
     {
       "ID": 27001101,
       "Entries": [
-        "…すまんが、その話はやめてくれんか"
+        "...Please, do not speak of her."
       ]
     },
     {
       "ID": 27001102,
       "Entries": [
-        "…私は、母も、妹たちも、すべて棄てて逃げ出したんだ"
+        "...I abandoned my mother and sisters and fled to this land."
       ]
     },
     {
       "ID": 27001103,
       "Entries": [
-        "…そして、罪を滅ぼすと言い、探求のふりをしている"
+        "...Now I roam these parts, feigning ablution,"
       ]
     },
     {
       "ID": 27001104,
       "Entries": [
-        "…卑怯者だよ…"
+        "and pretending to seek answers."
       ]
     },
     {
       "ID": 27001200,
       "Entries": [
-        "…なあ、お前"
+        "...Hmm..."
       ]
     },
     {
       "ID": 27001201,
       "Entries": [
-        "1つ、頼みがあるんだが…"
+        "I have a favour to ask..."
       ]
     },
     {
       "ID": 27001202,
       "Entries": [
-        "私の母イザリスは、かつて最初の王の1人だった"
+        "My mother, the Witch of Izalith, was one of the primeval Lords..."
       ]
     },
     {
       "ID": 27001203,
       "Entries": [
-        "最初の火のそばで、ソウルを見出し、その力で王になったんだ"
+        "Her power came from the soul that she found near the First Flame."
       ]
     },
     {
       "ID": 27001204,
       "Entries": [
-        "…そして母は、その力で自分だけの炎を熾そうとして…それを制御できなかった"
+        "...She focused this power to light a flame of her own, but she\nfailed to control it."
       ]
     },
     {
       "ID": 27001205,
       "Entries": [
-        "混沌の炎は、母も、妹たちも飲み込み、異形の生命の苗床にしてしまった"
+        "The Flame of Chaos engulfed Mother and my sisters, and moulded\nthem into deformed creatures."
       ]
     },
     {
       "ID": 27001206,
       "Entries": [
-        "だが、私だけは逃げ出して、こんなところにいる"
+        "Only I escaped, and now I am here."
       ]
     },
     {
       "ID": 27001207,
       "Entries": [
-        "母も、妹たちも、ずっと、ずっと、苦しんでいるというのに…"
+        "But my mother and sisters have been in anguish since."
       ]
     },
     {
       "ID": 27001208,
       "Entries": [
-        "だから、お前に頼みたい。母と、妹たちを、混沌の炎から解放してやってくれ"
+        "I beseech you. Free Mother and my sisters from the Flame of\nChaos."
       ]
     },
     {
       "ID": 27001209,
       "Entries": [
-        "私には、できない。その力も、覚悟もない…"
+        "I cannot do it myself; I lack the strength, and the bravery..."
       ]
     },
     {
       "ID": 27001210,
       "Entries": [
-        "だがお前なら…"
+        "...But you..."
       ]
     },
     {
       "ID": 27001211,
       "Entries": [
-        "勝手なことは分かっている。だが、お願いだ、皆を解放してやってくれ…"
+        "I realize what I am asking. But please, free their poor souls..."
       ]
     },
     {
       "ID": 27001212,
       "Entries": [
-        "母の野心が不遜なものであったとて、1000年だ、もう償いは済んでいるだろう…"
+        "Mother's ambitions were misguided, no doubt, but surely a\nthousand years of atonement is enough!"
       ]
     },
     {
       "ID": 27001300,
       "Entries": [
-        "お前…よくやってくれたな"
+        "Outstanding...You have done very well."
       ]
     },
     {
       "ID": 27001301,
       "Entries": [
-        "ありがとう。お前に会えて、本当によかったよ"
+        "Thank you. I am blessed to have met you."
       ]
     },
     {
       "ID": 27001302,
       "Entries": [
-        "もうとても、馬鹿弟子なんて呼べないな…"
+        "I suppose I can call you fool no longer..."
       ]
     },
     {
       "ID": 27001303,
       "Entries": [
-        "私では、碌な礼もできんが…"
+        "I can hardly thank you enough."
       ]
     },
     {
       "ID": 27001304,
       "Entries": [
-        "これが、私のすべてだ。受け取ってくれ"
+        "Please take this...It is all of me."
       ]
     },
     {
       "ID": 27001310,
       "Entries": [
-        "ありがとう。お前に会えて、本当によかったよ"
+        "Thank you. I am blessed to have met you."
       ]
     },
     {
       "ID": 27001311,
       "Entries": [
-        "もうとても、馬鹿弟子なんて呼べないな…"
+        "I suppose I can call you fool no longer..."
       ]
     },
     {
       "ID": 28000000,
       "Entries": [
-        "ほう、こんなところに訪問者とは。幽霊以外は久しぶりじゃ"
+        "Well, this is a surprise. I don't get many visitors, except for\nghosts."
       ]
     },
     {
       "ID": 28000001,
       "Entries": [
-        "何か用かの？"
+        "Do you have some business here?"
       ]
     },
     {
       "ID": 28000002,
       "Entries": [
-        "わしの名はイングウァード"
+        "My name is Ingward."
       ]
     },
     {
       "ID": 28000003,
       "Entries": [
-        "わけあって、この場も動けぬ老いぼれじゃが…"
+        "I'm an old man, bound to these parts."
       ]
     },
     {
       "ID": 28000004,
       "Entries": [
-        "久しぶりの話し相手じゃ。できることなら協力するぞ"
+        "But I don't mind a chat. I may even be of some help."
       ]
     },
     {
       "ID": 28000100,
       "Entries": [
-        "ほう、こんなところに訪問者とは。幽霊以外は久しぶりじゃが…"
+        "Well, this is a surprise. I don't get many visitors, except\nghosts."
       ]
     },
     {
       "ID": 28000101,
       "Entries": [
-        "お前さん…呪死したのじゃな？だからわしを訪ねてきたか"
+        "Oh, cursed, are you? Is that what brings you to me?"
       ]
     },
     {
       "ID": 28000102,
       "Entries": [
-        "苦労じゃったのう。じゃが、もう大丈夫じゃ"
+        "It is a wise choice. Your troubles will soon be over."
       ]
     },
     {
       "ID": 28000103,
       "Entries": [
-        "わしの名はイングウァード"
+        "My name is Ingward."
       ]
     },
     {
       "ID": 28000104,
       "Entries": [
-        "わけあって、この場も動けぬ老いぼれじゃが…"
+        "I'm an old man, bound to these parts."
       ]
     },
     {
       "ID": 28000105,
       "Entries": [
-        "お前さんの呪いを解くことくらいはできるじゃろう"
+        "But cleansing your curses; that I can do."
       ]
     },
     {
       "ID": 28000106,
       "Entries": [
-        "じゃが、解呪は本来神の業じゃ。相応の犠牲は、覚悟するのじゃぞ…"
+        "The breaking of curses is the territory of deities. You must be\nprepared to give some of yourself."
       ]
     },
     {
       "ID": 28000200,
       "Entries": [
-        "おお、お前さんか。どうしたのじゃ？"
+        "Oh, hello there. How are you?"
       ]
     },
     {
       "ID": 28000201,
       "Entries": [
-        "久しぶりの話し相手じゃ。できることなら協力するぞ"
+        "I don't mind a chat. I may even be of some help."
       ]
     },
     {
       "ID": 28000250,
       "Entries": [
-        "またお前さんか。どうしたのじゃ？"
+        "Hello again. How are you?"
       ]
     },
     {
       "ID": 28000300,
       "Entries": [
-        "ほう、お前さん、久しぶりじゃな。まだ無事じゃったか"
+        "Hello, there. Where have you been? I'm glad to see you well."
       ]
     },
     {
       "ID": 28000301,
       "Entries": [
-        "それで、わしに何か用かの？"
+        "How can I be of assistance?"
       ]
     },
     {
       "ID": 28000400,
       "Entries": [
-        "ほう、お前さん…もしや、呪死したのか？"
+        "Well, hello there. Have you been cursed?"
       ]
     },
     {
       "ID": 28000401,
       "Entries": [
-        "それは苦労じゃったのう。じゃが、もう大丈夫じゃ"
+        "That can be quite onerous. But not to worry."
       ]
     },
     {
       "ID": 28000402,
       "Entries": [
-        "わしが、お前さんの呪いを解いてやろう"
+        "Such cleansing, I am happy to administer."
       ]
     },
     {
       "ID": 28000403,
       "Entries": [
-        "じゃが、解呪は本来神の業じゃ。相応の犠牲は、覚悟するのじゃぞ…"
+        "But the breaking of curses is the territory of deities. You must\nbe prepared for sacrifice."
       ]
     },
     {
       "ID": 28000500,
       "Entries": [
-        "ほう、お前さん…もしや、また呪死したのか？"
+        "Hello, there. Cursed again?"
       ]
     },
     {
       "ID": 28000501,
       "Entries": [
-        "英雄の気か、それともただ無茶なのか…どちらにしろ、何度も難儀な奴じゃのう…"
+        "I do not know whether you are brave, or just foolish, but you do\nseem to find your share of trouble."
       ]
     },
     {
       "ID": 28000900,
       "Entries": [
-        "お前さんか。どうしたのじゃ？"
+        "Hello there. What is it?"
       ]
     },
     {
       "ID": 28000901,
       "Entries": [
-        "封印の鍵を託したのじゃ。わしにできることなら、なんでも協力するぞ"
+        "The key to the seal is now in your hands. I will help you in any\nway possible."
       ]
     },
     {
       "ID": 28001000,
       "Entries": [
-        "…お前さん、封印を解いたか…"
+        "...You've broken the seal, have you?..."
       ]
     },
     {
       "ID": 28001001,
       "Entries": [
-        "…"
+        "..."
       ]
     },
     {
       "ID": 28001002,
       "Entries": [
-        "いや、後悔はしちょらんよ。わしはフラムトと、お前さんを信じとる"
+        "No, I have no regrets. My trust lies with you, and Frampt."
       ]
     },
     {
       "ID": 28001003,
       "Entries": [
-        "だが、深淵に入れぬことには、どうしようもないのじゃぞ"
+        "But you cannot proceed without being able to traverse the Abyss."
       ]
     },
     {
       "ID": 28001010,
       "Entries": [
-        "…お前さん、封印を解いたか…"
+        "...You've broken the seal, have you?..."
       ]
     },
     {
       "ID": 28001011,
       "Entries": [
-        "…"
+        "..."
       ]
     },
     {
       "ID": 28001012,
       "Entries": [
-        "いや、後悔はしちょらんよ。わしはお前さんを信じとる"
+        "No, I have no regrets. For I trust in you."
       ]
     },
     {
       "ID": 28001013,
       "Entries": [
-        "だが、深淵に入れぬことには、どうしようもないのじゃぞ"
+        "But you cannot proceed without being able to traverse the Abyss."
       ]
     },
     {
       "ID": 28001100,
       "Entries": [
-        "わしも、多くを知っているわけではないのだが…"
+        "According to legend, the knight Artorias crossed the Abyss,"
       ]
     },
     {
       "ID": 28001101,
       "Entries": [
-        "ただ、かつて騎士アルトリウスは、深淵を歩き、ダークレイスを狩ったと言う"
+        "and annihilated the atrocious Darkwraiths."
       ]
     },
     {
       "ID": 28001102,
       "Entries": [
-        "彼を探し、力を借りれば、あるいは、深淵に入れるかもしれぬぞ…"
+        "If you can find him, and learn from him, the Abyss may prove\nsurmountable."
       ]
     },
     {
       "ID": 28001200,
       "Entries": [
-        "…そうか。四人の小王を倒したか"
+        "...Magnificent. You defeated the Four Kings."
       ]
     },
     {
       "ID": 28001201,
       "Entries": [
-        "さすがはお前さん、王の器の勇者じゃ"
+        "Impressive, even for a bearer of the Lordvessel."
       ]
     },
     {
       "ID": 28001202,
       "Entries": [
-        "これで、わしの役目も終わりじゃな…"
+        "And with this, my purpose is exhausted."
       ]
     },
     {
       "ID": 28001203,
       "Entries": [
-        "少しばかり、太陽が懐かしくなってきたところじゃ…"
+        "I have not seen the sun for a long time."
       ]
     },
     {
       "ID": 28001204,
       "Entries": [
-        "丁度よいわ…"
+        "Perhaps I could do with a change..."
       ]
     },
     {
       "ID": 28001300,
       "Entries": [
-        "おお、お前さんか"
+        "Oh, hello."
       ]
     },
     {
       "ID": 28001301,
       "Entries": [
-        "久しぶりの太陽はちときつくてな、こんな暗がりに引っ込んでおるんじゃ"
+        "The sunlight made me wince, and now I've come back to this dark\nhole!"
       ]
     },
     {
       "ID": 28001302,
       "Entries": [
-        "で、何の用じゃ？わしにできることなら、なんでも協力するぞ"
+        "So, what brings you here? I will help you in any way I can."
       ]
     },
     {
       "ID": 28001400,
       "Entries": [
-        "おお、お前さんか"
+        "Oh, hello."
       ]
     },
     {
       "ID": 28001401,
       "Entries": [
-        "どうしたのじゃ？わしにできることなら、なんでも協力するぞ"
+        "What is it? I will help you in any way that I can."
       ]
     },
     {
       "ID": 28001500,
       "Entries": [
-        "ほう、お前さん…王の器を手に入れたのか…"
+        "Oh, hello. You've acquired the Lordvessel, have you?"
       ]
     },
     {
       "ID": 28001501,
       "Entries": [
-        "そうか、お前さんが…"
+        "Very impressive."
       ]
     },
     {
       "ID": 28001502,
       "Entries": [
-        "お前さんの目的は、分かっちょる"
+        "I know exactly what your intentions are."
       ]
     },
     {
       "ID": 28001503,
       "Entries": [
-        "わしの封印しとる、四人の小王に用があるのじゃろう"
+        "You seek the Four Kings whom I guard over."
       ]
     },
     {
       "ID": 28001504,
       "Entries": [
-        "…確かに、封印の鍵は、わしが持っておる"
+        "And yes, I do have the key to the seal."
       ]
     },
     {
       "ID": 28001505,
       "Entries": [
-        "じゃが、それを渡す前に、ひとつ頼まれてくれんか"
+        "But before I give it up, there is something I must ask."
       ]
     },
     {
       "ID": 28001506,
       "Entries": [
-        "目の前に、大きな食堂があるじゃろう？"
+        "Do you see the great hall that stands before you?"
       ]
     },
     {
       "ID": 28001507,
       "Entries": [
-        "その屋上に、四人の小王の眷属、ダークレイスが、一匹棲みついておる"
+        "Atop it, you will find a Darkwraith, a servant of the Four Kings."
       ]
     },
     {
       "ID": 28001508,
       "Entries": [
-        "…お前さん、そいつを退治してくれんかの"
+        "Show me that you can defeat it."
       ]
     },
     {
       "ID": 28001509,
       "Entries": [
-        "四人の小王に挑もうという者が、その眷属も倒せんようでは"
+        "As guardian of the seal, it behoves me to test your strength."
       ]
     },
     {
       "ID": 28001510,
       "Entries": [
-        "封印の番として、お主を信用するわけにはいかんでな"
+        "For if you cannot defeat the Darkwraith, you will be no match for\nthe Four Kings."
       ]
     },
     {
       "ID": 28001511,
       "Entries": [
-        "いかにお前さんが、フラムトの選んだ者だとしてもじゃ…"
+        "Even if Frampt has chosen you."
       ]
     },
     {
       "ID": 28001512,
       "Entries": [
-        "いかにお前さんが、王の器を持つ者だとしてもじゃ…"
+        "Even if you are the bearer of the Lordvessel."
       ]
     },
     {
       "ID": 28001520,
       "Entries": [
-        "ほう、お前さん…王の器を手に入れたのか…"
+        "Oh, hello. You've acquired the Lordvessel, have you?"
       ]
     },
     {
       "ID": 28001521,
       "Entries": [
-        "そうか、お前さんが…"
+        "Very impressive."
       ]
     },
     {
       "ID": 28001522,
       "Entries": [
-        "お前さんの目的は、分かっちょる"
+        "I know exactly what your intentions are."
       ]
     },
     {
       "ID": 28001523,
       "Entries": [
-        "わしの封印しとる、四人の小王に用があるのじゃろう"
+        "You seek the Four Kings whom I guard over."
       ]
     },
     {
       "ID": 28001524,
       "Entries": [
-        "これが、封印の鍵じゃ"
+        "This is the key to the seal."
       ]
     },
     {
       "ID": 28001530,
       "Entries": [
-        "ほう、こんなところに訪問者とは。幽霊以外は久しぶりじゃが…"
+        "Well, this is a surprise. I get few visitors, save for ghosts."
       ]
     },
     {
       "ID": 28001531,
       "Entries": [
-        "お前さん…王の器をもっとるのか…"
+        "You have...the Lordvessel."
       ]
     },
     {
       "ID": 28001532,
       "Entries": [
-        "そうか、お前さんが…"
+        "Very impressive."
       ]
     },
     {
       "ID": 28001533,
       "Entries": [
-        "お前さんの目的は、分かっちょる"
+        "I know exactly what your intentions are."
       ]
     },
     {
       "ID": 28001534,
       "Entries": [
-        "わしの封印しとる、四人の小王に用があるのじゃろう"
+        "You seek the Four Kings whom I guard over."
       ]
     },
     {
       "ID": 28001535,
       "Entries": [
-        "これが、封印の鍵じゃ"
+        "This is the key to the seal."
       ]
     },
     {
       "ID": 28001540,
       "Entries": [
-        "四人の小王は、この遺跡の最深部におる"
+        "The Four Kings slumber in the deepest chamber of the ruins."
       ]
     },
     {
       "ID": 28001541,
       "Entries": [
-        "この鍵で、封印を解き…水門を開いて、進むがよい"
+        "Use this key to break the seal and open the floodgates."
       ]
     },
     {
       "ID": 28001542,
       "Entries": [
-        "…ああ、それから、ひとつ忠告じゃ"
+        "...Oh, and do not forget..."
       ]
     },
     {
       "ID": 28001543,
       "Entries": [
-        "奴らは、深淵と呼ばれる、闇に住んでおる"
+        "The Darkwraiths reside in a dark void called the Abyss."
       ]
     },
     {
       "ID": 28001544,
       "Entries": [
-        "そこは、尋常な人の赴ける場所ではないが…"
+        "But the Abyss is no place for ordinary mortals."
       ]
     },
     {
       "ID": 28001545,
       "Entries": [
-        "はるか昔、騎士アルトリウスだけが、深淵を歩いたという"
+        "Although long ago, the knight Artorias traversed the Abyss."
       ]
     },
     {
       "ID": 28001546,
       "Entries": [
-        "彼を探し、力を借りれば、あるいは、深淵に入れるかもしれぬぞ…"
+        "If you can find him, and learn from him, the Abyss may prove\nsurmountable."
       ]
     },
     {
       "ID": 28001600,
       "Entries": [
-        "ほう、こんなところに訪問者とは。幽霊以外は久しぶりじゃが…"
+        "Well, this is a surprise. I get few visitors, save for ghosts."
       ]
     },
     {
       "ID": 28001601,
       "Entries": [
-        "お前さん…王の器をもっとるのか…"
+        "You have...the Lordvessel."
       ]
     },
     {
       "ID": 28001700,
       "Entries": [
-        "おお、お前さんか"
+        "Oh, hello."
       ]
     },
     {
       "ID": 28001701,
       "Entries": [
-        "どうしたのじゃ？わしにできることなら、なんでも協力するぞ"
+        "What is it? I will help you in any way that I can."
       ]
     },
     {
       "ID": 28001800,
       "Entries": [
-        "すまんのう…お前さん…"
+        "Hate to ask, really."
       ]
     },
     {
       "ID": 28001801,
       "Entries": [
-        "じゃが、わしは封印の番じゃ。遥か昔、犠牲になった者たちのためにも"
+        "But I am the Guardian of the Seal. I have seen too many lives\nwasted over the eons."
       ]
     },
     {
       "ID": 28001802,
       "Entries": [
-        "どうしても、お前さんを試さなければならないのじゃよ"
+        "So, I had no choice but to test your mettle."
       ]
     },
     {
       "ID": 28001900,
       "Entries": [
-        "おお、お前さん、ダークレイスを倒したのじゃな！"
+        "You, you have defeated the Darkwraith!"
       ]
     },
     {
       "ID": 28001901,
       "Entries": [
-        "よくやった。…わしも、お前さんを信用しよう"
+        "Very good, indeed. I can certainly trust you."
       ]
     },
     {
       "ID": 28001902,
       "Entries": [
-        "これが、封印の鍵じゃ"
+        "This is the key to the seal."
       ]
     },
     {
       "ID": 28001903,
       "Entries": [
-        "四人の小王は、この遺跡の最深部におる"
+        "The Four Kings slumber in the deepest chamber of the ruins."
       ]
     },
     {
       "ID": 28001904,
       "Entries": [
-        "この鍵で、封印を解き…水門を開いて、進むがよい"
+        "Use this key to break the seal and open the floodgates."
       ]
     },
     {
       "ID": 28001905,
       "Entries": [
-        "…ああ、それから、ひとつ忠告じゃ"
+        "...Oh, and do not forget..."
       ]
     },
     {
       "ID": 28001906,
       "Entries": [
-        "奴らは、深淵と呼ばれる、闇に住んでおる"
+        "The Darkwraiths reside in a dark void called the Abyss."
       ]
     },
     {
       "ID": 28001907,
       "Entries": [
-        "そこは、尋常な人の赴ける場所ではないが…"
+        "But the Abyss is no place for ordinary mortals."
       ]
     },
     {
       "ID": 28001908,
       "Entries": [
-        "はるか昔、騎士アルトリウスだけが、深淵を歩いたという"
+        "Although long ago, the knight Artorias traversed the Abyss."
       ]
     },
     {
       "ID": 28001909,
       "Entries": [
-        "彼を探し、力を借りれば、あるいは、深淵に入れるかもしれぬぞ…"
+        "If you can find him, and learn from him, the Abyss may prove\nsurmountable."
       ]
     },
     {
       "ID": 28002000,
       "Entries": [
-        "わしは、封印の番じゃ"
+        "I am the Guardian of the Seal."
       ]
     },
     {
       "ID": 28002001,
       "Entries": [
-        "ダークレイスの主、四人の小王を封じておる"
+        "I watch over the Four Kings, the masters of the Darkwraiths."
       ]
     },
     {
       "ID": 28002002,
       "Entries": [
-        "ダークレイスは、人と、ソウルで生きる全ての敵"
+        "The Darkwraiths are the enemies of man, and any living thing that\nhas a soul."
       ]
     },
     {
       "ID": 28002003,
       "Entries": [
-        "この小ロンドは、奴らを生み、ただそれを封じるために、滅びたのじゃ"
+        "They were born in New Londo, and that is where they perished; the\nentire city was sacrificed to contain them."
       ]
     },
     {
       "ID": 28002004,
       "Entries": [
-        "…それほどに、あれは恐ろしい存在なのじゃよ…"
+        "...For that is how great a threat they were..."
       ]
     },
     {
       "ID": 28002100,
       "Entries": [
-        "この小ロンドは、ただダークレイスを封じるために、滅びた"
+        "New Londo was sacrificed to contain the Darkwraiths."
       ]
     },
     {
       "ID": 28002101,
       "Entries": [
-        "心するのじゃぞ。ダークレイスは、人と、ソウルで生きる全ての敵じゃ"
+        "Mark my words. The Darkwraiths are the enemies of man, and any\nliving thing that has a soul."
       ]
     },
     {
       "ID": 28002102,
       "Entries": [
-        "もう二度と、この世に放ってはならんのじゃと…"
+        "They were never meant to roam again."
       ]
     },
     {
       "ID": 28002200,
       "Entries": [
-        "…四人の小王も、昔はただの…弱い人じゃった"
+        "Long ago, the Four Kings were powerful men. Only, their hearts\nwere weak."
       ]
     },
     {
       "ID": 28002201,
       "Entries": [
-        "だが、あるとき、闇の蛇が彼らの隙につけこみ、生命喰いの力を与え"
+        "When an evil serpent dangled the art of Lifedrain before them,"
       ]
     },
     {
       "ID": 28002202,
       "Entries": [
-        "彼らを、悪にしてしまったのじゃ…"
+        "they were unable to resist, and became pawns of evil."
       ]
     },
     {
       "ID": 28002300,
       "Entries": [
-        "な！なにを！"
+        "What! No!"
       ]
     },
     {
       "ID": 28002310,
       "Entries": [
-        "なにをする！"
+        "What are you doing!"
       ]
     },
     {
       "ID": 28002320,
       "Entries": [
-        "やめろ！"
+        "Cease!"
       ]
     },
     {
       "ID": 28002330,
       "Entries": [
-        "やめんか！"
+        "Stop that!"
       ]
     },
     {
       "ID": 28002400,
       "Entries": [
-        "ふう…"
+        "Sigh..."
       ]
     },
     {
       "ID": 28002401,
       "Entries": [
-        "お前さんも、奴らと同じか…"
+        "You are no different from the rest..."
       ]
     },
     {
       "ID": 28002402,
       "Entries": [
-        "よろしい！ならば、封印の番として…"
+        "So be it! I am Ingward, the guardian of the seal."
       ]
     },
     {
       "ID": 28002403,
       "Entries": [
-        "イングウァードが引導を渡してやるわい！"
+        "Prepare to meet your doom!"
       ]
     },
     {
       "ID": 28002500,
       "Entries": [
-        "お、おおお…わしとしたことが…"
+        "Ohh...ogghh...How could I allow this..."
       ]
     },
     {
       "ID": 28002501,
       "Entries": [
-        "すまん…皆の衆…"
+        "Forgive me...my countrymen..."
       ]
     },
     {
       "ID": 28003300,
       "Entries": [
-        "な！なにを！"
+        "What! No!"
       ]
     },
     {
       "ID": 28003310,
       "Entries": [
-        "なにをする！"
+        "What are you doing!"
       ]
     },
     {
       "ID": 28003320,
       "Entries": [
-        "やめろ！"
+        "Cease!"
       ]
     },
     {
       "ID": 28003330,
       "Entries": [
-        "やめんか！"
+        "Stop that!"
       ]
     },
     {
       "ID": 28003400,
       "Entries": [
-        "ふう…"
+        "Sigh..."
       ]
     },
     {
       "ID": 28003401,
       "Entries": [
-        "お前さんも、奴らと同じか…"
+        "You are no different from the rest..."
       ]
     },
     {
       "ID": 28003402,
       "Entries": [
-        "よろしい！ならば、封印の番として…"
+        "So be it! I am Ingward, the guardian of the seal."
       ]
     },
     {
       "ID": 28003403,
       "Entries": [
-        "イングウァードが引導を渡してやるわい！"
+        "Prepare to meet your doom!"
       ]
     },
     {
       "ID": 28003500,
       "Entries": [
-        "お、おおお…わしとしたことが…"
+        "Ohh...ogghh...How could I allow this..."
       ]
     },
     {
       "ID": 28003501,
       "Entries": [
-        "すまん…皆の衆…"
+        "Forgive me...my countrymen..."
       ]
     },
     {
       "ID": 29000000,
       "Entries": [
-        "よう、新顔だな"
+        "Well, you must be a new arrival."
       ]
     },
     {
       "ID": 29000001,
       "Entries": [
-        "俺の名はアストラのアンドレイ"
+        "I'm Andre, of Astora."
       ]
     },
     {
       "ID": 29000002,
       "Entries": [
-        "見ての通り、鍛冶話なら、力になれると思うぜ"
+        "If you require smithing, then speak to me."
       ]
     },
     {
       "ID": 29000100,
       "Entries": [
-        "よう、あんたか"
+        "Well, hello again."
       ]
     },
     {
       "ID": 29000101,
       "Entries": [
-        "まだ無事なようでなによりだ"
+        "You seem to be doing all right."
       ]
     },
     {
       "ID": 29000102,
       "Entries": [
-        "で、何を鍛えたいんだ？"
+        "Need anything forged?"
       ]
     },
     {
       "ID": 29000200,
       "Entries": [
-        "武器や防具ってのは、そりゃあ丈夫なもんばっかりだ"
+        "Most weapons and armour are mighty sturdy indeed."
       ]
     },
     {
       "ID": 29000201,
       "Entries": [
-        "だからって、酷使し続ければ、当然壊れちまう"
+        "But every hunk of metal has its breaking point."
       ]
     },
     {
       "ID": 29000202,
       "Entries": [
-        "だから、耐久度が下がってきたら、まめに修理してやってくれ"
+        "If you notice durability running low, it's time to repair."
       ]
     },
     {
       "ID": 29000203,
       "Entries": [
-        "俺のような鍛冶に頼むのもいいし、砥石があれば、自分でやることもできる"
+        "You can ask a blacksmith like meself, or do it on your own with a\ngrindstone."
       ]
     },
     {
       "ID": 29000204,
       "Entries": [
-        "あいつらは戦友だ。決してあんたを裏切らない"
+        "The nice thing about weapons... they never betray you."
       ]
     },
     {
       "ID": 29000205,
       "Entries": [
-        "だから…大事にしてやってくれよ"
+        "So, pay them a little respect, eh?"
       ]
     },
     {
       "ID": 29000300,
       "Entries": [
-        "武器を鍛えるやり方は、大きく2つある。単純強化と、進化だ"
+        "There are two types of weapon forging. There's reinforcement, and\nthere's ascension."
       ]
     },
     {
       "ID": 29000301,
       "Entries": [
-        "単純強化は簡単だ。武器の性質を変えずに、その武器を強くする"
+        "Reinforcement is simple. It strengthens the weapon and nothing\nmore."
       ]
     },
     {
       "ID": 29000302,
       "Entries": [
-        "俺のような鍛冶は当然だが、鍛冶箱があれば、自分でやることもできるぜ"
+        "A simple task for any blacksmith. Hell, you could even do it\nyourself with a smithbox."
       ]
     },
     {
       "ID": 29000303,
       "Entries": [
-        "だが、進化は違う。武器の性質を変える、高度な鍛冶だ"
+        "But ascension's a finer art. It alters a weapon's properties."
       ]
     },
     {
       "ID": 29000304,
       "Entries": [
-        "だから進化は、俺のような鍛冶の専売だ。鍛冶箱ていどではどうにもならん"
+        "Ascension is the territory of we blacksmiths; a smithbox just\nwon't do the trick."
       ]
     },
     {
       "ID": 29000305,
       "Entries": [
-        "まあ、単純強化は、いずれ限界にぶち当たる。そうしたら、進化を考えればいい"
+        "Start out with reinforcement. When that loses its charm, you can\nconsider ascension."
       ]
     },
     {
       "ID": 29000306,
       "Entries": [
-        "あんたももう分かってるだろうが、この地には、まともの奴なんていやしない"
+        "As you've noticed, this land is flush with the mad and wicked."
       ]
     },
     {
       "ID": 29000307,
       "Entries": [
-        "尋常な武器のままじゃあ、とうてい刃が立たなくなっちまうぜ"
+        "You won't make it through the night without employing my\nservices!"
       ]
     },
     {
       "ID": 29000308,
       "Entries": [
-        "ウワッハッハッ"
+        "Hah hah hah!"
       ]
     },
     {
       "ID": 29000400,
       "Entries": [
-        "ああ、防具を鍛えるやり方も、武器とほとんど同じだ"
+        "You can forge armour just like you do weapons."
       ]
     },
     {
       "ID": 29000401,
       "Entries": [
-        "単純強化だけだから、むしろ武器よりも簡単だな"
+        "Forging armour is even easier than forging weapons."
       ]
     },
     {
       "ID": 29000402,
       "Entries": [
-        "武器と防具、どっちを先に鍛えるのかはあんた次第だ"
+        "Whether you forge weapons or armour first? Well, that's up to\nyou."
       ]
     },
     {
       "ID": 29000403,
       "Entries": [
-        "俺だって、あんたの亡者は見たくもねえ"
+        "But nobody wants to see you go Hollow."
       ]
     },
     {
       "ID": 29000404,
       "Entries": [
-        "よく考えて判断してくれよ"
+        "So, whatever you do, you'd better do it well!"
       ]
     },
     {
       "ID": 29000405,
       "Entries": [
-        "ウワッハッハッ"
+        "Hah hah hah!"
       ]
     },
     {
       "ID": 29000500,
       "Entries": [
-        "ここは古い教会だ"
+        "This is the old church."
       ]
     },
     {
       "ID": 29000501,
       "Entries": [
-        "あんたの通ってきた不死教会は、ここを棄てて建てられたんだ"
+        "It was abandoned in favour of the church that you passed through."
       ]
     },
     {
       "ID": 29000502,
       "Entries": [
-        "だから、ってわけでもないが、ここは2つの、古い禁域につながってる。センの古城と、黒い森の庭だ"
+        "There are paths leading from here to two forbidden planes: Sen's\nFortress, and the Darkroot Garden."
       ]
     },
     {
       "ID": 29000503,
       "Entries": [
-        "どっちも、まともな奴が訪れる場所じゃあない"
+        "They attract all sorts of lunatics, no-one as cultured as\nyourself."
       ]
     },
     {
       "ID": 29000504,
       "Entries": [
-        "…もっとも、まともな不死など見たこともないけどな"
+        "It's fine to be Undead, but keep a level head, eh?"
       ]
     },
     {
       "ID": 29000505,
       "Entries": [
-        "ウワッハッハッ"
+        "Hah hah hah!"
       ]
     },
     {
       "ID": 29000600,
       "Entries": [
-        "センの古城ってのは、古い神々が作った試練の道だ"
+        "Sen's Fortress is an old proving grounds built by the ancient\ngods."
       ]
     },
     {
       "ID": 29000601,
       "Entries": [
-        "その先には、彼らの居城、偉大なるアノール・ロンドがあると言われている"
+        "It is the only route leading to the great Anor Londo."
       ]
     },
     {
       "ID": 29000602,
       "Entries": [
-        "もっとも、古城自体に入ることだって、できやしないのが大半だがな"
+        "Of course, most fools can't even find their way into that\nfortified deathtrap."
       ]
     },
     {
       "ID": 29000603,
       "Entries": [
-        "あのタマネギ卿とかな"
+        "But they won't stop trying! Take that bumbling Sir Onion..."
       ]
     },
     {
       "ID": 29000604,
       "Entries": [
-        "ウワッハッハッ"
+        "Hah hah hah!"
       ]
     },
     {
       "ID": 29000700,
       "Entries": [
-        "おい、どこへ行くんだ？"
+        "Oi, where're you off to?"
       ]
     },
     {
       "ID": 29000800,
       "Entries": [
-        "突然どうしたんだ、まったく"
+        "What's going on with you, eh?"
       ]
     },
     {
       "ID": 29000801,
       "Entries": [
-        "亡者になっちまったかと思うじゃないか"
+        "I thought you'd gone Hollow there."
       ]
     },
     {
       "ID": 29000802,
       "Entries": [
-        "ウワッハッハッ"
+        "Hah hah hah!"
       ]
     },
     {
       "ID": 29000900,
       "Entries": [
-        "イテェッ！"
+        "Ow!"
       ]
     },
     {
       "ID": 29000950,
       "Entries": [
-        "イテェだろうが！"
+        "Owww, that hurts!"
       ]
     },
     {
       "ID": 29001000,
       "Entries": [
-        "手前、いい度胸だ！"
+        "Well, you've got some nerve!"
       ]
     },
     {
       "ID": 29001001,
       "Entries": [
-        "ふざけた真似しやがって！"
+        "Coming at me like that!"
       ]
     },
     {
       "ID": 29001002,
       "Entries": [
-        "ぶっころしてやるぞ！亡者め！"
+        "I'll tear you to shreds! You bloody Hollow!"
       ]
     },
     {
       "ID": 29001100,
       "Entries": [
-        "くそ野郎が…"
+        "Curses, you damn backstabber..."
       ]
     },
     {
       "ID": 29001200,
       "Entries": [
-        "おう、あんた、いい種火を持ってるじゃないか"
+        "Ahh, why, that's a fine ember you have there."
       ]
     },
     {
       "ID": 29001201,
       "Entries": [
-        "どうだ、その種火、俺に預けてみないか？"
+        "I could smith some mighty weapons with one of those."
       ]
     },
     {
       "ID": 29001202,
       "Entries": [
-        "そうすれば、もっといい武器を作れると思うぜ"
+        "Why not lend it to me?"
       ]
     },
     {
       "ID": 29001300,
       "Entries": [
-        "そうか…残念だ…"
+        "I see...'Tis a pity..."
       ]
     },
     {
       "ID": 29001400,
       "Entries": [
-        "よし、任せてくれ"
+        "Magnificent! You won't be disappointed."
       ]
     },
     {
       "ID": 29001401,
       "Entries": [
-        "俺の太腕が鳴るぜ…"
+        "I can hardly wait to get started..."
       ]
     },
     {
       "ID": 29001450,
       "Entries": [
-        "おう、あんた、すごい種火じゃないか！"
+        "Well, I'll be! That's a brilliant ember you've got there!"
       ]
     },
     {
       "ID": 29001451,
       "Entries": [
-        "長く鍛冶をやってるが、そんなのは見たこともねえ！"
+        "For all my years in the trade, that might be the finest!"
       ]
     },
     {
       "ID": 29001452,
       "Entries": [
-        "なあ、その種火、俺に預けてくれないか？"
+        "How's about...you leave that ember with me?"
       ]
     },
     {
       "ID": 29001453,
       "Entries": [
-        "俺も鍛冶のはしくれだ。そんなもの見せられちゃあ、もう、たまらないんだ"
+        "I'm just an old smith. I'd give my left arm for a gem like that!"
       ]
     },
     {
       "ID": 29001460,
       "Entries": [
-        "そうか…それは残念だ…"
+        "I see...'Tis a pity..."
       ]
     },
     {
       "ID": 29001461,
       "Entries": [
-        "だが…"
+        "But perhaps you'd..."
       ]
     },
     {
       "ID": 29001462,
       "Entries": [
-        "いや、いやいや、仕方ねえ…"
+        "No, no, it's quite all right..."
       ]
     },
     {
       "ID": 29001463,
       "Entries": [
-        "仕方ねえんだ…"
+        "Quite all right, indeed..."
       ]
     },
     {
       "ID": 29001470,
       "Entries": [
-        "そうか！預けてくれるか！"
+        "Well! Thank you mightily for that."
       ]
     },
     {
       "ID": 29001471,
       "Entries": [
-        "ようし、だったら任せてくれ！"
+        "Now, just leave the rest to me."
       ]
     },
     {
       "ID": 29001472,
       "Entries": [
-        "アストラのアンドレイ、あんたの期待にこたえて見せるぜ！"
+        "Andre of Astora gets the job done, you shall see!"
       ]
     },
     {
       "ID": 29001500,
       "Entries": [
-        "おう、あんた、めずらしい種火を持ってるじゃないか"
+        "My, that's a rare ember you have there."
       ]
     },
     {
       "ID": 29001501,
       "Entries": [
-        "一度だけ見たことがある…それは、聖職の鍛冶の種火だ"
+        "I've seen one of those before...It's the ember of a divine\nblacksmith."
       ]
     },
     {
       "ID": 29001502,
       "Entries": [
-        "どうだ、その種火、俺に預けてみないか？"
+        "Might you consider leaving that with me?"
       ]
     },
     {
       "ID": 29001503,
       "Entries": [
-        "神聖の武器が鍛えられるかもしれないぜ"
+        "I could produce divine weapons with a flame such as that."
       ]
     },
     {
       "ID": 29001600,
       "Entries": [
-        "そうか…それは残念だ…"
+        "I see...'Tis a pity..."
       ]
     },
     {
       "ID": 29001700,
       "Entries": [
-        "おう、預けてくれるか！"
+        "Well, thanks for that!"
       ]
     },
     {
       "ID": 29001701,
       "Entries": [
-        "いい判断だ！まあ、俺に任せときな！"
+        "You've made a fine decision. You soon shall see!"
       ]
     },
     {
       "ID": 29001800,
       "Entries": [
-        "おう、あんた、すごい種火を持ってるじゃないか…"
+        "Oh, my, what a brilliant ember you have there."
       ]
     },
     {
       "ID": 29001801,
       "Entries": [
-        "俺も、噂でしかしらないが…"
+        "I've only heard legends of such specimens..."
       ]
     },
     {
       "ID": 29001802,
       "Entries": [
-        "そりゃあ、その種火は、聖職の秘儀に違いないぜ…"
+        "The embers used for the secret rites of divine blacksmiths..."
       ]
     },
     {
       "ID": 29001803,
       "Entries": [
-        "なあ、その種火、俺に預けてくれないか？"
+        "Perhaps you could lend it to me?"
       ]
     },
     {
       "ID": 29001804,
       "Entries": [
-        "こうなったら、神聖の武器を究めてみたいんだ"
+        "I've long dreamed of forging divine weapons..."
       ]
     },
     {
       "ID": 29001900,
       "Entries": [
-        "そうか…それは残念だ…"
+        "I see...'Tis a pity..."
       ]
     },
     {
       "ID": 29001901,
       "Entries": [
-        "だが、そいつはあんたのものだ。仕方ねえな…"
+        "I can't expect you to give up what's yours."
       ]
     },
     {
       "ID": 29002000,
       "Entries": [
-        "おう！預けてくれるか！ありがとよ！"
+        "Ah-hah! Splendid, splendid! Thank you!"
       ]
     },
     {
       "ID": 29002001,
       "Entries": [
-        "アストラのアンドレイ、あんたに損はさせないぜ！"
+        "Andre of Astora never disappoints, I assure you!"
       ]
     },
     {
       "ID": 29002100,
       "Entries": [
-        "うん？あんた、その種火は…"
+        "Hrm? Show me that ember of yours..."
       ]
     },
     {
       "ID": 29002101,
       "Entries": [
-        "黒い種火なんて、聞いたこともないぜ…"
+        "Well, I've never heard of a black ember."
       ]
     },
     {
       "ID": 29002102,
       "Entries": [
-        "むぅ…"
+        "Hmmm..."
       ]
     },
     {
       "ID": 29002103,
       "Entries": [
-        "なあ、その種火、俺に預けてみないか？"
+        "How about leaving that ember with me?"
       ]
     },
     {
       "ID": 29002104,
       "Entries": [
-        "よく分からないが、何か惹かれるんだ…"
+        "I find it strangely fascinating.."
       ]
     },
     {
       "ID": 29002200,
       "Entries": [
-        "そうか…まあいい"
+        "Are you sure? Well, fair enough."
       ]
     },
     {
       "ID": 29002201,
       "Entries": [
-        "残念だが、忘れることにするさ"
+        "Tis a pity, but I'll live."
       ]
     },
     {
       "ID": 29002300,
       "Entries": [
-        "そうか、預けてくれるか"
+        "Yes, well! Thank you."
       ]
     },
     {
       "ID": 29002301,
       "Entries": [
-        "これはすごい種火だ。どうしようもなく惹きこまれる…"
+        "This ember really is something special. I'm already under its\nspell."
       ]
     },
     {
       "ID": 29002302,
       "Entries": [
-        "いい予感がするぜ…"
+        "I sense great potential, indeed..."
       ]
     },
     {
       "ID": 29002400,
       "Entries": [
-        "おう、あんた、変な種火を持ってるな"
+        "Hmm, that's an odd ember you have there."
       ]
     },
     {
       "ID": 29002401,
       "Entries": [
-        "…まあ、言いたいことは分かる。でも、それは、俺の仕事にはあわんぜ"
+        "Ahh, I know what you're thinking. But I'm no good with those."
       ]
     },
     {
       "ID": 29002402,
       "Entries": [
-        "すまんが、他をあたってくれよ"
+        "It won't be easy, but..."
       ]
     },
     {
       "ID": 29002403,
       "Entries": [
-        "もっとも、そんなのがいりゃあいいんだがな…"
+        "I'm afraid you'll have to look for someone else."
       ]
     },
     {
       "ID": 29002500,
       "Entries": [
-        "…じゃあな"
+        "I'll be seeing you, then."
       ]
     },
     {
       "ID": 29002501,
       "Entries": [
-        "あんまり無理するんじゃねえぜ…"
+        "Be careful out there."
       ]
     },
     {
       "ID": 29002600,
       "Entries": [
-        "…死ぬんじゃねえぜ"
+        "Don't get yourself killed."
       ]
     },
     {
       "ID": 29002601,
       "Entries": [
-        "あんたの亡者なんて、見たくもねえ…"
+        "Neither of us want to see you go Hollow."
       ]
     },
     {
       "ID": 29002700,
       "Entries": [
-        "黒い森の庭ってのは、俺にもよくわからない"
+        "I know little of the Darkroot Garden."
       ]
     },
     {
       "ID": 29002701,
       "Entries": [
-        "だが、かつてあそこに、聖職の鍛冶がいたって噂があってな…"
+        "Although I've heard rumours of a divine blacksmith who resides\nthere."
       ]
     },
     {
       "ID": 29002702,
       "Entries": [
-        "地下墓地あたりでどうにもならなくなったやつらが、神聖の武器欲しさに、よくここを通るのさ"
+        "Those who get stumped in the Catacombs seek him for divine\nweapons."
       ]
     },
     {
       "ID": 29002800,
       "Entries": [
-        "ああ、そういえば、黒い森の庭には、もうひとつ話があるんだ"
+        "Oh, yes, and one other thing about the Darkroot Garden."
       ]
     },
     {
       "ID": 29002801,
       "Entries": [
-        "なんでも、「深淵歩き」の騎士アルトリウスの墓があるってな"
+        "It is said to house the grave of Sir Artorias the Abysswalker."
       ]
     },
     {
       "ID": 29002802,
       "Entries": [
-        "もっとも、そう言って森に向かった連中、誰も帰ってきやしないんだがな…"
+        "Only, of those who ventured into the forest, none has returned."
       ]
     },
     {
       "ID": 30000000,
       "Entries": [
-        "…さっさと出ていかんか"
+        "...Be gone with you!"
       ]
     },
     {
       "ID": 30000001,
       "Entries": [
-        "…気が散るわい…"
+        "...You'll spoil my focus."
       ]
     },
     {
       "ID": 30000100,
       "Entries": [
-        "…なんじゃ？鍛冶仕事か？"
+        "...What's that, then? Need some smithing?"
       ]
     },
     {
       "ID": 30000101,
       "Entries": [
-        "だったらさっさと出さんか"
+        "Then produce me some wares!"
       ]
     },
     {
       "ID": 30000300,
       "Entries": [
-        "なんじゃ、おのれは"
+        "Well, what was that about?"
       ]
     },
     {
       "ID": 30000301,
       "Entries": [
-        "無用なら、さっさと出て行かんか"
+        "Don't be coming around here without a good reason!"
       ]
     },
     {
       "ID": 30000400,
       "Entries": [
-        "用が済んだら、さっさと出ていかんか"
+        "If that'll be all, then be gone with you!"
       ]
     },
     {
       "ID": 30000401,
       "Entries": [
-        "…気が散るわい…"
+        "...You'll spoil my focus."
       ]
     },
     {
       "ID": 30000500,
       "Entries": [
-        "どこへいくんじゃ？"
+        "Now where've you gone?"
       ]
     },
     {
       "ID": 30000600,
       "Entries": [
-        "…まったく、おのれは失礼者じゃ"
+        "...You've got rotten manners."
       ]
     },
     {
       "ID": 30000601,
       "Entries": [
-        "鍛冶仕事なら、余計せずさっさと出さんか"
+        "If it be smithing you need, then produce your wares."
       ]
     },
     {
       "ID": 30000700,
       "Entries": [
-        "なんじゃ？"
+        "Bah!"
       ]
     },
     {
       "ID": 30000750,
       "Entries": [
-        "なんじゃおのれは！"
+        "You rotten scoundrel!"
       ]
     },
     {
       "ID": 30000800,
       "Entries": [
-        "邪魔するなら、相手になるぞ！"
+        "Trying to cause trouble, are you?"
       ]
     },
     {
       "ID": 30000801,
       "Entries": [
-        "骨だからとて、鍛冶のバモスをなめるなよ、小僧！"
+        "I am Vamos the blacksmith, and I'm no bag of bones!"
       ]
     },
     {
       "ID": 30000900,
       "Entries": [
-        "無念じゃ…"
+        "Curses..."
       ]
     },
     {
       "ID": 30001000,
       "Entries": [
-        "…ん？それは…"
+        "...Hmph? Why, is that..."
       ]
     },
     {
       "ID": 30001001,
       "Entries": [
-        "…小ロンドの種火じゃな…"
+        "...An ember from New Londo..."
       ]
     },
     {
       "ID": 30001002,
       "Entries": [
-        "…よい種火じゃ…"
+        "...And a fine ember it be..."
       ]
     },
     {
       "ID": 30001003,
       "Entries": [
-        "どうだ？それをワシに預けてみんか？"
+        "What do you say? Why not leave it with me?"
       ]
     },
     {
       "ID": 30001004,
       "Entries": [
-        "おのれにも、炎の神髄を見せてやるぞい"
+        "I'll give you a flame to feast your eyes upon."
       ]
     },
     {
       "ID": 30001100,
       "Entries": [
-        "フン、フン、そうか、そうか…"
+        "Hmm, hmm, yes, yes, I see..."
       ]
     },
     {
       "ID": 30001101,
       "Entries": [
-        "まあ、ゆっくり考え直すのも、またよかろう…"
+        "Well, do not hesitate if you should change your mind..."
       ]
     },
     {
       "ID": 30001200,
       "Entries": [
-        "よし、よし、それでよい。老骨の仕事を見せてやるわい"
+        "Yes, yes, very well! We'll get these old bones to work!"
       ]
     },
     {
       "ID": 30001201,
       "Entries": [
-        "コッコッコッ"
+        "Keh heh heh!"
       ]
     },
     {
       "ID": 30001300,
       "Entries": [
-        "…ん？それは…"
+        "...Hmph? Why, that's..."
       ]
     },
     {
       "ID": 30001301,
       "Entries": [
-        "…見たことのない種火じゃな…"
+        "...an ember unlike any that I have seen..."
       ]
     },
     {
       "ID": 30001302,
       "Entries": [
-        "…興味深い文様じゃ…"
+        "...a very curious pattern..."
       ]
     },
     {
       "ID": 30001303,
       "Entries": [
-        "…伝承にあった、魔女の炎か…？"
+        "...Could it be the flame of the legendary witch?"
       ]
     },
     {
       "ID": 30001304,
       "Entries": [
-        "…どうだ？それをワシに預けてみんか？"
+        "...I know! Suppose you left that ember with me?"
       ]
     },
     {
       "ID": 30001305,
       "Entries": [
-        "鍛冶のバモス、後悔はさせんぞぃ…"
+        "Old Vamos would never let you down, no, not ever!"
       ]
     },
     {
       "ID": 30001400,
       "Entries": [
-        "フン、フン…まあよい"
+        "Hmm, hmm...Fine, then..."
       ]
     },
     {
       "ID": 30001401,
       "Entries": [
-        "そもそも…、まあよい、まあよいわ"
+        "I doubt you'd even...bah, forget it..."
       ]
     },
     {
       "ID": 30001402,
       "Entries": [
-        "どうせずっと骨の身だ。いつかまた、見えることもあろうて…"
+        "These bones won't fail me anytime soon. I'll come across another,\neventually..."
       ]
     },
     {
       "ID": 30001500,
       "Entries": [
-        "コッコッコッコッコッ"
+        "Keh heh heh heh heh!"
       ]
     },
     {
       "ID": 30001501,
       "Entries": [
-        "それでよい、それでよいんじゃ"
+        "Yes, splendid, splendid indeed!"
       ]
     },
     {
       "ID": 30001502,
       "Entries": [
-        "…ほぅ、ほぅ、これはよい種火じゃわい…"
+        "...My, oh, my! You precious little thing..."
       ]
     },
     {
       "ID": 30001600,
       "Entries": [
-        "…ん？それは…"
+        "...Hmph? Why, you have..."
       ]
     },
     {
       "ID": 30001601,
       "Entries": [
-        "…種火じゃな…？"
+        "...an ember, do you?"
       ]
     },
     {
       "ID": 30001602,
       "Entries": [
-        "だが、ダメじゃな。そんなまがい物に興味はない"
+        "Ahh, forget about it. I don't deal with that kind."
       ]
     },
     {
       "ID": 30001603,
       "Entries": [
-        "まったく、近頃はよい種火も少なくなった…"
+        "What has gone wrong with embers these days?"
       ]
     },
     {
       "ID": 30001700,
       "Entries": [
-        "…ふん、鍛冶仕事でなければ、用などないわ"
+        "...Hmph! I'm here to smith, not to chit chat."
       ]
     },
     {
       "ID": 30001800,
       "Entries": [
-        "…鍛冶仕事でなけりゃ、用などないと言っとろうが！"
+        "...I've told you, I'm here for the trade, not for the talk!"
       ]
     },
     {
       "ID": 30001900,
       "Entries": [
-        "余計するでないわ。気が散るわい"
+        "Enough with your presence. It disturbs me."
       ]
     },
     {
       "ID": 30002000,
       "Entries": [
-        "まったく、しつこいな、おのれも…"
+        "Well, you are a persistent one, are you not? "
       ]
     },
     {
       "ID": 30002001,
       "Entries": [
-        "ワシぁ何も知らん、鍛冶しか知らん頑固者じゃ"
+        "But I'm afraid I'm a mere blacksmith, it's just me and my trade."
       ]
     },
     {
       "ID": 30002002,
       "Entries": [
-        "おのれのような戦人の、何の役にもたたんぞい…"
+        "I would be of no help to a righteous warrior such as yourself."
       ]
     },
     {
       "ID": 30002100,
       "Entries": [
-        "まったく、話などないと、言っとろうに…"
+        "I've told you, I have nothing to discuss..."
       ]
     },
     {
       "ID": 30002101,
       "Entries": [
-        "ワシがおのれの役に立つとすれば、鍛冶だけじゃ"
+        "If I have anything to offer, it's my smithing, and nothing more."
       ]
     },
     {
       "ID": 30002102,
       "Entries": [
-        "小ロンドで見た、あのすばらしい種火でもあれば、もっとじゃが"
+        "I'd be of more help with that ember from New Londo, of course..."
       ]
     },
     {
       "ID": 30002103,
       "Entries": [
-        "あの街は、とうに水没してしまったからのう…"
+        "It's a shame the whole place was flooded..."
       ]
     },
     {
       "ID": 30002200,
       "Entries": [
-        "まったく、話などないと、言っとろうに…"
+        "I've told you, I have nothing to discuss..."
       ]
     },
     {
       "ID": 30002201,
       "Entries": [
-        "ワシがおのれの役に立つとすれば、鍛冶だけじゃが…"
+        "If I have anything to offer, it's my smithing, and nothing more."
       ]
     },
     {
       "ID": 30002202,
       "Entries": [
-        "正直、ワシぁもう限界じゃ。今以上の仕事など、できやせん"
+        "Speaking honestly, I must say that I'm at my very limit. There's\nno more work to be done."
       ]
     },
     {
       "ID": 30002203,
       "Entries": [
-        "まあ、伝承にある魔女の炎でもあれば、話は別かもしれんが"
+        "Ahh, unless I had the flame of that legendary witch..."
       ]
     },
     {
       "ID": 30002204,
       "Entries": [
-        "そもそも、廃都イザリスなど、誰も辿り着けはせんのじゃ…"
+        "But that would require a visit to Lost Izalith. Impossible..."
       ]
     },
     {
       "ID": 31000000,
       "Entries": [
-        "あんた、誰？"
+        "Who are you?"
       ]
     },
     {
       "ID": 31000001,
       "Entries": [
-        "武器、鍛えるか？"
+        "Forge your weapons?"
       ]
     },
     {
       "ID": 31000100,
       "Entries": [
-        "お。あんた"
+        "Mng. Hello."
       ]
     },
     {
       "ID": 31000101,
       "Entries": [
-        "武器、鍛えるぞ"
+        "Forge, I can!"
       ]
     },
     {
       "ID": 31000102,
       "Entries": [
-        "いつでもばんぜん"
+        "Strong, I am!"
       ]
     },
     {
       "ID": 31000200,
       "Entries": [
-        "またこい"
+        "Cometh soon."
       ]
     },
     {
       "ID": 31000300,
       "Entries": [
-        "またこい"
+        "Cometh soon."
       ]
     },
     {
       "ID": 31000400,
       "Entries": [
-        "あ、あれ？"
+        "Mng, hmng?"
       ]
     },
     {
       "ID": 31000500,
       "Entries": [
-        "おかえり"
+        "Hello again."
       ]
     },
     {
       "ID": 31000600,
       "Entries": [
-        "いてぇ"
+        "Oww."
       ]
     },
     {
       "ID": 31000650,
       "Entries": [
-        "いてぇぞ、あんた"
+        "Oww, that hurts."
       ]
     },
     {
       "ID": 31000700,
       "Entries": [
-        "あんた！"
+        "Oi!"
       ]
     },
     {
       "ID": 31000701,
       "Entries": [
-        "許さねえぞ！"
+        "Stop that!"
       ]
     },
     {
       "ID": 31000800,
       "Entries": [
-        "お、おおお…"
+        "Angh, uggghh..."
       ]
     },
     {
       "ID": 31000801,
       "Entries": [
-        "これ、どうなる…？"
+        "Nighty-night..."
       ]
     },
     {
       "ID": 31000900,
       "Entries": [
-        "お。それ、知ってるぞ"
+        "Mng. What's that?"
       ]
     },
     {
       "ID": 31000901,
       "Entries": [
-        "キラキラ、キラキラ"
+        "Shiny-shiny."
       ]
     },
     {
       "ID": 31000902,
       "Entries": [
-        "それ、あれば"
+        "Give me that."
       ]
     },
     {
       "ID": 31000903,
       "Entries": [
-        "キラキラ武器、できるぞ"
+        "I make weapons shiny."
       ]
     },
     {
       "ID": 31001000,
       "Entries": [
-        "それ、ないか…"
+        "Hmph, 'tis pity..."
       ]
     },
     {
       "ID": 31001100,
       "Entries": [
-        "これ、あれば"
+        "I hath shiny-shiny,"
       ]
     },
     {
       "ID": 31001101,
       "Entries": [
-        "キラキラ武器、できるぞ！"
+        "I make weapons shiny!"
       ]
     },
     {
       "ID": 31001200,
       "Entries": [
-        "話す、苦手"
+        "Talk, 'tis no good."
       ]
     },
     {
       "ID": 31001201,
       "Entries": [
-        "鍛えるの、得意"
+        "But forge...very good!"
       ]
     },
     {
       "ID": 31001202,
       "Entries": [
-        "いつでもばんぜん"
+        "I help anytime."
       ]
     },
     {
       "ID": 31001300,
       "Entries": [
-        "話す、苦手"
+        "Talk, 'tis no good."
       ]
     },
     {
       "ID": 31001301,
       "Entries": [
-        "誰も、いない"
+        "No-one home."
       ]
     },
     {
       "ID": 31001302,
       "Entries": [
-        "いなくなった"
+        "Everyone gone."
       ]
     },
     {
       "ID": 31001400,
       "Entries": [
-        "あんた、くる"
+        "But you, friend."
       ]
     },
     {
       "ID": 31001401,
       "Entries": [
-        "あんた、話す"
+        "You talk,"
       ]
     },
     {
       "ID": 31001402,
       "Entries": [
-        "何もない"
+        "I no talk,"
       ]
     },
     {
       "ID": 31001403,
       "Entries": [
-        "ないけど、いいか"
+        "but happy."
       ]
     },
     {
       "ID": 31001500,
       "Entries": [
-        "あんた、くる"
+        "You come,"
       ]
     },
     {
       "ID": 31001501,
       "Entries": [
-        "武器、鍛える"
+        "I forge."
       ]
     },
     {
       "ID": 31001502,
       "Entries": [
-        "キラキラキラキラ"
+        "Shiny-shiny."
       ]
     },
     {
       "ID": 31001503,
       "Entries": [
-        "こーしゃく様の、キラキラあれば"
+        "Get shiny from Duke."
       ]
     },
     {
       "ID": 31001504,
       "Entries": [
-        "キラキラ武器、できるぞ"
+        "Forge weapons, make shiny."
       ]
     },
     {
       "ID": 31001505,
       "Entries": [
-        "うれしい"
+        "More happy."
       ]
     },
     {
       "ID": 31001600,
       "Entries": [
-        "あんた、くる"
+        "You come,"
       ]
     },
     {
       "ID": 31001601,
       "Entries": [
-        "武器、鍛える"
+        "I forge,"
       ]
     },
     {
       "ID": 31001602,
       "Entries": [
-        "話す"
+        "we talk."
       ]
     },
     {
       "ID": 31001603,
       "Entries": [
-        "寂しくない"
+        "You good friend."
       ]
     },
     {
       "ID": 31001604,
       "Entries": [
-        "楽しいぞ"
+        "I very happy."
       ]
     },
     {
       "ID": 31001700,
       "Entries": [
-        "あんた…"
+        "You weak."
       ]
     },
     {
       "ID": 32000000,
       "Entries": [
-        "あん…？"
+        "Hrm?"
       ]
     },
     {
       "ID": 32000001,
       "Entries": [
-        "へえ、珍しい。まともじゃないか"
+        "Well, this is unusual. You haven't lost your head."
       ]
     },
     {
       "ID": 32000002,
       "Entries": [
-        "しかも自由ときてる。あんた、何者だ？"
+        "And more importantly, you're free. How on earth..."
       ]
     },
     {
       "ID": 32000003,
       "Entries": [
-        "…そんなことは、どうだっていいか"
+        "...Well, I shouldn't pry."
       ]
     },
     {
       "ID": 32000004,
       "Entries": [
-        "俺はヴィンハイムのリッケルト"
+        "I am Rickert of Vinheim."
       ]
     },
     {
       "ID": 32000005,
       "Entries": [
-        "昔は一端の職人だったが…今はこの有様さ"
+        "I was once an established smith, but look at me now."
       ]
     },
     {
       "ID": 32000006,
       "Entries": [
-        "笑えるだろ？"
+        "Can you believe it?"
       ]
     },
     {
       "ID": 32000020,
       "Entries": [
-        "ん？なんだ？"
+        "Hm? What is it?"
       ]
     },
     {
       "ID": 32000021,
       "Entries": [
-        "まだ…ああ、勘違いするなよ。牢を出たいなんて思っちゃいない"
+        "Have you...Oh, no, don't worry. I've no intention of escape."
       ]
     },
     {
       "ID": 32000022,
       "Entries": [
-        "ここは安全だ。死んで亡者になるなんて、まっぴらだからな"
+        "It's safe here. I can't bear the thought of going Hollow out\nthere."
       ]
     },
     {
       "ID": 32000023,
       "Entries": [
-        "…だが、そうだな、退屈してるのも事実だ"
+        "Although, I must admit, I've not much to occupy myself."
       ]
     },
     {
       "ID": 32000024,
       "Entries": [
-        "どうだ？幸い、質は悪いが道具もある。あんたの武器を、俺に鍛えさせてくれないか？"
+        "How about this? I could forge your weapons, albeit with rather\nminimal tools."
       ]
     },
     {
       "ID": 32000025,
       "Entries": [
-        "ヴィンハイム一と言われた、俺の腕を見せてやるぜ"
+        "I will show you what made me the best in Vinheim!"
       ]
     },
     {
       "ID": 32000030,
       "Entries": [
-        "ん？なんだ？"
+        "Hm? What is it?"
       ]
     },
     {
       "ID": 32000031,
       "Entries": [
-        "俺は、あんたに用なんてないが…"
+        "Normally I wouldn't bother, but..."
       ]
     },
     {
       "ID": 32000032,
       "Entries": [
-        "…だが、そうだな、退屈してるのも事実だ"
+        "I must admit, I've not much to occupy myself."
       ]
     },
     {
       "ID": 32000033,
       "Entries": [
-        "どうだ？幸い、質は悪いが道具もある。あんたの武器を、俺に鍛えさせてくれないか？"
+        "How about this? I could forge your weapons, albeit with rather\nminimal tools."
       ]
     },
     {
       "ID": 32000034,
       "Entries": [
-        "ヴィンハイム一と言われた、俺の腕を見せてやるぜ"
+        "I will show you what made me the best in Vinheim!"
       ]
     },
     {
       "ID": 32000100,
       "Entries": [
-        "おう、あんたか"
+        "Oh, hello."
       ]
     },
     {
       "ID": 32000101,
       "Entries": [
-        "どうせ武器だろう？見せてみろよ"
+        "What weapons have you brought? Go on; show me."
       ]
     },
     {
       "ID": 32000150,
       "Entries": [
-        "おう、あんたか"
+        "Oh, hello."
       ]
     },
     {
       "ID": 32000151,
       "Entries": [
-        "待ってたぜ。退屈してたんだ"
+        "I was beginning to wonder when you'd come."
       ]
     },
     {
       "ID": 32000152,
       "Entries": [
-        "素材は持ってきたんだろう？はやく出せよ"
+        "Have you materials? Go on, show me."
       ]
     },
     {
       "ID": 32000200,
       "Entries": [
-        "今度は頼むぜ"
+        "Come back soon."
       ]
     },
     {
       "ID": 32000201,
       "Entries": [
-        "鍛冶仕事は脳にいいんだ"
+        "Smithing helps soothe my nerves."
       ]
     },
     {
       "ID": 32000202,
       "Entries": [
-        "俺が退屈で死んじまう前にな"
+        "Don't let me wither away out of idleness!"
       ]
     },
     {
       "ID": 32000300,
       "Entries": [
-        "じゃあな"
+        "Good-bye, then."
       ]
     },
     {
       "ID": 32000301,
       "Entries": [
-        "次もまともできてくれよな"
+        "Keep your head on, out there."
       ]
     },
     {
       "ID": 32000302,
       "Entries": [
-        "いい退屈しのぎになったぜ"
+        "You really help break the monotony."
       ]
     },
     {
       "ID": 32000400,
       "Entries": [
-        "ん？どうした？"
+        "Hm? What's happened?"
       ]
     },
     {
       "ID": 32000500,
       "Entries": [
-        "どうしたんだ、さっきは"
+        "What was that about?"
       ]
     },
     {
       "ID": 32000501,
       "Entries": [
-        "ま、どうだっていいか"
+        "Ahh, it doesn't matter."
       ]
     },
     {
       "ID": 32000660,
       "Entries": [
-        "なにすんだよっ！"
+        "What's got into you!"
       ]
     },
     {
       "ID": 32000700,
       "Entries": [
-        "なんだよ、まともじゃなかったのかよ…"
+        "Damn, you've gone Hollow, have you?"
       ]
     },
     {
       "ID": 32000701,
       "Entries": [
-        "もういい、あんたと話すこともない"
+        "Forget about it! I have nothing more to say."
       ]
     },
     {
       "ID": 32000702,
       "Entries": [
-        "行っちまえよ！"
+        "Be gone!"
       ]
     },
     {
       "ID": 32000703,
       "Entries": [
-        "行っちまえったら！"
+        "Oh, go away!"
       ]
     },
     {
       "ID": 32000704,
       "Entries": [
-        "あんたには何もやらんよ。何もな…"
+        "There's nothing here for you. Nothing at all."
       ]
     },
     {
       "ID": 32000800,
       "Entries": [
-        "そんな、ばかな…"
+        "No...impossible..."
       ]
     },
     {
       "ID": 32000801,
       "Entries": [
-        "なんで…"
+        "Why didn't I see?"
       ]
     },
     {
       "ID": 32000802,
       "Entries": [
-        "まともじゃねえ…"
+        "...You've gone Hollow..."
       ]
     },
     {
       "ID": 32000900,
       "Entries": [
-        "おい、あんた"
+        "Hey, hang on..."
       ]
     },
     {
       "ID": 32000901,
       "Entries": [
-        "それは…魔術の種火じゃねえか…？"
+        "That's a sorcery ember...isn't it?"
       ]
     },
     {
       "ID": 32000902,
       "Entries": [
-        "そうだ、間違いない…ヴィンハイムを追われて後、はじめてだ…"
+        "Yes, it certainly is...The first I've seen since my banishment\nfrom Vinheim."
       ]
     },
     {
       "ID": 32000903,
       "Entries": [
-        "なあ、あんた。それを俺にくれないか？"
+        "What do you say, friend? Mind giving that to me?"
       ]
     },
     {
       "ID": 32000904,
       "Entries": [
-        "こんな辺鄙の地だ。俺以外に、それを扱える奴なんざ、いないと思うぜ"
+        "This is no-man's land. I'm the only one who could handle it\nanyway."
       ]
     },
     {
       "ID": 32001000,
       "Entries": [
-        "…ああ、そうかい。まあ、しょうがねえ"
+        "...Yes, I see. All right, fine."
       ]
     },
     {
       "ID": 32001001,
       "Entries": [
-        "正しい判断には思えねえがな"
+        "But I don't think you're really seeing things clearly."
       ]
     },
     {
       "ID": 32001100,
       "Entries": [
-        "まあ、そうくるわな"
+        "Yes, as you should!"
       ]
     },
     {
       "ID": 32001101,
       "Entries": [
-        "任せときな。これで、しばらくは退屈しなくてすみそうだぜ"
+        "I won't disappoint you. I'm taskless no longer!"
       ]
     },
     {
       "ID": 32001200,
       "Entries": [
-        "おい、あんた"
+        "Hey, hang on..."
       ]
     },
     {
       "ID": 32001201,
       "Entries": [
-        "それは…魔術の種火か…？"
+        "Is that...a sorcery ember?"
       ]
     },
     {
       "ID": 32001202,
       "Entries": [
-        "すげえ…ヴィンハイムでだって、見たこともねえ…"
+        "I've never seen one like that, not even back in Vinheim."
       ]
     },
     {
       "ID": 32001203,
       "Entries": [
-        "すげえ火だ…"
+        "What a brilliant flame!"
       ]
     },
     {
       "ID": 32001204,
       "Entries": [
-        "なあ、あんた。それを、俺ににくれ。頼む。お願いだ"
+        "Please, friend, let me have that. I am begging you."
       ]
     },
     {
       "ID": 32001205,
       "Entries": [
-        "俺だって、腐ってもヴィンハイムの職人だ。そんなすごい火、見なかったことにはできねえよ…"
+        "I am a craftsman of Vinheim. I'd go Hollow before I pass up a\nflame like that!"
       ]
     },
     {
       "ID": 32001300,
       "Entries": [
-        "……わかった"
+        "...Fine."
       ]
     },
     {
       "ID": 32001301,
       "Entries": [
-        "……わかったよ、諦める"
+        "...Fine, I won't bother you."
       ]
     },
     {
       "ID": 32001302,
       "Entries": [
-        "でも、いいもの見せてくれたな。ありがとよ"
+        "It was wonderful if only to gaze upon."
       ]
     },
     {
       "ID": 32001303,
       "Entries": [
-        "少しだけ、昔を思い出しちまったじゃないか…"
+        "It takes me back to old times."
       ]
     },
     {
       "ID": 32001400,
       "Entries": [
-        "おお、そうか！あんた、最高だ！"
+        "Oh, really! You are wonderful!"
       ]
     },
     {
       "ID": 32001401,
       "Entries": [
-        "リッケルトの最高傑作をお見せするぜ"
+        "I will forge a Rickert masterpiece, just for you!"
       ]
     },
     {
       "ID": 32001402,
       "Entries": [
-        "あんたを英雄にする武器だ…"
+        "A weapon to make a legend out of you..."
       ]
     },
     {
       "ID": 32001500,
       "Entries": [
-        "おい、あんた"
+        "Hey, hang on..."
       ]
     },
     {
       "ID": 32001501,
       "Entries": [
-        "それは、種火か？"
+        "Is that an ember?"
       ]
     },
     {
       "ID": 32001502,
       "Entries": [
-        "だが残念。ヴィンハイムでは、そんな粗野な種火は使わないんだ"
+        "Oh, no, I'm sorry. We of Vinheim don't deal in shoddy embers like\nthat."
       ]
     },
     {
       "ID": 32001503,
       "Entries": [
-        "田舎の鍛冶屋なら、そんなんでも我慢できるんだろうけどな"
+        "Perhaps you should try an old smith out in the country."
       ]
     },
     {
       "ID": 32001600,
       "Entries": [
-        "ん？なんだ？"
+        "Hm? What is it?"
       ]
     },
     {
       "ID": 32001601,
       "Entries": [
-        "話すことなんて特にないぞ"
+        "There's nothing to talk about."
       ]
     },
     {
       "ID": 32001602,
       "Entries": [
-        "呪われて、故郷を追われた不死同士、傷をなめあうのも惨めじゃないか"
+        "We're both cursed; Undead. But what's there, really, to moan\nabout?"
       ]
     },
     {
       "ID": 32001700,
       "Entries": [
-        "ビッグハット？ああ、知ってるぜ"
+        "Old Big Hat? Of course I've heard of him."
       ]
     },
     {
       "ID": 32001701,
       "Entries": [
-        "ヴィンハイムでも有名な伝説だからな"
+        "Who hasn't in Vinheim?"
       ]
     },
     {
       "ID": 32001702,
       "Entries": [
-        "なんでも、竜の学院の外戚だったが、不死になったとか"
+        "He was a royal member of Dragon School, until he turned Undead."
       ]
     },
     {
       "ID": 32001703,
       "Entries": [
-        "おもしろい爺様だったらしいが…まあ、100年以上も前の話さ"
+        "I hear he was quite the character...Only, that was a hundred\nyears ago."
       ]
     },
     {
       "ID": 32001704,
       "Entries": [
-        "変なことに興味があるんだな？"
+        "What interest have you in the old eccentric now?"
       ]
     },
     {
       "ID": 32001800,
       "Entries": [
-        "魔術？俺は、何もわからねえよ"
+        "Sorcery? Don't ask me how it actually works."
       ]
     },
     {
       "ID": 32001801,
       "Entries": [
-        "あるものは、受け容れて、自分たちの技術にする"
+        "We only fiddle and forge, until it works itself in."
       ]
     },
     {
       "ID": 32001802,
       "Entries": [
-        "ヴィンハイムの職人たちは、ただ、皆そうしている"
+        "That's how we do it in Vinheim, at least."
       ]
     },
     {
       "ID": 32001803,
       "Entries": [
-        "理屈をつけるのは、学者どもの嗜みってわけさ"
+        "We prefer to leave the theorizing to those uppity scholars."
       ]
     },
     {
       "ID": 33000000,
       "Entries": [
-        "おう、あんた"
+        "Well, now..."
       ]
     },
     {
       "ID": 33000001,
       "Entries": [
-        "どうやら、まともみたいだな…？"
+        "You seem to have your wits about you, hmm?"
       ]
     },
     {
       "ID": 33000002,
       "Entries": [
-        "だったら、俺のお客様だ"
+        "Then you are a welcome customer!"
       ]
     },
     {
       "ID": 33000003,
       "Entries": [
-        "ソウルと交換だ。いいものを揃えてるぜ"
+        "I trade for souls. Everything's for sale!"
       ]
     },
     {
       "ID": 33000004,
       "Entries": [
-        "イヒヒヒヒヒッ"
+        "Nee hee hee hee hee!"
       ]
     },
     {
       "ID": 33000100,
       "Entries": [
-        "おう、またあんたか"
+        "Oh, you again?"
       ]
     },
     {
       "ID": 33000101,
       "Entries": [
-        "ソウルはしっかり貯めてきたか？"
+        "I hope you've brought plenty of souls?"
       ]
     },
     {
       "ID": 33000102,
       "Entries": [
-        "イヒヒヒヒヒッ"
+        "Nee hee hee hee hee!"
       ]
     },
     {
       "ID": 33000120,
       "Entries": [
-        "おう、あんたか"
+        "Oh, there you are."
       ]
     },
     {
       "ID": 33000121,
       "Entries": [
-        "まだ、まともみたいだな…？"
+        "Still keeping your marbles all together?"
       ]
     },
     {
       "ID": 33000122,
       "Entries": [
-        "だったら、買ってくんな"
+        "Then, go ahead, don't be a nitwit."
       ]
     },
     {
       "ID": 33000123,
       "Entries": [
-        "どうせ長くないんだ、ケチしてもしょうがないだろう？"
+        "Never hurts to splurge when your days are numbered!"
       ]
     },
     {
       "ID": 33000124,
       "Entries": [
-        "イヒヒヒヒヒッ"
+        "Nee hee hee hee hee!"
       ]
     },
     {
       "ID": 33000140,
       "Entries": [
-        "おう、あんたか"
+        "Oh, there you are."
       ]
     },
     {
       "ID": 33000141,
       "Entries": [
-        "ひさしぶりだな"
+        "Where have you been hiding?"
       ]
     },
     {
       "ID": 33000142,
       "Entries": [
-        "てっきり終わったと思ってたが"
+        "I guessed you'd hopped the twig for certain."
       ]
     },
     {
       "ID": 33000143,
       "Entries": [
-        "分からないものだな"
+        "Bah, shows what I know!"
       ]
     },
     {
       "ID": 33000144,
       "Entries": [
-        "イヒヒヒヒヒッ"
+        "Nee hee hee hee hee!"
       ]
     },
     {
       "ID": 33000200,
       "Entries": [
-        "ちぇ"
+        "Hmph!"
       ]
     },
     {
       "ID": 33000201,
       "Entries": [
-        "けちくさいねぇ"
+        "Cheap bastard."
       ]
     },
     {
       "ID": 33000202,
       "Entries": [
-        "なあ、ユリア？"
+        "Right, Yulia?"
       ]
     },
     {
       "ID": 33000220,
       "Entries": [
-        "ケッ"
+        "Tsk!"
       ]
     },
     {
       "ID": 33000221,
       "Entries": [
-        "しけてるねぇ"
+        "Throw me a bone, will you?"
       ]
     },
     {
       "ID": 33000222,
       "Entries": [
-        "あんた、もう長くないぜ"
+        "You haven't got much time anyway."
       ]
     },
     {
       "ID": 33000223,
       "Entries": [
-        "なあ、ユリア？"
+        "Right, Yulia?"
       ]
     },
     {
       "ID": 33000240,
       "Entries": [
-        "フン"
+        "Hmph."
       ]
     },
     {
       "ID": 33000241,
       "Entries": [
-        "なんだ、ひやかしかよ"
+        "What a waste of time."
       ]
     },
     {
       "ID": 33000242,
       "Entries": [
-        "終わっちまえ、屑が（小声で）"
+        "Go and fall off a cliff. "
       ]
     },
     {
       "ID": 33000300,
       "Entries": [
-        "まいどあり"
+        "Thank you kindly."
       ]
     },
     {
       "ID": 33000301,
       "Entries": [
-        "イヒヒヒヒヒッ"
+        "Nee hee hee hee hee!"
       ]
     },
     {
       "ID": 33000320,
       "Entries": [
-        "ありがとうごぜえました"
+        "Ah, thank you, very much."
       ]
     },
     {
       "ID": 33000321,
       "Entries": [
-        "今後ともご贔屓に…"
+        "Come back soon!"
       ]
     },
     {
       "ID": 33000322,
       "Entries": [
-        "イヒヒヒヒヒッ"
+        "Nee hee hee hee hee!"
       ]
     },
     {
       "ID": 33000400,
       "Entries": [
-        "あん、なんだ？どうした？"
+        "Hey, what! What's the matter?"
       ]
     },
     {
       "ID": 33000500,
       "Entries": [
-        "さっきは、どうしたってんだい？"
+        "What was that about?"
       ]
     },
     {
       "ID": 33000501,
       "Entries": [
-        "まあ、どうでもいいがな"
+        "Oh, nevermind."
       ]
     },
     {
       "ID": 33000600,
       "Entries": [
-        "うわっ！"
+        "Eeg!"
       ]
     },
     {
       "ID": 33000610,
       "Entries": [
-        "いてえっ！"
+        "Yeowch!"
       ]
     },
     {
       "ID": 33000620,
       "Entries": [
-        "おい、何するんだ？"
+        "Oi, what's this about?"
       ]
     },
     {
       "ID": 33000630,
       "Entries": [
-        "俺だよ！やめてくれよ！"
+        "It's me! Stop it, I tell you!"
       ]
     },
     {
       "ID": 33000700,
       "Entries": [
-        "てめえ、終わっちまったか！"
+        "You've gone mad, have you!?"
       ]
     },
     {
       "ID": 33000701,
       "Entries": [
-        "やってやるよ！ゆるさねえぞ！"
+        "I'll teach you! You lousy rat!"
       ]
     },
     {
       "ID": 33000702,
       "Entries": [
-        "ユリアッ！ユリアッ！"
+        "Yulia! Yulia!"
       ]
     },
     {
       "ID": 33000800,
       "Entries": [
-        "何で俺が…"
+        "Why, me..."
       ]
     },
     {
       "ID": 33000801,
       "Entries": [
-        "ユリアよう…"
+        "Little Yulia..."
       ]
     },
     {
       "ID": 33000900,
       "Entries": [
-        "ああ、こいつか。可愛いだろう？"
+        "Ah, this one? Ain't she lovely?"
       ]
     },
     {
       "ID": 33000901,
       "Entries": [
-        "名前はユリア。もうずっと一緒だ"
+        "Her name is Yulia. She's plumb in love with me."
       ]
     },
     {
       "ID": 33000902,
       "Entries": [
-        "こいつは俺に惚れちまってるのさ…"
+        "You'd never leave my side, now would you, Yulia?"
       ]
     },
     {
       "ID": 33001000,
       "Entries": [
-        "ああ、無駄だよ、無駄"
+        "Ah, you can forget it."
       ]
     },
     {
       "ID": 33001001,
       "Entries": [
-        "こいつには俺だけだ"
+        "I'm all that she needs."
       ]
     },
     {
       "ID": 33001002,
       "Entries": [
-        "下手に手を出すと噛まれるぜ"
+        "Careful, she'll bite your little fingers off!"
       ]
     },
     {
       "ID": 33001003,
       "Entries": [
-        "なあ、ユリア？"
+        "Be kind, Yulia, be kind!"
       ]
     },
     {
       "ID": 33001004,
       "Entries": [
-        "イヒヒヒヒヒッ"
+        "Nee hee hee hee hee!"
       ]
     },
     {
       "ID": 33001100,
       "Entries": [
-        "あん？俺の売り物？"
+        "Eh? My wares?"
       ]
     },
     {
       "ID": 33001101,
       "Entries": [
-        "勿論盗品だぜ、何か文句あんのか？"
+        "Of course they're stolen; what did you think?"
       ]
     },
     {
       "ID": 33001102,
       "Entries": [
-        "せいぜいあんたがおかしくなったら"
+        "And when you lose your head,"
       ]
     },
     {
       "ID": 33001103,
       "Entries": [
-        "遺品は有効活用してやるぜ"
+        "I'll sell it all again!"
       ]
     },
     {
       "ID": 33001104,
       "Entries": [
-        "イヒヒヒヒヒッ"
+        "Nee hee hee hee hee!"
       ]
     },
     {
       "ID": 33001200,
       "Entries": [
-        "ささ、話なんてどうでもいいじゃないか"
+        "Now, don't squander your time chatting!"
       ]
     },
     {
       "ID": 33001201,
       "Entries": [
-        "どんどん買ってくれ、買ってくれよ"
+        "You need to look over my wares!"
       ]
     },
     {
       "ID": 33001300,
       "Entries": [
-        "あん？話なんざねえよ"
+        "Eh? I'm not here to chit-chat."
       ]
     },
     {
       "ID": 33001301,
       "Entries": [
-        "用がないなら、とっとと帰ってくんな"
+        "We talk business, or we talk nothing at all."
       ]
     },
     {
       "ID": 33001400,
       "Entries": [
-        "ここらへんも、最近は物騒でなあ"
+        "Things are getting treacherous in these parts."
       ]
     },
     {
       "ID": 33001401,
       "Entries": [
-        "この下にゃあ、ちょっと前から、山羊頭のデーモンが住みついてやがるし"
+        "A horrible goat demon has moved in below."
       ]
     },
     {
       "ID": 33001402,
       "Entries": [
-        "上は上で、でっかい飛竜やら、最近では牛頭のデーモンまで現れるらしい"
+        "And up above, there's that humungous drake, and a bull demon,\ntoo."
       ]
     },
     {
       "ID": 33001403,
       "Entries": [
-        "あんたも、せいぜい死に場所を選んでおいた方がいいぜ"
+        "If you stick around this place, it might end up being your grave!"
       ]
     },
     {
       "ID": 33001404,
       "Entries": [
-        "イヒヒヒヒヒッ"
+        "Nee hee hee hee hee!"
       ]
     },
     {
       "ID": 33001500,
       "Entries": [
-        "…実際、ここは結構快適さ"
+        "It's actually quite nice here, you know?"
       ]
     },
     {
       "ID": 33001501,
       "Entries": [
-        "亡者どもは、俺みたいに枯れたのはどうでもいいらしいし"
+        "The Hollows don't care for a skinny old twig like me."
       ]
     },
     {
       "ID": 33001502,
       "Entries": [
-        "それに、こいつもいるし…誰も、石を投げたりしねえ"
+        "I've got Yulia...And nobody pelts me with stones anymore."
       ]
     },
     {
       "ID": 33001503,
       "Entries": [
-        "あんたも不死なら、分かるだろう？"
+        "You're Undead, you know how it is."
       ]
     },
     {
       "ID": 33001504,
       "Entries": [
-        "故郷は地獄だったじゃないか…"
+        "I was treated worse back at home."
       ]
     },
     {
       "ID": 34000000,
       "Entries": [
-        "ああ、あんた、まともな人かい？"
+        "Hmm, you still have your senses about you?"
       ]
     },
     {
       "ID": 34000001,
       "Entries": [
-        "だったら、あたしの苔を買っておくれよ"
+        "Then why won't you buy some of my moss?"
       ]
     },
     {
       "ID": 34000002,
       "Entries": [
-        "あんたのソウルが欲しいんだよ"
+        "I need your souls!"
       ]
     },
     {
       "ID": 34000003,
       "Entries": [
-        "フヒヒッ"
+        "Vee hee hee!"
       ]
     },
     {
       "ID": 34000100,
       "Entries": [
-        "ああ、あんた、またきてくれたのかい？"
+        "Oh, there you are, dearie!"
       ]
     },
     {
       "ID": 34000101,
       "Entries": [
-        "あたしゃ嬉しいよ"
+        "A pleasure to see you again."
       ]
     },
     {
       "ID": 34000102,
       "Entries": [
-        "フヒヒッ"
+        "Vee hee hee!"
       ]
     },
     {
       "ID": 34000120,
       "Entries": [
-        "ああ、あんた、きてくれたのかい？"
+        "Oh, there you are, dearie!"
       ]
     },
     {
       "ID": 34000121,
       "Entries": [
-        "苔ならあるよ。あんたのソウルをお出しよ"
+        "I have moss; now dish up some souls!"
       ]
     },
     {
       "ID": 34000122,
       "Entries": [
-        "フヒヒッ"
+        "Vee hee hee!"
       ]
     },
     {
       "ID": 34000140,
       "Entries": [
-        "ああ、あんたかい？"
+        "Oh, hello, dearie."
       ]
     },
     {
       "ID": 34000141,
       "Entries": [
-        "随分と久しぶりじゃないか"
+        "You left me high and dry for a while, there."
       ]
     },
     {
       "ID": 34000142,
       "Entries": [
-        "あたしゃ寂しかったよ"
+        "I thought maybe you'd forgotten about me."
       ]
     },
     {
       "ID": 34000143,
       "Entries": [
-        "あたしの苔が欲しいんだろう？"
+        "Are you back for more of my moss, then?"
       ]
     },
     {
       "ID": 34000144,
       "Entries": [
-        "あんたのために集めておいたんだ。たーんとあげるよ"
+        "Plenty of it here. Freshly peeled, just for you!"
       ]
     },
     {
       "ID": 34000145,
       "Entries": [
-        "フヒヒッ"
+        "Vee hee hee!"
       ]
     },
     {
       "ID": 34000200,
       "Entries": [
-        "なんだい…"
+        "Drat."
       ]
     },
     {
       "ID": 34000201,
       "Entries": [
-        "つまらない男だね…"
+        "What a humdrum lad you are."
       ]
     },
     {
       "ID": 34000210,
       "Entries": [
-        "なんだい…"
+        "Drat."
       ]
     },
     {
       "ID": 34000211,
       "Entries": [
-        "つまらない女だね…"
+        "What a humdrum lass you are."
       ]
     },
     {
       "ID": 34000220,
       "Entries": [
-        "フン、そうかい"
+        "Hmph, fine, then."
       ]
     },
     {
       "ID": 34000221,
       "Entries": [
-        "後悔すればいいのさ"
+        "But you'll regret it."
       ]
     },
     {
       "ID": 34000240,
       "Entries": [
-        "なんだい、からかってるのかい？"
+        "Are you toying with me?"
       ]
     },
     {
       "ID": 34000241,
       "Entries": [
-        "きっと碌なことにならないよ、あんた"
+        "One day, your fate will catch up with you."
       ]
     },
     {
       "ID": 34000242,
       "Entries": [
-        "あたしには分かるんだ…"
+        "I have a sense for these things..."
       ]
     },
     {
       "ID": 34000243,
       "Entries": [
-        "神様は、いつも見てるんだよ…"
+        "The Gods above are watching you!"
       ]
     },
     {
       "ID": 34000300,
       "Entries": [
-        "またきておくれよ"
+        "Come again, if you please!"
       ]
     },
     {
       "ID": 34000301,
       "Entries": [
-        "フヒヒッ"
+        "Vee hee hee!"
       ]
     },
     {
       "ID": 34000320,
       "Entries": [
-        "たーんと、どうもね"
+        "Much obliged."
       ]
     },
     {
       "ID": 34000321,
       "Entries": [
-        "あたしゃ、あんた好きだよ"
+        "I think I like you!"
       ]
     },
     {
       "ID": 34000322,
       "Entries": [
-        "フヒヒヒヒッ"
+        "Vee hee hee hee hee!"
       ]
     },
     {
       "ID": 34000400,
       "Entries": [
-        "あんた、どこいくんだい！"
+        "Don't run off!"
       ]
     },
     {
       "ID": 34000500,
       "Entries": [
-        "どうしたってんだい、まったく"
+        "What's the matter with you!"
       ]
     },
     {
       "ID": 34000501,
       "Entries": [
-        "あたしだって、びっくりするじゃないか"
+        "Don't you toy with my nerves!"
       ]
     },
     {
       "ID": 34000600,
       "Entries": [
-        "ちょっと！"
+        "Why, you!"
       ]
     },
     {
       "ID": 34000610,
       "Entries": [
-        "やめとくれよ！"
+        "Stop that!"
       ]
     },
     {
       "ID": 34000620,
       "Entries": [
-        "いたいっ！"
+        "Ouch!"
       ]
     },
     {
       "ID": 34000630,
       "Entries": [
-        "キャアッ！"
+        "Eeek!"
       ]
     },
     {
       "ID": 34000700,
       "Entries": [
-        "あんた、なにすんのよ！"
+        "What do you think you're doing?!"
       ]
     },
     {
       "ID": 34000701,
       "Entries": [
-        "あたしだって、一端のものさ！"
+        "I have my pride, you damn fool!"
       ]
     },
     {
       "ID": 34000702,
       "Entries": [
-        "あんたなんかの好きにはさせないよ！"
+        "You think you can get away with murder?"
       ]
     },
     {
       "ID": 34000703,
       "Entries": [
-        "なんだい、人が優しくすれば、いい気になって！"
+        "Yes, I suppose you think you're special!"
       ]
     },
     {
       "ID": 34000704,
       "Entries": [
-        "あんたなんか、ただの貢ぎ屋なんだよ！"
+        "Well, you're not! You're just another customer!"
       ]
     },
     {
       "ID": 34000705,
       "Entries": [
-        "死ね！死ね！"
+        "Burn! Burn in hell!"
       ]
     },
     {
       "ID": 34000706,
       "Entries": [
-        "呪われたごみ屑が！"
+        "You cross-eyed Hollow!"
       ]
     },
     {
       "ID": 34000707,
       "Entries": [
-        "あたしが許したって、神様があんたを許しゃしないよ！"
+        "There's no hope for anyone like you! The Gods will not have it!"
       ]
     },
     {
       "ID": 34000708,
       "Entries": [
-        "死ね！死ね！"
+        "Die! Die!"
       ]
     },
     {
       "ID": 34000709,
       "Entries": [
-        "死ね！死ね！"
+        "Die! Die!"
       ]
     },
     {
       "ID": 34000710,
       "Entries": [
-        "死ねッ！"
+        "Die a thousand times again!"
       ]
     },
     {
       "ID": 34000711,
       "Entries": [
-        "呪われろッ！"
+        "Curses upon you!"
       ]
     },
     {
       "ID": 34000712,
       "Entries": [
-        "あんたも、あんたの家族も、赤ん坊も"
+        "Upon you, and yours,"
       ]
     },
     {
       "ID": 34000713,
       "Entries": [
-        "全員呪われろッ！"
+        "for generations eternal!"
       ]
     },
     {
       "ID": 34000714,
       "Entries": [
-        "苦しめッ！"
+        "All of you!"
       ]
     },
     {
       "ID": 34000715,
       "Entries": [
-        "ずっと、ずっと苦しめッ！"
+        "Eternal pain and suffering!"
       ]
     },
     {
       "ID": 34000716,
       "Entries": [
-        "苦しめッ！"
+        "Lots and lots!"
       ]
     },
     {
       "ID": 34000800,
       "Entries": [
-        "呪われろ…"
+        "A curse upon you..."
       ]
     },
     {
       "ID": 34000900,
       "Entries": [
-        "あんたも、大変なところにきちまったね"
+        "You've come to this land at a bad time."
       ]
     },
     {
       "ID": 34000901,
       "Entries": [
-        "この地には、まともな人なんてほとんどいない。あたしくらいさ"
+        "There are nothing but Hollows in these parts. Save for me, of\ncourse."
       ]
     },
     {
       "ID": 34000902,
       "Entries": [
-        "あんたも、不死なんだろう？せいぜい気をつけておくれよ"
+        "You're Undead, too, aren't you? You be careful, then."
       ]
     },
     {
       "ID": 34000903,
       "Entries": [
-        "フヒヒッ"
+        "Vee hee hee!"
       ]
     },
     {
       "ID": 34001000,
       "Entries": [
-        "あたしゃ、苔を集めてるんだ"
+        "I forage moss."
       ]
     },
     {
       "ID": 34001001,
       "Entries": [
-        "この街は、下にいけばいくほど、毒だとか疫病だとか、不潔なものばかりだからね"
+        "In the lower areas of this town, you'll find all kinds of poison\nand pestilence."
       ]
     },
     {
       "ID": 34001002,
       "Entries": [
-        "誰だって、苔がなくっちゃあ、どうしようもないのさ"
+        "You can't travel a stone's toss without some trusty moss."
       ]
     },
     {
       "ID": 34001003,
       "Entries": [
-        "あんたも、たーんと持っていかなくちゃねえ？"
+        "Make sure you take plenty with you!"
       ]
     },
     {
       "ID": 34001004,
       "Entries": [
-        "フヒヒッ"
+        "Vee hee hee!"
       ]
     },
     {
       "ID": 34001100,
       "Entries": [
-        "ああ、この横を下りれば、不死街の最下層につながってるよ"
+        "Ah, go down along the side to reach the depths of the Undead\nBurg."
       ]
     },
     {
       "ID": 34001101,
       "Entries": [
-        "不潔で汚い、下賎の連中だけがいるところさ"
+        "Only unkempt crooks and liars to be found there."
       ]
     },
     {
       "ID": 34001102,
       "Entries": [
-        "まあ、あたしには無縁の場所だけどねえ"
+        "Hardly a place for a lady like myself!"
       ]
     },
     {
       "ID": 34001103,
       "Entries": [
-        "あんたは、どうなんだろうねえ？"
+        "But who knows, maybe you'd fit right in?"
       ]
     },
     {
       "ID": 34001104,
       "Entries": [
-        "フヒヒヒヒッ"
+        "Vee hee hee hee hee!"
       ]
     },
     {
       "ID": 34001200,
       "Entries": [
-        "ここは、すばらしい場所だろう？"
+        "This is a wonderful place, don't you think?"
       ]
     },
     {
       "ID": 34001201,
       "Entries": [
-        "水もあって、苔もあって、ずっとジメジメして、鉄格子まである"
+        "We have water, moss, moisture, these nice iron bars..."
       ]
     },
     {
       "ID": 34001202,
       "Entries": [
-        "あたしゃ、この場所が好きなんだ"
+        "I like it here, I really do."
       ]
     },
     {
       "ID": 34001203,
       "Entries": [
-        "昔っから、いいことなんか１つもありゃしなかったんだから"
+        "Nothing good ever happened to me in life."
       ]
     },
     {
       "ID": 34001204,
       "Entries": [
-        "不死になって、今が一番幸せさね"
+        "But now that I'm Undead, I've never been happier!"
       ]
     },
     {
       "ID": 34001300,
       "Entries": [
-        "ねえ、あんた…"
+        "Tell me honestly..."
       ]
     },
     {
       "ID": 34001301,
       "Entries": [
-        "あんた、本当は思ってるんじゃないかい？"
+        "You think I've gone to the other side, don't you?"
       ]
     },
     {
       "ID": 34001302,
       "Entries": [
-        "あたしは、もう、まともじゃないって…"
+        "That I've cracked my head and gone Hollow..."
       ]
     },
     {
       "ID": 34001303,
       "Entries": [
-        "そうなんだろう、あんた？"
+        "You do, don't you?"
       ]
     },
     {
       "ID": 34001304,
       "Entries": [
-        "黙ってるんじゃないよ"
+        "I can see it in your eyes."
       ]
     },
     {
       "ID": 34001305,
       "Entries": [
-        "あたしには分かるんだよ…"
+        "You'd trust a patch of moss over me..."
       ]
     },
     {
       "ID": 35000000,
       "Entries": [
-        "…うう…"
+        "...Hrrg..."
       ]
     },
     {
       "ID": 35000001,
       "Entries": [
-        "…うううううう…"
+        "...Rrgggg..."
       ]
     },
     {
       "ID": 35000002,
       "Entries": [
-        "…ぐうううううううう…"
+        "...Rrrrrgggg..."
       ]
     },
     {
       "ID": 35000003,
       "Entries": [
-        "…ぐおおおおおおおおっ…"
+        "...Hrrrggaaaagghhh..."
       ]
     },
     {
       "ID": 35000004,
       "Entries": [
-        "…かんがれろ…おぼれろ…"
+        "...think, think...remember...remember"
       ]
     },
     {
       "ID": 35000005,
       "Entries": [
-        "…なんでいい…かぞれろ…"
+        "...remember...count, count...yeah count...count"
       ]
     },
     {
       "ID": 35000006,
       "Entries": [
-        "…いち、にぃ、さん、しぃ、ごう、ろう、な、な…なんでいぃ…"
+        "...one, two, three, four, five, six, seven...argh...hrgggg"
       ]
     },
     {
       "ID": 35000007,
       "Entries": [
-        "…ぐぬぬぬぬぬぬうっ…"
+        "...Hrrgggggggg!!"
       ]
     },
     {
       "ID": 35000100,
       "Entries": [
-        "…"
+        "..."
       ]
     },
     {
       "ID": 35000101,
       "Entries": [
-        "あ、なんだ？なんだ？お前は？"
+        "Ah, what? What? Who are you?"
       ]
     },
     {
       "ID": 35000102,
       "Entries": [
-        "…ああ、そうか、不死だな。無謀にも、センの古城に挑んだ"
+        "Ahh, another Undead, eh? I took on Sen's Fortress alone..."
       ]
     },
     {
       "ID": 35000103,
       "Entries": [
-        "俺や、あの成れの果てたちと同じだ。過信した、自分の力を"
+        "But I'm no different from those vile creatures...I was driven by\nconceit..."
       ]
     },
     {
       "ID": 35000104,
       "Entries": [
-        "だが、言っても信じまい。したいのだろう？悪あがきを"
+        "Ahh, you think you're different? That you can handle it?"
       ]
     },
     {
       "ID": 35000105,
       "Entries": [
-        "ああ、わかるぞ。そうだった。俺もそうだった"
+        "Yes, I remember that feeling. For I was the same."
       ]
     },
     {
       "ID": 35000106,
       "Entries": [
-        "…だから、協力してやる。喜べよ。必要なものを売ってやるよ"
+        "...So, let me help you out. With your soul-searching."
       ]
     },
     {
       "ID": 35000200,
       "Entries": [
-        "…"
+        "..."
       ]
     },
     {
       "ID": 35000201,
       "Entries": [
-        "あ…ああ、お前か。お前だな"
+        "Hm...Oh, yes, it's you."
       ]
     },
     {
       "ID": 35000202,
       "Entries": [
-        "どうした？欲しいのか、まだ何か、何かあるのか"
+        "What is it? Still something you need, eh, anything at all?"
       ]
     },
     {
       "ID": 35000220,
       "Entries": [
-        "…"
+        "..."
       ]
     },
     {
       "ID": 35000221,
       "Entries": [
-        "あ、ああ、お前か"
+        "Hm, ah, oh you?"
       ]
     },
     {
       "ID": 35000222,
       "Entries": [
-        "まだ無事か。思わなかったな"
+        "Still alive? That's a surprise."
       ]
     },
     {
       "ID": 35000223,
       "Entries": [
-        "何か欲しいんだろう？だったら、また売ってやる"
+        "Anything you want? What's mine is yours, but at a price!"
       ]
     },
     {
       "ID": 35000300,
       "Entries": [
-        "なにもなしか"
+        "Nothing at all?"
       ]
     },
     {
       "ID": 35000301,
       "Entries": [
-        "いいさ、せいぜい強がって、絶望して果ててくれ"
+        "Fine then, rush in like a naked babe, and be skinned alive!"
       ]
     },
     {
       "ID": 35000320,
       "Entries": [
-        "強がりか。いらんとは"
+        "So, you're that good? Don't need a thing?"
       ]
     },
     {
       "ID": 35000321,
       "Entries": [
-        "まあいい。待ってるぜ。あんたの死声を"
+        "Bah. It won't be long, before you're begging for mercy."
       ]
     },
     {
       "ID": 35000400,
       "Entries": [
-        "じゃあ、せいぜいあがくんだな"
+        "Go along, try and make something of yourself."
       ]
     },
     {
       "ID": 35000401,
       "Entries": [
-        "俺もそうだった。どうせだめなものを"
+        "But nothing will come of it. And I should know!"
       ]
     },
     {
       "ID": 35000420,
       "Entries": [
-        "ほう、いくか。蛮勇だな、皆そうだ"
+        "There you go, another brave soul."
       ]
     },
     {
       "ID": 35000421,
       "Entries": [
-        "今に分かる。お前も俺たちと同じなんだ"
+        "But soon you shall see...You and I are no different..."
       ]
     },
     {
       "ID": 35000422,
       "Entries": [
-        "今に思い知るのさ…"
+        "Yes, yes, you soon shall see..."
       ]
     },
     {
       "ID": 35000423,
       "Entries": [
-        "思い知ればいいのさ…"
+        "...the putrid fate we both share..."
       ]
     },
     {
       "ID": 35000500,
       "Entries": [
-        "…あ？"
+        "...Hmm?"
       ]
     },
     {
       "ID": 35000600,
       "Entries": [
-        "…あ、ああ。わかってるさ"
+        "...Hm, fine, fine. I understand."
       ]
     },
     {
       "ID": 35000601,
       "Entries": [
-        "俺はまともだ"
+        "I have my head about me."
       ]
     },
     {
       "ID": 35000700,
       "Entries": [
-        "お゛お゛っ"
+        "Hrgro!"
       ]
     },
     {
       "ID": 35000720,
       "Entries": [
-        "あ゛あ゛っ"
+        "Hrgrah!"
       ]
     },
     {
       "ID": 35000740,
       "Entries": [
-        "ぐおっ"
+        "Hrgroah!"
       ]
     },
     {
       "ID": 35000760,
       "Entries": [
-        "ぐわっ"
+        "Hrgaw!"
       ]
     },
     {
       "ID": 35000800,
       "Entries": [
-        "何のつもりだ、お前はぁぁぁぁつ！"
+        "What the devil's got into you!"
       ]
     },
     {
       "ID": 35000801,
       "Entries": [
-        "ぐおおおおおっ！"
+        "Hrrgrrrroooggh!"
       ]
     },
     {
       "ID": 35000802,
       "Entries": [
-        "ごがあっ！"
+        "You hrggraaaghh!"
       ]
     },
     {
       "ID": 35000900,
       "Entries": [
-        "ごああっ…"
+        "Hrrggahh..."
       ]
     },
     {
       "ID": 35000901,
       "Entries": [
-        "ああっ…嫌だっ…"
+        "Ahhh...help me..."
       ]
     },
     {
       "ID": 35001000,
       "Entries": [
-        "…お前と、話すことなどない"
+        "There's nothing more to say."
       ]
     },
     {
       "ID": 35001001,
       "Entries": [
-        "俺は、もう終わっている。お前も、すぐそうなる"
+        "I'm finished. We're both on the brink, you see?"
       ]
     },
     {
       "ID": 35001002,
       "Entries": [
-        "それだけだ。分からないさ、まだ"
+        "End of story. You bloody fool."
       ]
     },
     {
       "ID": 35001100,
       "Entries": [
-        "…そうだな、ひとつアドバイスしてやろう"
+        "Let me give you a nibble of advice."
       ]
     },
     {
       "ID": 35001101,
       "Entries": [
-        "お前では、絶対に行けない。あの、アノール・ロンドには"
+        "Don't even consider visiting Anor Londo. Not in your state."
       ]
     },
     {
       "ID": 35001102,
       "Entries": [
-        "俺は知ってるんだ。もう100年もそうだ"
+        "For a century, they have tried, and failed."
       ]
     },
     {
       "ID": 35001103,
       "Entries": [
-        "騎士王レンドルも、黒鉄のタルカスも、あのローガンでさえ"
+        "The Knight King Rendal, Black Iron Tarkus, and even Logan\nhimself."
       ]
     },
     {
       "ID": 35001104,
       "Entries": [
-        "お前ごときが、どうもできん。できてたまるものか"
+        "You won't stand a chance. You'll be eaten alive."
       ]
     },
     {
       "ID": 35001105,
       "Entries": [
-        "だから、せいぜいあがけばいい。その方が、また深くなる。絶望もな"
+        "But, go along, if you wish. If only to deepen your despair!"
       ]
     },
     {
       "ID": 35001200,
       "Entries": [
-        "…ああ、俺が売ってるものか？"
+        "Where do I get all my things?"
       ]
     },
     {
       "ID": 35001201,
       "Entries": [
-        "もちろん、剥ぎ取ったのさ。お前みたいな、英雄気取りの死体からな"
+        "Stripped off the corpses of fools like yourself."
       ]
     },
     {
       "ID": 35001202,
       "Entries": [
-        "危ないんだぜ。亡者になって、動く前に剥ぎ取らなきゃ、大変だからな"
+        "It isn't easy. I have to catch them just before they go Hollow."
       ]
     },
     {
       "ID": 35001203,
       "Entries": [
-        "心配するな。しっかりもらってやるよ、お前のだって。歪んだ顔を眺めながら"
+        "Don't worry. I'll be there to claim your trinkets. Gazing at your\nfinal twisted grimace!"
       ]
     },
     {
       "ID": 35001204,
       "Entries": [
-        "ググググググッ"
+        "Gee hee hee hee hee!"
       ]
     },
     {
       "ID": 36000000,
       "Entries": [
-        "やあ、こんにちは"
+        "Aye, siwmae."
       ]
     },
     {
       "ID": 36000001,
       "Entries": [
-        "はじめまして"
+        "And good day to you."
       ]
     },
     {
       "ID": 36000002,
       "Entries": [
-        "私はゼナのドーナル"
+        "I'm Domhnall of Zena."
       ]
     },
     {
       "ID": 36000003,
       "Entries": [
-        "なんというか…商い者さ"
+        "I'm just, well, a peddler, of sorts."
       ]
     },
     {
       "ID": 36000004,
       "Entries": [
-        "珍品奇品、取引するよ。大好きなんだ"
+        "I adore trinkets and oddities, so I trade for them."
       ]
     },
     {
       "ID": 36000020,
       "Entries": [
-        "やあ、こんにちは"
+        "Aye, siwmae."
       ]
     },
     {
       "ID": 36000021,
       "Entries": [
-        "珍品奇品、取引するよ。大好きなんだ"
+        "I adore trinkets and oddities, so I trade for them."
       ]
     },
     {
       "ID": 36000100,
       "Entries": [
-        "やあ、こんにちは"
+        "Aye, siwmae."
       ]
     },
     {
       "ID": 36000101,
       "Entries": [
-        "また会ったね"
+        "We meet again."
       ]
     },
     {
       "ID": 36000300,
       "Entries": [
-        "やあ、こんにちは"
+        "Aye, siwmae."
       ]
     },
     {
       "ID": 36000301,
       "Entries": [
-        "まさか、人が来るとは思わなかったよ"
+        "I didn't expect to meet anybody here."
       ]
     },
     {
       "ID": 36000302,
       "Entries": [
-        "お互い物好きってことかな。うん、うん"
+        "I suppose great minds think alike, eh? Heh heh."
       ]
     },
     {
       "ID": 36000400,
       "Entries": [
-        "ありがとう。いい取引だった"
+        "Thank you. That was a fine trade."
       ]
     },
     {
       "ID": 36000401,
       "Entries": [
-        "君とは、また会えたら嬉しいな"
+        "I have this funny feeling we'll meet again soon."
       ]
     },
     {
       "ID": 36000402,
       "Entries": [
-        "素晴らしい取引をしようよ"
+        "And we'll make another fine trade, of course!"
       ]
     },
     {
       "ID": 36000500,
       "Entries": [
-        "今回は、残念だったね"
+        "Well, that is a shame, then."
       ]
     },
     {
       "ID": 36000501,
       "Entries": [
-        "まあ、こんなこともあるさ。うん、うん"
+        "But no matter. No, not to worry."
       ]
     },
     {
       "ID": 36000502,
       "Entries": [
-        "懲りずに声をかけてくれよ、待ってるから"
+        "Come back again. I'm always available."
       ]
     },
     {
       "ID": 36000503,
       "Entries": [
-        "結局、取引は出会いの運命だからね"
+        "Not every trade was meant to be."
       ]
     },
     {
       "ID": 36000504,
       "Entries": [
-        "縁があればどうしたって導かれる。だから、待つのも楽しいものさ"
+        "There'll be more in store for us, someday, sometime!"
       ]
     },
     {
       "ID": 36000600,
       "Entries": [
-        "ど、どうした！"
+        "Hold on, there!"
       ]
     },
     {
       "ID": 36000610,
       "Entries": [
-        "何をするんだ！"
+        "What's this about?"
       ]
     },
     {
       "ID": 36000620,
       "Entries": [
-        "やめてくれ！"
+        "Now, stop that!"
       ]
     },
     {
       "ID": 36000630,
       "Entries": [
-        "イタッ"
+        "Ouch!"
       ]
     },
     {
       "ID": 36000640,
       "Entries": [
-        "アウッ"
+        "Oww!"
       ]
     },
     {
       "ID": 36000700,
       "Entries": [
-        "どうしたんだ、一体"
+        "What problem do you have now?"
       ]
     },
     {
       "ID": 36000701,
       "Entries": [
-        "だが、争うのは好きじゃない"
+        "I'm a man of peace, idiot!"
       ]
     },
     {
       "ID": 36000702,
       "Entries": [
-        "さよならだな。バイバイだ"
+        "Enough of you, I say, farewell."
       ]
     },
     {
       "ID": 36000800,
       "Entries": [
-        "そんな…どうして…"
+        "By the Lords...why..."
       ]
     },
     {
       "ID": 36000801,
       "Entries": [
-        "私のコレクションが…"
+        "My precious collection..."
       ]
     },
     {
       "ID": 36000900,
       "Entries": [
-        "ふーむ…"
+        "Hmm..."
       ]
     },
     {
       "ID": 36000901,
       "Entries": [
-        "特に何も無いなあ…"
+        "I'm afraid I don't see anything here."
       ]
     },
     {
       "ID": 36001000,
       "Entries": [
-        "ふーむ…"
+        "Hmm..."
       ]
     },
     {
       "ID": 36001001,
       "Entries": [
-        "まあ、君とはいい取引ができそうだからね…"
+        "Well, I'm certain we will make a good trade eventually..."
       ]
     },
     {
       "ID": 36001002,
       "Entries": [
-        "色々と教えてあげよう"
+        "So, I am willing to share some tips."
       ]
     },
     {
       "ID": 36001003,
       "Entries": [
-        "地下墓地の「注ぎ火」が欲しければ、神聖な武器を使うといい"
+        "If you seek Kindling in the Catacombs, use divine weapons."
       ]
     },
     {
       "ID": 36001004,
       "Entries": [
-        "よみがえる骸骨をおさえられるだろう"
+        "That will repel the reassembling skeletons."
       ]
     },
     {
       "ID": 36001100,
       "Entries": [
-        "ふーむ…"
+        "Hmm..."
       ]
     },
     {
       "ID": 36001101,
       "Entries": [
-        "まあ、君とはいい取引ができそうだからね…"
+        "Well, I'm certain we will make a good trade eventually..."
       ]
     },
     {
       "ID": 36001102,
       "Entries": [
-        "色々と教えてあげよう"
+        "So, I am willing to share some tips."
       ]
     },
     {
       "ID": 36001103,
       "Entries": [
-        "小ロンドの亡霊は、呪われているからね。通常じゃあ手も足も出ない"
+        "The cursed Ghosts of New Londo are formidable foes."
       ]
     },
     {
       "ID": 36001104,
       "Entries": [
-        "何とかしたければ、特別な武器か…呪われた体が必要なのさ"
+        "To face them, you will require special arms...Or a cursed body."
       ]
     },
     {
       "ID": 36001105,
       "Entries": [
-        "手っ取り早く呪われたければ、下水の目玉トカゲがお勧めだな"
+        "The quickest way to be cursed? Try the bug-eyed lizards in the\nsewer."
       ]
     },
     {
       "ID": 36001106,
       "Entries": [
-        "…やめた方がいいと思うけどね"
+        "Desperate measures, to be sure..."
       ]
     },
     {
       "ID": 36001200,
       "Entries": [
-        "ふーむ…"
+        "Hmm..."
       ]
     },
     {
       "ID": 36001201,
       "Entries": [
-        "まあ、君はいい取引相手だからね…"
+        "You are a fine trading partner."
       ]
     },
     {
       "ID": 36001202,
       "Entries": [
-        "真偽も分からない噂だけど、この地のどこかに、古い竜の生き残りがいるらしい"
+        "Rumour it may be, but I have heard of a surviving ancient dragon\nwho resides in this land."
       ]
     },
     {
       "ID": 36001203,
       "Entries": [
-        "僅かな不死が古竜に仕え、自らも竜になるために修行しているとも聞くよ"
+        "A coterie of Undead serves the dragon, as they train to become\ndragons themselves."
       ]
     },
     {
       "ID": 36001204,
       "Entries": [
-        "もし本当なら、是非会ってみたいものだねえ…"
+        "Sounds unlikely, but you never know, do you?"
       ]
     },
     {
       "ID": 36010000,
       "Entries": [
-        "やあ、こんにちは"
+        "Aye, siwmae."
       ]
     },
     {
       "ID": 36010001,
       "Entries": [
-        "はじめまして"
+        "And good day to you."
       ]
     },
     {
       "ID": 36010002,
       "Entries": [
-        "私はゼナのドーナル"
+        "I'm Domhnall of Zena."
       ]
     },
     {
       "ID": 36010003,
       "Entries": [
-        "なんというか…商い者さ"
+        "I'm just, well, a peddler, of sorts."
       ]
     },
     {
       "ID": 36010004,
       "Entries": [
-        "珍品奇品、取引するよ。大好きなんだ"
+        "I adore trinkets and oddities, so I trade for them."
       ]
     },
     {
       "ID": 36010100,
       "Entries": [
-        "やあ、こんにちは"
+        "Aye, siwmae."
       ]
     },
     {
       "ID": 36010101,
       "Entries": [
-        "また会ったね"
+        "We meet again."
       ]
     },
     {
       "ID": 36010102,
       "Entries": [
-        "何か珍品でも見つけたのかい？"
+        "Found anything special for my good self?"
       ]
     },
     {
       "ID": 36010103,
       "Entries": [
-        "だったら嬉しいな"
+        "Mmm, I certainly hope so!"
       ]
     },
     {
       "ID": 36010120,
       "Entries": [
-        "やあ、こんにちは"
+        "Aye, siwmae."
       ]
     },
     {
       "ID": 36010121,
       "Entries": [
-        "何か珍品でも見つけたのかい？"
+        "Found anything special for my good self?"
       ]
     },
     {
       "ID": 36010122,
       "Entries": [
-        "だったら嬉しいな"
+        "Mmm, I certainly hope so!"
       ]
     },
     {
       "ID": 36010200,
       "Entries": [
-        "やあ、こんにちは"
+        "Aye, siwmae."
       ]
     },
     {
       "ID": 36010201,
       "Entries": [
-        "こんなところで会うなんて、奇遇だな"
+        "Never thought I'd see you here."
       ]
     },
     {
       "ID": 36010202,
       "Entries": [
-        "予感がするよ。いい取引ができそうだ"
+        "This feels karmaic. Pray tell, what do you have for me?"
       ]
     },
     {
       "ID": 36010300,
       "Entries": [
-        "やあ、こんにちは"
+        "Aye, siwmae."
       ]
     },
     {
       "ID": 36010301,
       "Entries": [
-        "まさか、人が来るとは思わなかったよ"
+        "I didn't expect to meet anybody here."
       ]
     },
     {
       "ID": 36010302,
       "Entries": [
-        "お互い物好きってことかな。うん、うん"
+        "I suppose great minds think alike, eh? Heh heh."
       ]
     },
     {
       "ID": 36010400,
       "Entries": [
-        "ありがとう。いい取引だった"
+        "Thank you. That was a fine trade."
       ]
     },
     {
       "ID": 36010401,
       "Entries": [
-        "君とは、また会えたら嬉しいな"
+        "I have this funny feeling we'll meet again soon."
       ]
     },
     {
       "ID": 36010402,
       "Entries": [
-        "素晴らしい取引をしようよ"
+        "And we'll make another fine trade, of course!"
       ]
     },
     {
       "ID": 36010500,
       "Entries": [
-        "今回は、残念だったね"
+        "Well, that is a shame, then."
       ]
     },
     {
       "ID": 36010501,
       "Entries": [
-        "まあ、こんなこともあるさ。うん、うん"
+        "But no matter. No, not to worry."
       ]
     },
     {
       "ID": 36010502,
       "Entries": [
-        "懲りずに声をかけてくれよ、待ってるから"
+        "Come back again. I'm always available."
       ]
     },
     {
       "ID": 36010503,
       "Entries": [
-        "結局、取引は出会いの運命だからね"
+        "Not every trade was meant to be."
       ]
     },
     {
       "ID": 36010504,
       "Entries": [
-        "縁があればどうしたって導かれる。だから、待つのも楽しいものさ"
+        "There'll be more in store for us, someday, sometime!"
       ]
     },
     {
       "ID": 36010600,
       "Entries": [
-        "ど、どうした！"
+        "Hold on, there!"
       ]
     },
     {
       "ID": 36010610,
       "Entries": [
-        "何をするんだ！"
+        "What's this about?"
       ]
     },
     {
       "ID": 36010620,
       "Entries": [
-        "やめてくれ！"
+        "Now, stop that!"
       ]
     },
     {
       "ID": 36010630,
       "Entries": [
-        "イタッ"
+        "Ouch!"
       ]
     },
     {
       "ID": 36010640,
       "Entries": [
-        "アウッ"
+        "Oww!"
       ]
     },
     {
       "ID": 36010700,
       "Entries": [
-        "どうしたんだ、一体"
+        "What problem do you have now?"
       ]
     },
     {
       "ID": 36010701,
       "Entries": [
-        "だが、争うのは好きじゃない"
+        "I'm a man of peace, idiot!"
       ]
     },
     {
       "ID": 36010702,
       "Entries": [
-        "さよならだな。バイバイだ"
+        "Enough of you, I say, farewell."
       ]
     },
     {
       "ID": 36010800,
       "Entries": [
-        "そんな…どうして…"
+        "By the Lords...why..."
       ]
     },
     {
       "ID": 36010801,
       "Entries": [
-        "私のコレクションが…"
+        "My precious collection..."
       ]
     },
     {
       "ID": 36010900,
       "Entries": [
-        "ふーむ…"
+        "Hmm..."
       ]
     },
     {
       "ID": 36010901,
       "Entries": [
-        "特に何も無いなあ…"
+        "I'm afraid I don't see anything here."
       ]
     },
     {
       "ID": 36011000,
       "Entries": [
-        "ふーむ…"
+        "Hmm..."
       ]
     },
     {
       "ID": 36011001,
       "Entries": [
-        "まあ、君とはいい取引ができそうだからね…"
+        "Well, I'm certain we will make a good trade eventually..."
       ]
     },
     {
       "ID": 36011002,
       "Entries": [
-        "色々と教えてあげよう"
+        "So, I am willing to share some tips."
       ]
     },
     {
       "ID": 36011003,
       "Entries": [
-        "地下墓地の「注ぎ火」が欲しければ、神聖な武器を使うといい"
+        "If you seek Kindling in the Catacombs, use divine weapons."
       ]
     },
     {
       "ID": 36011004,
       "Entries": [
-        "よみがえる骸骨をおさえられるだろう"
+        "That will repel the reassembling skeletons."
       ]
     },
     {
       "ID": 36011100,
       "Entries": [
-        "ふーむ…"
+        "Hmm..."
       ]
     },
     {
       "ID": 36011101,
       "Entries": [
-        "まあ、君とはいい取引ができそうだからね…"
+        "Well, I'm certain we will make a good trade eventually..."
       ]
     },
     {
       "ID": 36011102,
       "Entries": [
-        "色々と教えてあげよう"
+        "So, I am willing to share some tips."
       ]
     },
     {
       "ID": 36011103,
       "Entries": [
-        "小ロンドの亡霊は、呪われているからね。通常じゃあ手も足も出ない"
+        "The cursed Ghosts of New Londo are formidable foes."
       ]
     },
     {
       "ID": 36011104,
       "Entries": [
-        "何とかしたければ、特別な武器か…呪われた体が必要なのさ"
+        "To face them, you will require special arms...Or a cursed body."
       ]
     },
     {
       "ID": 36011105,
       "Entries": [
-        "手っ取り早く呪われたければ、下水の目玉トカゲがお勧めだな"
+        "The quickest way to be cursed? Try the bug-eyed lizards in the\nsewer."
       ]
     },
     {
       "ID": 36011106,
       "Entries": [
-        "…やめた方がいいと思うけどね"
+        "Desperate measures, to be sure..."
       ]
     },
     {
       "ID": 36011200,
       "Entries": [
-        "ふーむ…"
+        "Hmm..."
       ]
     },
     {
       "ID": 36011201,
       "Entries": [
-        "まあ、君はいい取引相手だからね…"
+        "You are a fine trading partner."
       ]
     },
     {
       "ID": 36011202,
       "Entries": [
-        "真偽も分からない噂だけど、この地のどこかに、古い竜の生き残りがいるらしい"
+        "Rumour it may be, but I have heard of a surviving ancient dragon\nwho resides in this land."
       ]
     },
     {
       "ID": 36011203,
       "Entries": [
-        "僅かな不死が古竜に仕え、自らも竜になるために修行しているとも聞くよ"
+        "A coterie of Undead serves the dragon, as they train to become\ndragons themselves."
       ]
     },
     {
       "ID": 36011204,
       "Entries": [
-        "もし本当なら、是非会ってみたいものだねえ…"
+        "Sounds unlikely, but you never know, do you?"
       ]
     },
     {
       "ID": 36020000,
       "Entries": [
-        "やあ、こんにちは"
+        "Aye, siwmae."
       ]
     },
     {
       "ID": 36020001,
       "Entries": [
-        "はじめまして"
+        "And good day to you."
       ]
     },
     {
       "ID": 36020002,
       "Entries": [
-        "私はゼナのドーナル"
+        "I'm Domhnall of Zena."
       ]
     },
     {
       "ID": 36020003,
       "Entries": [
-        "なんというか…商い者さ"
+        "I'm just, well, a peddler, of sorts."
       ]
     },
     {
       "ID": 36020004,
       "Entries": [
-        "珍品奇品、取引するよ。大好きなんだ"
+        "I adore trinkets and oddities, so I trade for them."
       ]
     },
     {
       "ID": 36020100,
       "Entries": [
-        "やあ、こんにちは"
+        "Aye, siwmae."
       ]
     },
     {
       "ID": 36020101,
       "Entries": [
-        "また会ったね"
+        "We meet again."
       ]
     },
     {
       "ID": 36020102,
       "Entries": [
-        "何か珍品でも見つけたのかい？"
+        "Found anything special for my good self?"
       ]
     },
     {
       "ID": 36020103,
       "Entries": [
-        "だったら嬉しいな"
+        "Mmm, I certainly hope so!"
       ]
     },
     {
       "ID": 36020200,
       "Entries": [
-        "やあ、こんにちは"
+        "Aye, siwmae."
       ]
     },
     {
       "ID": 36020201,
       "Entries": [
-        "こんなところで会うなんて、奇遇だな"
+        "Never thought I'd see you here."
       ]
     },
     {
       "ID": 36020202,
       "Entries": [
-        "予感がするよ。いい取引ができそうだ"
+        "This feels karmaic. Pray tell, what do you have for me?"
       ]
     },
     {
       "ID": 36020300,
       "Entries": [
-        "やあ、こんにちは"
+        "Aye, siwmae."
       ]
     },
     {
       "ID": 36020301,
       "Entries": [
-        "まさか、人が来るとは思わなかったよ"
+        "I didn't expect to meet anybody here."
       ]
     },
     {
       "ID": 36020302,
       "Entries": [
-        "お互い物好きってことかな。うん、うん"
+        "I suppose great minds think alike, eh? Heh heh."
       ]
     },
     {
       "ID": 36020400,
       "Entries": [
-        "ありがとう。いい取引だった"
+        "Thank you. That was a fine trade."
       ]
     },
     {
       "ID": 36020401,
       "Entries": [
-        "君とは、また会えたら嬉しいな"
+        "I have this funny feeling we'll meet again soon."
       ]
     },
     {
       "ID": 36020402,
       "Entries": [
-        "素晴らしい取引をしようよ"
+        "And we'll make another fine trade, of course!"
       ]
     },
     {
       "ID": 36020500,
       "Entries": [
-        "今回は、残念だったね"
+        "Well, that is a shame, then."
       ]
     },
     {
       "ID": 36020501,
       "Entries": [
-        "まあ、こんなこともあるさ。うん、うん"
+        "But no matter. No, not to worry."
       ]
     },
     {
       "ID": 36020502,
       "Entries": [
-        "懲りずに声をかけてくれよ、待ってるから"
+        "Come back again. I'm always available."
       ]
     },
     {
       "ID": 36020503,
       "Entries": [
-        "結局、取引は出会いの運命だからね"
+        "Not every trade was meant to be."
       ]
     },
     {
       "ID": 36020504,
       "Entries": [
-        "縁があればどうしたって導かれる。だから、待つのも楽しいものさ"
+        "There'll be more in store for us, someday, sometime!"
       ]
     },
     {
       "ID": 36020600,
       "Entries": [
-        "ど、どうした！"
+        "Hold on, there!"
       ]
     },
     {
       "ID": 36020610,
       "Entries": [
-        "何をするんだ！"
+        "What's this about?"
       ]
     },
     {
       "ID": 36020620,
       "Entries": [
-        "やめてくれ！"
+        "Now, stop that!"
       ]
     },
     {
       "ID": 36020630,
       "Entries": [
-        "イタッ"
+        "Ouch!"
       ]
     },
     {
       "ID": 36020640,
       "Entries": [
-        "アウッ"
+        "Oww!"
       ]
     },
     {
       "ID": 36020700,
       "Entries": [
-        "どうしたんだ、一体"
+        "What problem do you have now?"
       ]
     },
     {
       "ID": 36020701,
       "Entries": [
-        "だが、争うのは好きじゃない"
+        "I'm a man of peace, idiot!"
       ]
     },
     {
       "ID": 36020702,
       "Entries": [
-        "さよならだな。バイバイだ"
+        "Enough of you, I say, farewell."
       ]
     },
     {
       "ID": 36020800,
       "Entries": [
-        "そんな…どうして…"
+        "By the Lords...why..."
       ]
     },
     {
       "ID": 36020801,
       "Entries": [
-        "私のコレクションが…"
+        "My precious collection..."
       ]
     },
     {
       "ID": 36020900,
       "Entries": [
-        "ふーむ…"
+        "Hmm..."
       ]
     },
     {
       "ID": 36020901,
       "Entries": [
-        "特に何も無いなあ…"
+        "I'm afraid I don't see anything here."
       ]
     },
     {
       "ID": 36021000,
       "Entries": [
-        "ふーむ…"
+        "Hmm..."
       ]
     },
     {
       "ID": 36021001,
       "Entries": [
-        "まあ、君とはいい取引ができそうだからね…"
+        "Well, I'm certain we will make a good trade eventually..."
       ]
     },
     {
       "ID": 36021002,
       "Entries": [
-        "色々と教えてあげよう"
+        "So, I am willing to share some tips."
       ]
     },
     {
       "ID": 36021003,
       "Entries": [
-        "地下墓地の「注ぎ火」が欲しければ、神聖な武器を使うといい"
+        "If you seek Kindling in the Catacombs, use divine weapons."
       ]
     },
     {
       "ID": 36021004,
       "Entries": [
-        "よみがえる骸骨をおさえられるだろう"
+        "That will repel the reassembling skeletons."
       ]
     },
     {
       "ID": 36021100,
       "Entries": [
-        "ふーむ…"
+        "Hmm..."
       ]
     },
     {
       "ID": 36021101,
       "Entries": [
-        "まあ、君とはいい取引ができそうだからね…"
+        "Well, I'm certain we will make a good trade eventually..."
       ]
     },
     {
       "ID": 36021102,
       "Entries": [
-        "色々と教えてあげよう"
+        "So, I am willing to share some tips."
       ]
     },
     {
       "ID": 36021103,
       "Entries": [
-        "小ロンドの亡霊は、呪われているからね。通常じゃあ手も足も出ない"
+        "The cursed Ghosts of New Londo are formidable foes."
       ]
     },
     {
       "ID": 36021104,
       "Entries": [
-        "何とかしたければ、特別な武器か…呪われた体が必要なのさ"
+        "To face them, you will require special arms...Or a cursed body."
       ]
     },
     {
       "ID": 36021105,
       "Entries": [
-        "手っ取り早く呪われたければ、下水の目玉トカゲがお勧めだな"
+        "The quickest way to be cursed? Try the bug-eyed lizards in the\nsewer."
       ]
     },
     {
       "ID": 36021106,
       "Entries": [
-        "…やめた方がいいと思うけどね"
+        "Desperate measures, to be sure..."
       ]
     },
     {
       "ID": 36021200,
       "Entries": [
-        "ふーむ…"
+        "Hmm..."
       ]
     },
     {
       "ID": 36021201,
       "Entries": [
-        "まあ、君はいい取引相手だからね…"
+        "You are a fine trading partner."
       ]
     },
     {
       "ID": 36021202,
       "Entries": [
-        "真偽も分からない噂だけど、この地のどこかに、古い竜の生き残りがいるらしい"
+        "Rumour it may be, but I have heard of a surviving ancient dragon\nwho resides in this land."
       ]
     },
     {
       "ID": 36021203,
       "Entries": [
-        "僅かな不死が古竜に仕え、自らも竜になるために修行しているとも聞くよ"
+        "A coterie of Undead serves the dragon, as they train to become\ndragons themselves."
       ]
     },
     {
       "ID": 36021204,
       "Entries": [
-        "もし本当なら、是非会ってみたいものだねえ…"
+        "Sounds unlikely, but you never know, do you?"
       ]
     },
     {
       "ID": 36030000,
       "Entries": [
-        "やあ、こんにちは"
+        "Aye, siwmae."
       ]
     },
     {
       "ID": 36030001,
       "Entries": [
-        "はじめまして"
+        "And good day to you."
       ]
     },
     {
       "ID": 36030002,
       "Entries": [
-        "私はゼナのドーナル"
+        "I'm Domhnall of Zena."
       ]
     },
     {
       "ID": 36030003,
       "Entries": [
-        "なんというか…商い者さ"
+        "I'm just, well, a peddler, of sorts."
       ]
     },
     {
       "ID": 36030004,
       "Entries": [
-        "珍品奇品、取引するよ。大好きなんだ"
+        "I adore trinkets and oddities, so I trade for them."
       ]
     },
     {
       "ID": 36030100,
       "Entries": [
-        "やあ、こんにちは"
+        "Aye, siwmae."
       ]
     },
     {
       "ID": 36030101,
       "Entries": [
-        "また会ったね"
+        "We meet again."
       ]
     },
     {
       "ID": 36030102,
       "Entries": [
-        "何か珍品でも見つけたのかい？"
+        "Found anything special for my good self?"
       ]
     },
     {
       "ID": 36030103,
       "Entries": [
-        "だったら嬉しいな"
+        "Mmm, I certainly hope so!"
       ]
     },
     {
       "ID": 36030200,
       "Entries": [
-        "やあ、こんにちは"
+        "Aye, siwmae."
       ]
     },
     {
       "ID": 36030201,
       "Entries": [
-        "こんなところで会うなんて、奇遇だな"
+        "Never thought I'd see you here."
       ]
     },
     {
       "ID": 36030202,
       "Entries": [
-        "予感がするよ。いい取引ができそうだ"
+        "This feels karmaic. Pray tell, what do you have for me?"
       ]
     },
     {
       "ID": 36030300,
       "Entries": [
-        "やあ、こんにちは"
+        "Aye, siwmae."
       ]
     },
     {
       "ID": 36030301,
       "Entries": [
-        "まさか、人が来るとは思わなかったよ"
+        "I didn't expect to meet anybody here."
       ]
     },
     {
       "ID": 36030302,
       "Entries": [
-        "お互い物好きってことかな。うん、うん"
+        "I suppose great minds think alike, eh? Heh heh."
       ]
     },
     {
       "ID": 36030400,
       "Entries": [
-        "ありがとう。いい取引だった"
+        "Thank you. That was a fine trade."
       ]
     },
     {
       "ID": 36030401,
       "Entries": [
-        "君とは、また会えたら嬉しいな"
+        "I have this funny feeling we'll meet again soon."
       ]
     },
     {
       "ID": 36030402,
       "Entries": [
-        "素晴らしい取引をしようよ"
+        "And we'll make another fine trade, of course!"
       ]
     },
     {
       "ID": 36030500,
       "Entries": [
-        "今回は、残念だったね"
+        "Well, that is a shame, then."
       ]
     },
     {
       "ID": 36030501,
       "Entries": [
-        "まあ、こんなこともあるさ。うん、うん"
+        "But no matter. No, not to worry."
       ]
     },
     {
       "ID": 36030502,
       "Entries": [
-        "懲りずに声をかけてくれよ、待ってるから"
+        "Come back again. I'm always available."
       ]
     },
     {
       "ID": 36030503,
       "Entries": [
-        "結局、取引は出会いの運命だからね"
+        "Not every trade was meant to be."
       ]
     },
     {
       "ID": 36030504,
       "Entries": [
-        "縁があればどうしたって導かれる。だから、待つのも楽しいものさ"
+        "There'll be more in store for us, someday, sometime!"
       ]
     },
     {
       "ID": 36030600,
       "Entries": [
-        "ど、どうした！"
+        "Hold on, there!"
       ]
     },
     {
       "ID": 36030610,
       "Entries": [
-        "何をするんだ！"
+        "What's this about?"
       ]
     },
     {
       "ID": 36030620,
       "Entries": [
-        "やめてくれ！"
+        "Now, stop that!"
       ]
     },
     {
       "ID": 36030630,
       "Entries": [
-        "イタッ"
+        "Ouch!"
       ]
     },
     {
       "ID": 36030640,
       "Entries": [
-        "アウッ"
+        "Oww!"
       ]
     },
     {
       "ID": 36030700,
       "Entries": [
-        "どうしたんだ、一体"
+        "What problem do you have now?"
       ]
     },
     {
       "ID": 36030701,
       "Entries": [
-        "だが、争うのは好きじゃない"
+        "I'm a man of peace, idiot!"
       ]
     },
     {
       "ID": 36030702,
       "Entries": [
-        "さよならだな。バイバイだ"
+        "Enough of you, I say, farewell."
       ]
     },
     {
       "ID": 36030800,
       "Entries": [
-        "そんな…どうして…"
+        "By the Lords...why..."
       ]
     },
     {
       "ID": 36030801,
       "Entries": [
-        "私のコレクションが…"
+        "My precious collection..."
       ]
     },
     {
       "ID": 36030900,
       "Entries": [
-        "ふーむ…"
+        "Hmm..."
       ]
     },
     {
       "ID": 36030901,
       "Entries": [
-        "特に何も無いなあ…"
+        "I'm afraid I don't see anything here."
       ]
     },
     {
       "ID": 36031000,
       "Entries": [
-        "ふーむ…"
+        "Hmm..."
       ]
     },
     {
       "ID": 36031001,
       "Entries": [
-        "まあ、君とはいい取引ができそうだからね…"
+        "Well, I'm certain we will make a good trade eventually..."
       ]
     },
     {
       "ID": 36031002,
       "Entries": [
-        "色々と教えてあげよう"
+        "So, I am willing to share some tips."
       ]
     },
     {
       "ID": 36031003,
       "Entries": [
-        "地下墓地の「注ぎ火」が欲しければ、神聖な武器を使うといい"
+        "If you seek Kindling in the Catacombs, use divine weapons."
       ]
     },
     {
       "ID": 36031004,
       "Entries": [
-        "よみがえる骸骨をおさえられるだろう"
+        "That will repel the reassembling skeletons."
       ]
     },
     {
       "ID": 36031100,
       "Entries": [
-        "ふーむ…"
+        "Hmm..."
       ]
     },
     {
       "ID": 36031101,
       "Entries": [
-        "まあ、君とはいい取引ができそうだからね…"
+        "Well, I'm certain we will make a good trade eventually..."
       ]
     },
     {
       "ID": 36031102,
       "Entries": [
-        "色々と教えてあげよう"
+        "So, I am willing to share some tips."
       ]
     },
     {
       "ID": 36031103,
       "Entries": [
-        "小ロンドの亡霊は、呪われているからね。通常じゃあ手も足も出ない"
+        "The cursed Ghosts of New Londo are formidable foes."
       ]
     },
     {
       "ID": 36031104,
       "Entries": [
-        "何とかしたければ、特別な武器か…呪われた体が必要なのさ"
+        "To face them, you will require special arms...Or a cursed body."
       ]
     },
     {
       "ID": 36031105,
       "Entries": [
-        "手っ取り早く呪われたければ、下水の目玉トカゲがお勧めだな"
+        "The quickest way to be cursed? Try the bug-eyed lizards in the\nsewer."
       ]
     },
     {
       "ID": 36031106,
       "Entries": [
-        "…やめた方がいいと思うけどね"
+        "Desperate measures, to be sure..."
       ]
     },
     {
       "ID": 36031200,
       "Entries": [
-        "ふーむ…"
+        "Hmm..."
       ]
     },
     {
       "ID": 36031201,
       "Entries": [
-        "まあ、君はいい取引相手だからね…"
+        "You are a fine trading partner."
       ]
     },
     {
       "ID": 36031202,
       "Entries": [
-        "真偽も分からない噂だけど、この地のどこかに、古い竜の生き残りがいるらしい"
+        "Rumour it may be, but I have heard of a surviving ancient dragon\nwho resides in this land."
       ]
     },
     {
       "ID": 36031203,
       "Entries": [
-        "僅かな不死が古竜に仕え、自らも竜になるために修行しているとも聞くよ"
+        "A coterie of Undead serves the dragon, as they train to become\ndragons themselves."
       ]
     },
     {
       "ID": 36031204,
       "Entries": [
-        "もし本当なら、是非会ってみたいものだねえ…"
+        "Sounds unlikely, but you never know, do you?"
       ]
     },
     {
       "ID": 37000000,
       "Entries": [
-        "よう、あんた、よくきたな。新しい奴は、久しぶりだ"
+        "Well, what do we have here? You must be a new arrival."
       ]
     },
     {
       "ID": 37000001,
       "Entries": [
-        "どうせ、あれだろう？不死の使命がどうとか…皆一緒だ"
+        "Let me guess. Fate of the Undead, right? Well, you're not the\nfirst."
       ]
     },
     {
       "ID": 37000002,
       "Entries": [
-        "呪われた時点で終わってるんだ、不死院でじっとしれてばいいものを…ご苦労なことさ"
+        "But there's no salvation here. You'd have done better to rot in\nthe Undead Asylum... But, too late now."
       ]
     },
     {
       "ID": 37000003,
       "Entries": [
-        "まあ、いい。暇なんだ、教えてやるよ"
+        "Well, since you're here... Let me help you out."
       ]
     },
     {
       "ID": 37000004,
       "Entries": [
-        "不死の使命に言う、目覚ましの鐘ってのは、ふたつある"
+        "There are actually two Bells of Awakening."
       ]
     },
     {
       "ID": 37000005,
       "Entries": [
-        "ひとつは、この上にある、不死教会の鐘楼に、もうひとつは、この遥か下にある、病み村の底の古い遺跡に"
+        "One's up above, in the Undead Church. The other is far, far\nbelow, in the ruins at the base of Blighttown."
       ]
     },
     {
       "ID": 37000006,
       "Entries": [
-        "両方鳴らせば、何かが起こるって話だが…どうだろうね？"
+        "Ring them both, and something happens... Brilliant, right?"
       ]
     },
     {
       "ID": 37000007,
       "Entries": [
-        "少なくとも俺は、その先の話は、聞いたこともねえが…まあ、いい"
+        "Not much to go on, but I have a feeling that won't stop you."
       ]
     },
     {
       "ID": 37000008,
       "Entries": [
-        "さあ、行けよ。そのためにきたのだろう？この呪われた不死の地に"
+        "So, off you go. It is why you came, isn't it? To this accursed\nland of the Undead?"
       ]
     },
     {
       "ID": 37000009,
       "Entries": [
-        "…ハハハハハ"
+        "Hah hah hah hah..."
       ]
     },
     {
       "ID": 37000100,
       "Entries": [
-        "ん？なんだ？まだ何かあるのか？"
+        "Hm? What, you want to hear more?"
       ]
     },
     {
       "ID": 37000101,
       "Entries": [
-        "知りたがりは好きじゃないが…まあ、いい"
+        "Oh, that's all we need. Another inquisitive soul."
       ]
     },
     {
       "ID": 37000102,
       "Entries": [
-        "あと少しだけ教えてやるよ"
+        "Well, listen carefully, then..."
       ]
     },
     {
       "ID": 37000103,
       "Entries": [
-        "１つの鐘は、確かにこの上の不死教会だが、今はリフトが止まっちまってる"
+        "One of the bells is up above in the Undead Church, but the lift\nis broken."
       ]
     },
     {
       "ID": 37000104,
       "Entries": [
-        "だから、この先の崖沿いを上って、水路から不死街に入るしかない"
+        "You'll have to climb the stairs up the ruins, and access the\nUndead Burg through the waterway."
       ]
     },
     {
       "ID": 37000105,
       "Entries": [
-        "もう１つの鐘は、その不死街を下へ向かえばいいはずさ"
+        "The other bell is back down below the Undead Burg,"
       ]
     },
     {
       "ID": 37000106,
       "Entries": [
-        "…もっとも、不死街の先は、疫病者が集まる病み村だ"
+        "within the plague-infested Blighttown."
       ]
     },
     {
       "ID": 37000107,
       "Entries": [
-        "俺なら、近づくのもご免こうむりたいがねえ"
+        "But I'd die again before I step foot in that cesspool!"
       ]
     },
     {
       "ID": 37000108,
       "Entries": [
-        "ワハハハハハ"
+        "Hah hah hah hah!"
       ]
     },
     {
       "ID": 37000200,
       "Entries": [
-        "おいおい、まだ何かあるのか？"
+        "Bloody hell, what is it now?"
       ]
     },
     {
       "ID": 37000201,
       "Entries": [
-        "あんまり知りたがりだと、嫌われるぜ"
+        "You ask too many questions."
       ]
     },
     {
       "ID": 37000300,
       "Entries": [
-        "どうした？怖気づいたのか？"
+        "What's wrong? Get a bit of a scare out there?"
       ]
     },
     {
       "ID": 37000301,
       "Entries": [
-        "だったら、俺と同じように、ずっと、ここに座っていればいい"
+        "No problem. Have a seat and get comfortable."
       ]
     },
     {
       "ID": 37000302,
       "Entries": [
-        "いずれ亡者になるまで、ただぼうとしているのが一番楽さ"
+        "We'll both be Hollow before you know it."
       ]
     },
     {
       "ID": 37000303,
       "Entries": [
-        "…ハハハハハ"
+        "Hah hah hah hah..."
       ]
     },
     {
       "ID": 37000400,
       "Entries": [
-        "おう、あんた。意外だな、まだ無事だったのか"
+        "Why, what a surprise. I didn't expect you to make it."
       ]
     },
     {
       "ID": 37000401,
       "Entries": [
-        "…そういえば、さっき鐘の音が聞こえたが…まさか、あんたか？"
+        "...Oh, somebody rang the bell...Wait. Was it you?"
       ]
     },
     {
       "ID": 37000402,
       "Entries": [
-        "だとしたら、まあ熱心なことだな。頭が下がるよ"
+        "You never give up, do you? I don't know how you do it."
       ]
     },
     {
       "ID": 37000403,
       "Entries": [
-        "その調子で、もうひとつのヤバイ方も、頑張ってくれよ？"
+        "Well, don't stop now. Only one more, but it's going to be\nsuicide."
       ]
     },
     {
       "ID": 37000404,
       "Entries": [
-        "…ハハハハハ"
+        "Hah hah hah hah..."
       ]
     },
     {
       "ID": 37000450,
       "Entries": [
-        "おう、あんた。意外だな、まだ無事だったのか"
+        "Why, what a surprise. I didn't expect you to make it."
       ]
     },
     {
       "ID": 37000451,
       "Entries": [
-        "…そういえば、さっき鐘の音が聞こえたが…まさか、あんたか？"
+        "...Oh, somebody rang the bell...Wait. Was it you?"
       ]
     },
     {
       "ID": 37000452,
       "Entries": [
-        "だとしたら、まあ熱心なことだな。頭が下がるよ"
+        "You never give up, do you? I don't know how you do it."
       ]
     },
     {
       "ID": 37000453,
       "Entries": [
-        "その調子で、もうひとつの方も、頑張ってくれよ？"
+        "Only one more now, if you have the heart for it."
       ]
     },
     {
       "ID": 37000454,
       "Entries": [
-        "…ハハハハハ"
+        "Hah hah hah hah..."
       ]
     },
     {
       "ID": 37000500,
       "Entries": [
-        "そういえば、ついさっき、お上品な聖職者様も見えられてな。墓場から、地下墓地に入っていったよ"
+        "Did you see that hoity-toity cleric? He went through the\ngraveyard and down into the Catacombs."
       ]
     },
     {
       "ID": 37000501,
       "Entries": [
-        "何でも、あいつらの伝承に、不死の篝火を育てる「注ぎ火」の話があるらしくてな"
+        "Clerics speak of some nonsense called Kindling, used to feed\nbonfires."
       ]
     },
     {
       "ID": 37000502,
       "Entries": [
-        "あいつらは皆、地下墓地に向かう。坊主だけに、埋葬の手間を省いてるつもりなのかねえ"
+        "They're so bloody determined. They practically queue to explore\nthe Catacombs."
       ]
     },
     {
       "ID": 37000503,
       "Entries": [
-        "ワハハハハハ"
+        "Hah hah hah hah..."
       ]
     },
     {
       "ID": 37000600,
       "Entries": [
-        "あんた、この下の、小ロンド遺跡には行ってみたかい？"
+        "Have you been to the ruins of New Londo below?"
       ]
     },
     {
       "ID": 37000601,
       "Entries": [
-        "そこの階段をおりて、リフトに乗れば、すぐに着く"
+        "Just head down the stairs, and take the lift."
       ]
     },
     {
       "ID": 37000602,
       "Entries": [
-        "もしまだなら、一度行ってみるといい"
+        "It's certainly worth a visit."
       ]
     },
     {
       "ID": 37000603,
       "Entries": [
-        "古い不死の遺跡だ。何か、使命のヒントがあるかもしれんぜ"
+        "It was once an Undead city. You may find a clue or two."
       ]
     },
     {
       "ID": 37000604,
       "Entries": [
-        "例えば、亡霊の歓迎とかな…"
+        "Unless the ghosts find you first..."
       ]
     },
     {
       "ID": 37000605,
       "Entries": [
-        "クックックックッ"
+        "Keh heh heh heh!"
       ]
     },
     {
       "ID": 37000700,
       "Entries": [
-        "そういえば、あいつはどうしたっけなあ"
+        "How did that silly sorcerer's apprentice end up?"
       ]
     },
     {
       "ID": 37000701,
       "Entries": [
-        "「ビッグハット」を追ってるとか言ってた、魔術野郎がいたんだが…"
+        "You know, the one always prattling on about Master Logan."
       ]
     },
     {
       "ID": 37000702,
       "Entries": [
-        "不死街に向かったきり、帰ってきやしねえ"
+        "He left for the Undead Burg, but never came back."
       ]
     },
     {
       "ID": 37000703,
       "Entries": [
-        "馬鹿だよなあ？あの「ビッグハット」ならともかく、手前ごときに何ができるってんだか…"
+        "Serves him right. If even Old Big Hat can't make it out there,\nwhat chance does he have?"
       ]
     },
     {
       "ID": 37000704,
       "Entries": [
-        "どうせ、どっかで亡者になっちまったに決まってらあ…"
+        "I hope he enjoys his new life as a Hollow."
       ]
     },
     {
       "ID": 37000800,
       "Entries": [
-        "そういえば、あいつはどうしたっけなあ"
+        "How did that raggedy old chum end up?"
       ]
     },
     {
       "ID": 37000801,
       "Entries": [
-        "呪術の祖だとか、わけのわからないことを言ってた、こ汚い呪術師がいたんだが…"
+        "You know, the one who idolized some godmother of pyromancy."
       ]
     },
     {
       "ID": 37000802,
       "Entries": [
-        "病み村に向かったきり、帰ってきやしねえ"
+        "He left for Blighttown, but never came back."
       ]
     },
     {
       "ID": 37000803,
       "Entries": [
-        "物好きだよなあ？よりによってあの病み村だぜ？"
+        "Whereas most flee from sickness, he dives right in."
       ]
     },
     {
       "ID": 37000804,
       "Entries": [
-        "どうせ、どっかで亡者になっちまったに決まってらあ…"
+        "Well, nothing will harm him once he goes Hollow."
       ]
     },
     {
       "ID": 37000900,
       "Entries": [
-        "なんだ、あの聖職者様、無事だったのかよ"
+        "That cleric was spared?"
       ]
     },
     {
       "ID": 37000901,
       "Entries": [
-        "神様ってのも、存外見る目がないもんだな…"
+        "I never know what the Gods are thinking..."
       ]
     },
     {
       "ID": 37000902,
       "Entries": [
-        "ケッ…"
+        "Tsk!"
       ]
     },
     {
       "ID": 37001000,
       "Entries": [
-        "なんだ、あの魔術野郎、無事だったんだな…"
+        "How did that nutty sorcerer make it back?"
       ]
     },
     {
       "ID": 37001001,
       "Entries": [
-        "あんな小物が生きて戻るとは、珍しいこともあったもんだ…"
+        "Unexpected, but I suppose stranger things have happened."
       ]
     },
     {
       "ID": 37001100,
       "Entries": [
-        "なんだ、あの呪術師、無事だったんだな…"
+        "How did that old man make it back?"
       ]
     },
     {
       "ID": 37001101,
       "Entries": [
-        "あんな小物が生きて戻るとは、珍しいこともあったもんだ…"
+        "Unexpected, but I suppose stranger things have happened."
       ]
     },
     {
       "ID": 37001200,
       "Entries": [
-        "そういえば、あんた、なんで武器を鍛えねえんだ？"
+        "Don't you ever think to forge your weapons?"
       ]
     },
     {
       "ID": 37001201,
       "Entries": [
-        "もしアンドレイ親父を知らないのなら、不死教会の先、森の古教会にいってみな"
+        "Perhaps you haven't heard of Andre. Visit him in the Old Church,\nin the forest behind the Undead Church."
       ]
     },
     {
       "ID": 37001202,
       "Entries": [
-        "もしアンドレイ親父を知らないのなら、まあ、早く探した方がいいぜ"
+        "Perhaps you haven't heard of Andre. You really need to find him."
       ]
     },
     {
       "ID": 37001203,
       "Entries": [
-        "…もっとも、なまくらを使い続ける趣味なら、それもいいけどな！"
+        "Unless you enjoy swinging about with blunt instruments!"
       ]
     },
     {
       "ID": 37001204,
       "Entries": [
-        "ワハハハハハ"
+        "Hah hah hah hah!"
       ]
     },
     {
       "ID": 37001300,
       "Entries": [
-        "そういえば、あんたも見たか？"
+        "Oh, have you seen that terribly morose lass?"
       ]
     },
     {
       "ID": 37001301,
       "Entries": [
-        "大烏の側に、陰気な女がいるだろう。ありゃあ…火防女さ"
+        "...The Fire Keeper."
       ]
     },
     {
       "ID": 37001302,
       "Entries": [
-        "不死の篝火が消えないように、ずっとあそこにいるのが役目らしい"
+        "She's stuck keeping that bonfire lit."
       ]
     },
     {
       "ID": 37001303,
       "Entries": [
-        "まあ、悲惨なものさ。あの衣装、元は聖女だったんだろうが、今は口も聞けず、どこへもいけない"
+        "Sad, really. She's mute and bound to this forsaken place."
       ]
     },
     {
       "ID": 37001304,
       "Entries": [
-        "きっと、あの汚れた女が、間違っても神の名を呼ばないように、故郷の連中が舌を抜いちまったんだろう"
+        "They probably cut her tongue out back in her village, so that\nshe'd never say any god's name in vain."
       ]
     },
     {
       "ID": 37001305,
       "Entries": [
-        "まったく、敬虔な善人ってのは、すげえもんさ。俺には無理だ、感心するぜ！"
+        "How do these martyrs keep chugging along? I'd peter out in an\ninstant."
       ]
     },
     {
       "ID": 37001306,
       "Entries": [
-        "ワハハハハハ"
+        "Hah hah hah hah!"
       ]
     },
     {
       "ID": 37001400,
       "Entries": [
-        "…あんた、その顔、まるで亡者じゃねえか"
+        "Oh, your face! You're practically Hollow."
       ]
     },
     {
       "ID": 37001401,
       "Entries": [
-        "…もっとも、亡者になっちまった方が気楽かもしれないけどな"
+        "But who knows, going Hollow could solve quite a bit!"
       ]
     },
     {
       "ID": 37001402,
       "Entries": [
-        "…ハハハハハ"
+        "Hah hah hah hah..."
       ]
     },
     {
       "ID": 37001500,
       "Entries": [
-        "ん、どうした？人間性か？"
+        "Hm, what? Restoring your humanity?"
       ]
     },
     {
       "ID": 37001501,
       "Entries": [
-        "そりゃあ、やり方はあんた次第だが…"
+        "Well, there are a few ways to go about it..."
       ]
     },
     {
       "ID": 37001502,
       "Entries": [
-        "あるいは、聖職者連中みたいに、お互いを召喚して馴れ合うか…"
+        "Collect it bit by bit from corpses, or you can butter up a\ncleric, and get yourself summoned."
       ]
     },
     {
       "ID": 37001503,
       "Entries": [
-        "まあ、俺はやらねえが、一番手っ取り早いのは、まともな不死を殺して、奪うことさ"
+        "And the quickest way, although I'd never do it, is to kill a\nhealthy Undead, and pillage its humanity. "
       ]
     },
     {
       "ID": 37001504,
       "Entries": [
-        "人を殺して奪うのが、一番人間らしいかもしれねえなあ…"
+        "Coveting thy neighbour is only human, after all!"
       ]
     },
     {
       "ID": 37001505,
       "Entries": [
-        "…ハハハハハ"
+        "Hah hah hah hah..."
       ]
     },
     {
       "ID": 37001600,
       "Entries": [
-        "…だからって、俺に手をだすなよ"
+        "What are you looking at?"
       ]
     },
     {
       "ID": 37001601,
       "Entries": [
-        "安直な考えを後悔することになる…"
+        "Don't try anything clever. You might regret it."
       ]
     },
     {
       "ID": 37001700,
       "Entries": [
-        "おい、あんた…もしかして、呪われてるのか？"
+        "Oi, hold on...Don't tell me, have you been cursed?"
       ]
     },
     {
       "ID": 37001701,
       "Entries": [
-        "そりゃあ、不死人生積んじまったな。ご愁傷様だ"
+        "Oh woe is the Undead who's cursed on top of it all! Harsh times;\nharsh times, indeed!"
       ]
     },
     {
       "ID": 37001702,
       "Entries": [
-        "ワハハハハハ"
+        "Hah hah hah hah!"
       ]
     },
     {
       "ID": 37001703,
       "Entries": [
-        "ワハハハハハッ"
+        "Hah hah hah hah!"
       ]
     },
     {
       "ID": 37001704,
       "Entries": [
-        "ああ、すまん、すまん。お詫びに、ひとつ教えてやるよ"
+        "No, no, I'm sorry. Here, let me share a nice tip."
       ]
     },
     {
       "ID": 37001705,
       "Entries": [
-        "かなり昔の話だが…小ロンドに解呪師がいたと、聞いたことがある"
+        "Long ago, I was told of a remedician who resides in New Londo."
       ]
     },
     {
       "ID": 37001706,
       "Entries": [
-        "ダメでもともとだ。行ってみるのもいいんじゃないのか？"
+        "Does he really exist? Well, go and find out for yourself."
       ]
     },
     {
       "ID": 37001707,
       "Entries": [
-        "まあ、もしダメでも、俺を恨まないでくれよ！"
+        "But don't blame me if he's just an apparition!"
       ]
     },
     {
       "ID": 37001708,
       "Entries": [
-        "ワハハハハハ"
+        "Hah hah hah hah!"
       ]
     },
     {
       "ID": 37001800,
       "Entries": [
-        "おい、あんた、見たかい？"
+        "Oi, did you see him?"
       ]
     },
     {
       "ID": 37001801,
       "Entries": [
-        "ありゃあ、本物の「ビッグハット」だ。伝説的な魔術師だぜ"
+        "Big Hat Logan, the legendary sorcerer, in the flesh!"
       ]
     },
     {
       "ID": 37001802,
       "Entries": [
-        "…まったく、ここは、どうなってんだ？英雄様ばかりだ"
+        "...This place is simply mad...Legendary heroes popping up left\nand right..."
       ]
     },
     {
       "ID": 37001803,
       "Entries": [
-        "俺様なんて、いかにも場違い、居心地が悪いぜ…"
+        "They're making me feel quite inadequate, to be honest!"
       ]
     },
     {
       "ID": 37001804,
       "Entries": [
-        "…ハハハハハ"
+        "Hah hah hah hah..."
       ]
     },
     {
       "ID": 37001900,
       "Entries": [
-        "…あんた、もう見たかい？"
+        "Did you see her?"
       ]
     },
     {
       "ID": 37001901,
       "Entries": [
-        "どうやら、高貴な聖女様ご一行のご到着らしい"
+        "That virtuous little maiden, complete with followers in tow."
       ]
     },
     {
       "ID": 37001902,
       "Entries": [
-        "どうせ墓荒らしに向かうんだろうが、お嬢様がどうとか、甘坊どもが、胸糞悪いったらないぜ"
+        "They're probably going straight to pillage graves. I've heard\nenough about \"M'Lady\" for a lifetime."
       ]
     },
     {
       "ID": 37001903,
       "Entries": [
-        "あんたもそう思うだろう？"
+        "What absolute rubbish, eh?"
       ]
     },
     {
       "ID": 37001904,
       "Entries": [
-        "ケッ…"
+        "Tsk!"
       ]
     },
     {
       "ID": 37001950,
       "Entries": [
-        "…あんた、もう見たかい？"
+        "Did you see her?"
       ]
     },
     {
       "ID": 37001951,
       "Entries": [
-        "どうやら、高貴な聖女様ご一行のご到着らしい"
+        "That virtuous little maiden, complete with followers in tow."
       ]
     },
     {
       "ID": 37001952,
       "Entries": [
-        "どうせ墓荒らしに向かうんだろうが、お嬢様がどうとか、甘坊どもが、胸糞悪いったらないぜ"
+        "They're probably going straight to pillage graves. I've heard\nenough about \"M'Lady\" for a lifetime."
       ]
     },
     {
       "ID": 37002000,
       "Entries": [
-        "…あんた、知ってるかい？"
+        "Did you hear about the maiden?"
       ]
     },
     {
       "ID": 37002001,
       "Entries": [
-        "いつだかの、高貴な聖女様が、一人で戻ってきたんだ…ボロボロでな"
+        "The virtuous lass came back alone, and in absolute tatters..."
       ]
     },
     {
       "ID": 37002002,
       "Entries": [
-        "お供は死んだが、捨てられたか…どちらにしろ、愉快な話さ"
+        "Did her followers die, or was she abandoned? Who knows."
       ]
     },
     {
       "ID": 37002003,
       "Entries": [
-        "貴族が、ざまあみろってんだ"
+        "But I suppose we've heard the last from \"M'lady\"."
       ]
     },
     {
       "ID": 37002004,
       "Entries": [
-        "ワハハハハハ"
+        "Hah hah hah hah!"
       ]
     },
     {
       "ID": 37002100,
       "Entries": [
-        "聖女様？"
+        "That maiden?"
       ]
     },
     {
       "ID": 37002101,
       "Entries": [
-        "どっかにいっちまったぜ。不死教会の方だったかな"
+        "She's shuffled off somewhere. I believe to the Undead Church."
       ]
     },
     {
       "ID": 37002102,
       "Entries": [
-        "まあ、高貴な方には、こんな遺跡お気に召さなかったんだろう？"
+        "These ruins were probably too awkward for her."
       ]
     },
     {
       "ID": 37002200,
       "Entries": [
-        "あんた、ふたつめの鐘も鳴らしたろう？"
+        "Did you ring the second bell?"
       ]
     },
     {
       "ID": 37002201,
       "Entries": [
-        "いや、それは凄いし、正直驚いたが…変な奴がでてきたんだ"
+        "That is incredible, I must say...But now we have a new problem."
       ]
     },
     {
       "ID": 37002202,
       "Entries": [
-        "声もイビキもでけえし、口はおそろしく臭えし…"
+        "It's noisy, it snores, and its breath is lethal..."
       ]
     },
     {
       "ID": 37002203,
       "Entries": [
-        "笑えねえよ…"
+        "This is no laughing matter, I tell you."
       ]
     },
     {
       "ID": 37002300,
       "Entries": [
-        "クソッ、ここまで臭いやがる…結構快適な場所だったのになあ"
+        "Damn, that stench...And I was really beginning to like it here!"
       ]
     },
     {
       "ID": 37002301,
       "Entries": [
-        "ハァ…"
+        "Sigh..."
       ]
     },
     {
       "ID": 37002302,
       "Entries": [
-        "俺も、少しだけ頑張ってみるかなあ…"
+        "Maybe it's time I do something about it..."
       ]
     },
     {
       "ID": 37002400,
       "Entries": [
-        "なんだ、あんたか"
+        "You again?"
       ]
     },
     {
       "ID": 37002401,
       "Entries": [
-        "話すことなんて特にねえが…"
+        "There's nothing to speak about, really."
       ]
     },
     {
       "ID": 37002402,
       "Entries": [
-        "そういえば、変なことがあったな"
+        "Oh, actually...Something strange did happen."
       ]
     },
     {
       "ID": 37002403,
       "Entries": [
-        "いや、あの烏がな、丸くなった人を掴んで、どこかに飛んでいったんだ"
+        "That crow flew off with somebody in its clutches. I think it was\na man curled up in a ball."
       ]
     },
     {
       "ID": 37002404,
       "Entries": [
-        "ありゃあ、なんだったんだろうなあ…"
+        "Stranger things have happened, right?"
       ]
     },
     {
       "ID": 37002405,
       "Entries": [
-        "わからねえ…"
+        "No, maybe not..."
       ]
     },
     {
       "ID": 37002500,
       "Entries": [
-        "ん？なんだ？"
+        "Hm? What now?"
       ]
     },
     {
       "ID": 37002501,
       "Entries": [
-        "話すことなんてないぜ。放っておいてくれよ"
+        "I'm not up for chatting. Leave me alone."
       ]
     },
     {
       "ID": 37002600,
       "Entries": [
-        "で、どうするんだ？"
+        "Well, what are you going to do?"
       ]
     },
     {
       "ID": 37002601,
       "Entries": [
-        "俺は、そうしてるぜ"
+        "I've already decided."
       ]
     },
     {
       "ID": 37002602,
       "Entries": [
-        "情けないが、心が折れちまったからな…"
+        "I don't really care; I'm simply crestfallen..."
       ]
     },
     {
       "ID": 37002700,
       "Entries": [
-        "ウッ！"
+        "Ooph!"
       ]
     },
     {
       "ID": 37002710,
       "Entries": [
-        "イテェ！"
+        "Oww!"
       ]
     },
     {
       "ID": 37002720,
       "Entries": [
-        "なにしやがる！"
+        "What in the...!"
       ]
     },
     {
       "ID": 37002730,
       "Entries": [
-        "やめろ！おい！"
+        "Stop that! Oi!"
       ]
     },
     {
       "ID": 37002800,
       "Entries": [
-        "畜生が、いい度胸だ！"
+        "Lousy rat! You have some nerve!"
       ]
     },
     {
       "ID": 37002801,
       "Entries": [
-        "心折れたって、舐めるなよ！若造が！"
+        "I may be crestfallen, but I'm not defenceless, you rascal!"
       ]
     },
     {
       "ID": 37002802,
       "Entries": [
-        "後悔させてやるぜ！"
+        "You will soon regret this!"
       ]
     },
     {
       "ID": 37002900,
       "Entries": [
-        "へへ、やるな…"
+        "Heheh, not too shabby..."
       ]
     },
     {
       "ID": 37002901,
       "Entries": [
-        "これで終われるかな…"
+        "I think you've done me a favour..."
       ]
     },
     {
       "ID": 37003000,
       "Entries": [
-        "馬鹿野郎が…"
+        "Now, that's just embarrassing."
       ]
     },
     {
       "ID": 37003001,
       "Entries": [
-        "俺にやられて、どうするよ…"
+        "How'd you let me do that to you?"
       ]
     },
     {
       "ID": 37003100,
       "Entries": [
-        "そういえば、あんた、なんで武器を鍛えねえんだ？"
+        "Don't you ever think to forge your weapons?"
       ]
     },
     {
       "ID": 37003101,
       "Entries": [
-        "鍛冶箱を持ってないのなら、まあ、早く探した方がいいぜ"
+        "You'd better find a smithbox soon,"
       ]
     },
     {
       "ID": 37003102,
       "Entries": [
-        "…もっとも、なまくらを使い続ける趣味なら、それもいいけどな！"
+        "Unless you enjoy swinging about with blunt instruments!"
       ]
     },
     {
       "ID": 37003103,
       "Entries": [
-        "ワハハハハハ"
+        "Hah hah hah hah!"
       ]
     },
     {
       "ID": 37003150,
       "Entries": [
-        "…あんた、なんで武器をなおさねえんだ？"
+        "Don't you ever repair your weapons?"
       ]
     },
     {
       "ID": 37003151,
       "Entries": [
-        "粉でも、道具でも、なんでもあるじゃないか"
+        "You just need the right tools, or some powder."
       ]
     },
     {
       "ID": 37003152,
       "Entries": [
-        "…壊れた武器を好んで使うのは、頭のおかしい英雄くらいだぜ？"
+        "If you keep swinging those scraps around, you'll be mistaken for\na Hollow!"
       ]
     },
     {
       "ID": 37003153,
       "Entries": [
-        "ワハハハハハ"
+        "Hah hah hah hah!"
       ]
     },
     {
       "ID": 38000000,
       "Entries": [
-        "うーむ…"
+        "Mmm..."
       ]
     },
     {
       "ID": 38000001,
       "Entries": [
-        "ウムムムム…"
+        "Hrmmmmm..."
       ]
     },
     {
       "ID": 38000100,
       "Entries": [
-        "うーむ…うーむ…"
+        "Mmm...mmm..."
       ]
     },
     {
       "ID": 38000101,
       "Entries": [
-        "！お、おお！"
+        "Mm! Oh-hoh!"
       ]
     },
     {
       "ID": 38000102,
       "Entries": [
-        "すまぬ。考え耽っていた"
+        "Forgive me. I was absorbed in thought."
       ]
     },
     {
       "ID": 38000103,
       "Entries": [
-        "私はカタリナのジークマイヤー"
+        "I am Siegmeyer of Catarina."
       ]
     },
     {
       "ID": 38000104,
       "Entries": [
-        "実は、少し難儀しているのだ"
+        "Quite honestly, I have run flat up against a wall."
       ]
     },
     {
       "ID": 38000105,
       "Entries": [
-        "そこの門が、どうしても開かなくてな"
+        "Or, a gate, I should say. The thing just won't budge."
       ]
     },
     {
       "ID": 38000106,
       "Entries": [
-        "もうずっと待ってるのだが…どうにもならん"
+        "No matter how long I wait. And, oh, have I waited!"
       ]
     },
     {
       "ID": 38000107,
       "Entries": [
-        "だから、ここへ座って、思案している"
+        "So, here I sit, in quite a pickle."
       ]
     },
     {
       "ID": 38000108,
       "Entries": [
-        "悩んでるんだよ！"
+        "Weighing my options, so to speak!"
       ]
     },
     {
       "ID": 38000109,
       "Entries": [
-        "ガハハハハ"
+        "Hah hah hah hah!"
       ]
     },
     {
       "ID": 38000200,
       "Entries": [
-        "開かぬ…"
+        "Still closed..."
       ]
     },
     {
       "ID": 38000201,
       "Entries": [
-        "開かぬなあ…"
+        "Still closed..."
       ]
     },
     {
       "ID": 38000202,
       "Entries": [
-        "うーむ…"
+        "Mmm..."
       ]
     },
     {
       "ID": 38000400,
       "Entries": [
-        "うわっ"
+        "Yeeg!"
       ]
     },
     {
       "ID": 38000420,
       "Entries": [
-        "うおっ"
+        "Whoa!"
       ]
     },
     {
       "ID": 38000440,
       "Entries": [
-        "なっ"
+        "Wha!"
       ]
     },
     {
       "ID": 38000460,
       "Entries": [
-        "どうしたっ"
+        "Why, are you...!"
       ]
     },
     {
       "ID": 38000500,
       "Entries": [
-        "ようし、わかった！"
+        "That's your game, is it?"
       ]
     },
     {
       "ID": 38000501,
       "Entries": [
-        "貴公がその気なら、手加減せぬわ！"
+        "Well, I'm certainly not backing down!"
       ]
     },
     {
       "ID": 38000502,
       "Entries": [
-        "騎士の力を見せてやろうぞ！"
+        "By the honour of my knighthood!"
       ]
     },
     {
       "ID": 38000600,
       "Entries": [
-        "私としたことが…"
+        "Heavens, me..."
       ]
     },
     {
       "ID": 38000601,
       "Entries": [
-        "リンよぅ…"
+        "My dear little Lin..."
       ]
     },
     {
       "ID": 38000700,
       "Entries": [
-        "うーむ…うーむ…"
+        "Mmm...mmm..."
       ]
     },
     {
       "ID": 38000701,
       "Entries": [
-        "！お、おお！"
+        "Mm! Oh-hoh!"
       ]
     },
     {
       "ID": 38000702,
       "Entries": [
-        "貴公は、いつぞやの…再び見えるとは、驚いたぞ"
+        "Ahh, where did you come from? Splendid news, I tell you."
       ]
     },
     {
       "ID": 38000703,
       "Entries": [
-        "ガハハハハ"
+        "Hah hah hah hah!"
       ]
     },
     {
       "ID": 38000750,
       "Entries": [
-        "うーむ…うーむ…"
+        "Mmm...mmm..."
       ]
     },
     {
       "ID": 38000751,
       "Entries": [
-        "！お、おお！"
+        "Mm! Oh-hoh!"
       ]
     },
     {
       "ID": 38000752,
       "Entries": [
-        "すまぬ。考え耽っていた"
+        "Forgive me. I was absorbed in thought."
       ]
     },
     {
       "ID": 38000753,
       "Entries": [
-        "私はカタリナのジークマイヤー"
+        "I am Siegmeyer of Catarina."
       ]
     },
     {
       "ID": 38000754,
       "Entries": [
-        "実は、少し難儀しているのだ"
+        "Quite honestly, I have run flat up against a wall."
       ]
     },
     {
       "ID": 38000755,
       "Entries": [
-        "…あの、鉄球ゴロゴロがな…"
+        "...Or, a ball, to be precise."
       ]
     },
     {
       "ID": 38000756,
       "Entries": [
-        "…ほら、私はなんとなく太っているだろう？ゴロゴロが速すぎるんだ…"
+        "...I'm afraid I'm a bit too plump to be outrunning those things."
       ]
     },
     {
       "ID": 38000757,
       "Entries": [
-        "だから、ここへ座って、思案している"
+        "So, here I sit, in quite a pickle."
       ]
     },
     {
       "ID": 38000758,
       "Entries": [
-        "悩んでるんだよ！"
+        "Weighing my options, so to speak!"
       ]
     },
     {
       "ID": 38000759,
       "Entries": [
-        "ガハハハハ"
+        "Hah hah hah hah!"
       ]
     },
     {
       "ID": 38000800,
       "Entries": [
-        "ん、むむ…分かっちまうか？"
+        "Mn, mmm...Ah, so you see my plight?"
       ]
     },
     {
       "ID": 38000801,
       "Entries": [
-        "実は、また少し難儀しているのだ"
+        "Yes, indeed, I have run up against a wall."
       ]
     },
     {
       "ID": 38000802,
       "Entries": [
-        "…あの、鉄球ゴロゴロがな…"
+        "...Or, a ball, to be precise."
       ]
     },
     {
       "ID": 38000803,
       "Entries": [
-        "…ほら、私はなんとなく太っているだろう？ゴロゴロが速すぎるんだ…"
+        "...I'm afraid I'm a bit too plump to be outrunning those things."
       ]
     },
     {
       "ID": 38000804,
       "Entries": [
-        "だから、ここへ座って、思案している"
+        "So, here I sit, in quite a pickle."
       ]
     },
     {
       "ID": 38000805,
       "Entries": [
-        "また、なんとかなるかもしれないだろう？"
+        "But who knows? Perhaps we'll have another development?"
       ]
     },
     {
       "ID": 38000806,
       "Entries": [
-        "ガハハハハ"
+        "Hah hah hah hah!"
       ]
     },
     {
       "ID": 38000900,
       "Entries": [
-        "転がればもしかして…"
+        "Perhaps I could try some rolling..."
       ]
     },
     {
       "ID": 38000901,
       "Entries": [
-        "…無理だなあ。目も回るし"
+        "...Bah, no chance. My head would spin."
       ]
     },
     {
       "ID": 38000902,
       "Entries": [
-        "うーむ…"
+        "Mmm..."
       ]
     },
     {
       "ID": 38010000,
       "Entries": [
-        "うーむ…"
+        "Mmm..."
       ]
     },
     {
       "ID": 38010001,
       "Entries": [
-        "ウムムムム…"
+        "Hrmmmmm..."
       ]
     },
     {
       "ID": 38010002,
       "Entries": [
-        "さてどうしたものか…"
+        "Whatever can be done?"
       ]
     },
     {
       "ID": 38010100,
       "Entries": [
-        "おお、貴公か！"
+        "Ah, you again!"
       ]
     },
     {
       "ID": 38010101,
       "Entries": [
-        "どうやら同じ境遇だな。銀の騎士たちから逃げてきたのだろう"
+        "Let me guess. Were you repelled by the Silver Knights?"
       ]
     },
     {
       "ID": 38010102,
       "Entries": [
-        "なあに、恥じることは無い。私も同じだ、無謀は阿呆の仕業だからな"
+        "Aww, don't be ashamed. 'Tis the fate of vanguards like you and I."
       ]
     },
     {
       "ID": 38010103,
       "Entries": [
-        "今いい案を考える。協力してなんとかしようじゃないか！"
+        "I'll think of something. We can overcome this, together!"
       ]
     },
     {
       "ID": 38010200,
       "Entries": [
-        "どうしたものか…"
+        "This is quite a fix..."
       ]
     },
     {
       "ID": 38010201,
       "Entries": [
-        "やはり、あと3人、いや5人くらいは必要か…"
+        "We'll need another three, no, maybe five bodies..."
       ]
     },
     {
       "ID": 38010202,
       "Entries": [
-        "うーむ…悩ましい…"
+        "Hmm...quite a fix indeed..."
       ]
     },
     {
       "ID": 38010300,
       "Entries": [
-        "うーむ…うーむ…"
+        "Mmm...mmm..."
       ]
     },
     {
       "ID": 38010301,
       "Entries": [
-        "！お、おお！"
+        "Mm! Oh-hoh!"
       ]
     },
     {
       "ID": 38010302,
       "Entries": [
-        "どうしたのだ？"
+        "What's on your mind, friend?"
       ]
     },
     {
       "ID": 38010303,
       "Entries": [
-        "まさか貴公…あやつらを倒したのか！"
+        "Wait!...You defeated those monsters?!"
       ]
     },
     {
       "ID": 38010304,
       "Entries": [
-        "なんと豪気な…だが、助かった。カタリナのジークマイヤー、貴公に礼を言おう"
+        "Fantastic...I am saved. This knight of Catarina hereby commends\nyou!"
       ]
     },
     {
       "ID": 38010305,
       "Entries": [
-        "これは感謝の気持ちだ。受け取ってくれ"
+        "Take this, as a token of my gratitude."
       ]
     },
     {
       "ID": 38010320,
       "Entries": [
-        "だがな、貴公が心配で言うが、あまり豪気なのも考えものだぞ…"
+        "But be warned, gallantry entails great risks."
       ]
     },
     {
       "ID": 38010321,
       "Entries": [
-        "無事だからよかったものの、私の策を待つこともできたのだからな"
+        "Next time, give me a chance to come up with a plan."
       ]
     },
     {
       "ID": 38010400,
       "Entries": [
-        "うわっ"
+        "Yeeg!"
       ]
     },
     {
       "ID": 38010410,
       "Entries": [
-        "うおっ"
+        "Whoa!"
       ]
     },
     {
       "ID": 38010420,
       "Entries": [
-        "なっ"
+        "Wha!"
       ]
     },
     {
       "ID": 38010430,
       "Entries": [
-        "どうしたっ"
+        "Why, are you...!"
       ]
     },
     {
       "ID": 38010500,
       "Entries": [
-        "ようし、わかった！"
+        "That's your game, is it?"
       ]
     },
     {
       "ID": 38010501,
       "Entries": [
-        "貴公がその気なら、手加減せぬわ！"
+        "Well, I'm certainly not backing down!"
       ]
     },
     {
       "ID": 38010502,
       "Entries": [
-        "騎士の力を見せてやろうぞ！"
+        "By the honour of my knighthood!"
       ]
     },
     {
       "ID": 38010600,
       "Entries": [
-        "私としたことが…"
+        "Heavens, me..."
       ]
     },
     {
       "ID": 38010601,
       "Entries": [
-        "リンよぅ…"
+        "My dear little Lin..."
       ]
     },
     {
       "ID": 38020000,
       "Entries": [
-        "うーむ…うーむ…"
+        "Mmm...mmm..."
       ]
     },
     {
       "ID": 38020001,
       "Entries": [
-        "！お、おお！"
+        "Mm! Oh-hoh!"
       ]
     },
     {
       "ID": 38020002,
       "Entries": [
-        "貴公か！久しぶりだな！"
+        "There you are! What a pleasure!"
       ]
     },
     {
       "ID": 38020003,
       "Entries": [
-        "私は、見ての通りだ。うっかり捕まっちまった"
+        "Well, look at me. Trapped like a mouse."
       ]
     },
     {
       "ID": 38020004,
       "Entries": [
-        "だがな、貴公が案じることはない"
+        "But, don't lose any sleep over me."
       ]
     },
     {
       "ID": 38020005,
       "Entries": [
-        "もうずっと、ここへ座って、思案している"
+        "I'm very focused, sitting here, so very still."
       ]
     },
     {
       "ID": 38020006,
       "Entries": [
-        "いつもなら、そろそろよい事がおこるはずさ！"
+        "Something good is bound to happen soon!"
       ]
     },
     {
       "ID": 38020007,
       "Entries": [
-        "ガハハハハ"
+        "Hah hah hah hah!"
       ]
     },
     {
       "ID": 38020100,
       "Entries": [
-        "外に出るには鍵が必要…"
+        "I require a key to exit."
       ]
     },
     {
       "ID": 38020101,
       "Entries": [
-        "鍵は外にある…"
+        "But the key is on the outside..."
       ]
     },
     {
       "ID": 38020102,
       "Entries": [
-        "うーむ…難問だ…"
+        "Hmm...I'm in quite a fix..."
       ]
     },
     {
       "ID": 38020300,
       "Entries": [
-        "おお！貴公！助かった！"
+        "Ahh! There you are! Bless you!"
       ]
     },
     {
       "ID": 38020301,
       "Entries": [
-        "また助けられるとは、かたじけないな"
+        "You seem to help me at every turn."
       ]
     },
     {
       "ID": 38020302,
       "Entries": [
-        "カタリナのジークマイヤー、改めて貴公に礼を言おう"
+        "This knight of Catarina expresses his deepest gratitude."
       ]
     },
     {
       "ID": 38020303,
       "Entries": [
-        "これは感謝の気持ちだ。受け取ってくれ"
+        "Please take this, as a token of my appreciation."
       ]
     },
     {
       "ID": 38020320,
       "Entries": [
-        "しかし、貴公が現れるとは"
+        "I didn't expect you to show up."
       ]
     },
     {
       "ID": 38020321,
       "Entries": [
-        "やはり思案してみるものだな"
+        "Although, maybe I did!"
       ]
     },
     {
       "ID": 38020322,
       "Entries": [
-        "ガハハハハ"
+        "Hah hah hah hah!"
       ]
     },
     {
       "ID": 38020400,
       "Entries": [
-        "おお、貴公か"
+        "Ahh, hello, there."
       ]
     },
     {
       "ID": 38020401,
       "Entries": [
-        "私は、ここで少し休んでいくよ"
+        "I'm going to take it slowly here, at least for now."
       ]
     },
     {
       "ID": 38020402,
       "Entries": [
-        "長居したせいか、意外と悪くない部屋なんだよ"
+        "After all this time, it's not so intolerable."
       ]
     },
     {
       "ID": 38020403,
       "Entries": [
-        "まあ、どこだって住めば都さ"
+        "I've actually become quite fond of it!"
       ]
     },
     {
       "ID": 38020404,
       "Entries": [
-        "ガハハハハ"
+        "Hah hah hah hah!"
       ]
     },
     {
       "ID": 38020500,
       "Entries": [
-        "うわっ"
+        "Yeeg!"
       ]
     },
     {
       "ID": 38020510,
       "Entries": [
-        "うおっ"
+        "Whoa!"
       ]
     },
     {
       "ID": 38020520,
       "Entries": [
-        "なっ"
+        "Wha!"
       ]
     },
     {
       "ID": 38020530,
       "Entries": [
-        "どうしたっ"
+        "Why, are you...!"
       ]
     },
     {
       "ID": 38020600,
       "Entries": [
-        "ようし、わかった！"
+        "That's your game, is it?"
       ]
     },
     {
       "ID": 38020601,
       "Entries": [
-        "貴公がその気なら、手加減せぬわ！"
+        "Well, I'm certainly not backing down!"
       ]
     },
     {
       "ID": 38020602,
       "Entries": [
-        "騎士の力を見せてやろうぞ！"
+        "By the honour of my knighthood!"
       ]
     },
     {
       "ID": 38020700,
       "Entries": [
-        "私としたことが…"
+        "Heavens, me..."
       ]
     },
     {
       "ID": 38020701,
       "Entries": [
-        "リンよぅ…"
+        "My dear little Lin..."
       ]
     },
     {
       "ID": 38030000,
       "Entries": [
-        "うーむ…"
+        "Mmm..."
       ]
     },
     {
       "ID": 38030001,
       "Entries": [
-        "ウムムムム…"
+        "Mmm..."
       ]
     },
     {
       "ID": 38030100,
       "Entries": [
-        "うーむ…うーむ…"
+        "Mmm...mmm..."
       ]
     },
     {
       "ID": 38030101,
       "Entries": [
-        "！お、おお！"
+        "Mm! Oh-hoh!"
       ]
     },
     {
       "ID": 38030102,
       "Entries": [
-        "すまぬ。考え耽っていた"
+        "Forgive me. I was absorbed in thought."
       ]
     },
     {
       "ID": 38030103,
       "Entries": [
-        "私はカタリナのジークマイヤー"
+        "I am Siegmeyer of Catarina."
       ]
     },
     {
       "ID": 38030104,
       "Entries": [
-        "実は、少し難儀しているのだ"
+        "Quite honestly, I have run up against a wall."
       ]
     },
     {
       "ID": 38030105,
       "Entries": [
-        "貴公も見たかもしれないが、目玉のトカゲが厄介でなあ"
+        "Perhaps you've noticed those bug-eyed lizards?"
       ]
     },
     {
       "ID": 38030106,
       "Entries": [
-        "私も手だれだが、あれは石化の息を吐く。どうにもならん"
+        "I've had a go at them, but their breath is petrifying."
       ]
     },
     {
       "ID": 38030107,
       "Entries": [
-        "だから、ここへ座って、思案している"
+        "And so here I am, just thinking things over!"
       ]
     },
     {
       "ID": 38030108,
       "Entries": [
-        "そのうち妙案がでるだろうさ"
+        "Any moment now, and I'll be hit by an epiphany!"
       ]
     },
     {
       "ID": 38030109,
       "Entries": [
-        "ガハハハハ"
+        "Hah hah hah hah!"
       ]
     },
     {
       "ID": 38030200,
       "Entries": [
-        "うーむ…うーむ…"
+        "Mmm...mmm..."
       ]
     },
     {
       "ID": 38030201,
       "Entries": [
-        "！お、おお！"
+        "Mm! Oh-hoh!"
       ]
     },
     {
       "ID": 38030202,
       "Entries": [
-        "貴公か。すまぬ。考え耽っていた"
+        "Forgive me. I was absorbed in thought."
       ]
     },
     {
       "ID": 38030203,
       "Entries": [
-        "貴公も見たかもしれないが、目玉のトカゲが厄介でなあ"
+        "Perhaps you've noticed those bug-eyed lizards?"
       ]
     },
     {
       "ID": 38030204,
       "Entries": [
-        "私も手だれだが、あれは石化の息を吐く。どうにもならん"
+        "I've had a go at them, but their breath is petrifying."
       ]
     },
     {
       "ID": 38030205,
       "Entries": [
-        "だから、ここへ座って、思案している"
+        "And so here I am, just thinking things over!"
       ]
     },
     {
       "ID": 38030206,
       "Entries": [
-        "そのうち妙案がでるだろうさ"
+        "Any moment now, and I'll be hit by an epiphany!"
       ]
     },
     {
       "ID": 38030207,
       "Entries": [
-        "ガハハハハ"
+        "Hah hah hah hah!"
       ]
     },
     {
       "ID": 38030300,
       "Entries": [
-        "貴公、妙案はないか？"
+        "What about you? Any ideas?"
       ]
     },
     {
       "ID": 38030301,
       "Entries": [
-        "ないだろうなあ…私ですらないのだからなあ…"
+        "Ahh, I thought not. This is a difficult one, even for me..."
       ]
     },
     {
       "ID": 38030302,
       "Entries": [
-        "うーむ…参ったぞ…"
+        "Hmm...quite a fix indeed..."
       ]
     },
     {
       "ID": 38030303,
       "Entries": [
-        "目潰し、とか…"
+        "Perhaps I should aim for their eyes..."
       ]
     },
     {
       "ID": 38030400,
       "Entries": [
-        "うーむ…うーむ…"
+        "Mmm...mmm..."
       ]
     },
     {
       "ID": 38030401,
       "Entries": [
-        "！お、おお！"
+        "Mm! Oh-hoh!"
       ]
     },
     {
       "ID": 38030402,
       "Entries": [
-        "どうしたのだ？"
+        "What's on your mind, friend?"
       ]
     },
     {
       "ID": 38030403,
       "Entries": [
-        "まさか貴公…トカゲどもを倒したのか！"
+        "Wait!...Did you defeat those lizards?"
       ]
     },
     {
       "ID": 38030404,
       "Entries": [
-        "やはり目玉が…いや、そんなことよりも"
+        "Ahh, you went for the eyes! I knew it..."
       ]
     },
     {
       "ID": 38030405,
       "Entries": [
-        "助かった。カタリナのジークマイヤー、貴公に礼を言おう"
+        "I am saved. This knight of Catarina thanks you sincerely."
       ]
     },
     {
       "ID": 38030406,
       "Entries": [
-        "これは感謝の気持ちだ。受け取ってくれ"
+        "Please take this, as a token of my gratitude."
       ]
     },
     {
       "ID": 38030420,
       "Entries": [
-        "だがな、貴公が心配で言うが、あまり無謀なのも考えものだぞ…"
+        "But be warned, gallantry entails great risks."
       ]
     },
     {
       "ID": 38030421,
       "Entries": [
-        "無事だからよかったものの、私の妙案を待てばよかったのだから"
+        "Next time, give me a chance to come up with a plan."
       ]
     },
     {
       "ID": 38030500,
       "Entries": [
-        "うわっ"
+        "Yeeg!"
       ]
     },
     {
       "ID": 38030510,
       "Entries": [
-        "うおっ"
+        "Whoa!"
       ]
     },
     {
       "ID": 38030520,
       "Entries": [
-        "なっ"
+        "Wha!"
       ]
     },
     {
       "ID": 38030530,
       "Entries": [
-        "どうしたっ"
+        "Why, are you...!"
       ]
     },
     {
       "ID": 38030600,
       "Entries": [
-        "ようし、わかった！"
+        "That's your game, is it?"
       ]
     },
     {
       "ID": 38030601,
       "Entries": [
-        "貴公がその気なら、手加減せぬわ！"
+        "Well, I'm certainly not backing down!"
       ]
     },
     {
       "ID": 38030602,
       "Entries": [
-        "騎士の力を見せてやろうぞ！"
+        "By the honour of my knighthood!"
       ]
     },
     {
       "ID": 38030700,
       "Entries": [
-        "私としたことが…"
+        "Heavens, me..."
       ]
     },
     {
       "ID": 38030701,
       "Entries": [
-        "リンよぅ…"
+        "My dear little Lin..."
       ]
     },
     {
       "ID": 38040000,
       "Entries": [
-        "グゥ…グゥ…"
+        "Sng...sng..."
       ]
     },
     {
       "ID": 38040001,
       "Entries": [
-        "フゴーッ"
+        "Zzzzzz..."
       ]
     },
     {
       "ID": 38040100,
       "Entries": [
-        "！お、おお！"
+        "Mm! Oh-hoh!"
       ]
     },
     {
       "ID": 38040101,
       "Entries": [
-        "貴公か。すまぬ。私としたことが、考え耽っていたら、うとうとしてしまった"
+        "Excuse me. I was so absorbed in thought, I just drifted away."
       ]
     },
     {
       "ID": 38040102,
       "Entries": [
-        "というのも、実は、少し往生していてな"
+        "You see, I'm actually in a bit of a fix."
       ]
     },
     {
       "ID": 38040103,
       "Entries": [
-        "順調にここまできたのはいいのだが…帰り道に必要な、毒消しの苔が無くなってしまった…"
+        "I've made it this far, but I'm short on antitode moss for the\ntrip back."
       ]
     },
     {
       "ID": 38040104,
       "Entries": [
-        "…"
+        "..."
       ]
     },
     {
       "ID": 38040105,
       "Entries": [
-        "騎士ジークマイヤー、恥を忍んで言うのだが…"
+        "By my knighthood, I am ashamed to ask..."
       ]
     },
     {
       "ID": 38040106,
       "Entries": [
-        "貴公、苔を持っていたら、幾つか譲ってくれんか？"
+        "But can you spare a few scraps of moss?"
       ]
     },
     {
       "ID": 38040120,
       "Entries": [
-        "そうか！"
+        "Fantastic!"
       ]
     },
     {
       "ID": 38040121,
       "Entries": [
-        "そうか、そうか！すまんのう"
+        "Thank you, a saint you are."
       ]
     },
     {
       "ID": 38040122,
       "Entries": [
-        "カタリナのジークマイヤー、貴公に感謝するぞ。この恩は生涯忘れん"
+        "This knight of Catarina expresses his deepest gratitude. I shall\nnot forget this."
       ]
     },
     {
       "ID": 38040123,
       "Entries": [
-        "これはその気持ちだ。受け取ってくれ"
+        "Please, take this; a symbol of my appreciation."
       ]
     },
     {
       "ID": 38040130,
       "Entries": [
-        "しかし、貴公とは不思議な縁があるのう"
+        "Well, our fates do seem entwined, don't they?"
       ]
     },
     {
       "ID": 38040131,
       "Entries": [
-        "大王グウィンの思し召しかもしれんな"
+        "Perhaps this, too, is the will of Lord Gwyn!"
       ]
     },
     {
       "ID": 38040132,
       "Entries": [
-        "ガハハハハ"
+        "Hah hah hah hah!"
       ]
     },
     {
       "ID": 38040140,
       "Entries": [
-        "そうか…"
+        "Yes, I see..."
       ]
     },
     {
       "ID": 38040141,
       "Entries": [
-        "いや、分かっておる"
+        "No need to worry!"
       ]
     },
     {
       "ID": 38040142,
       "Entries": [
-        "大丈夫だ。苔など無くとも、どうにかしてみせるさ"
+        "I'll be fine. I can make it without that silly moss."
       ]
     },
     {
       "ID": 38040143,
       "Entries": [
-        "私が思索して、うまくいかなかったことなど、一度もないのだからな"
+        "Think about it. Have I ever let a little hardship slow me down?"
       ]
     },
     {
       "ID": 38040144,
       "Entries": [
-        "ガハハハハ"
+        "Hah hah hah hah!"
       ]
     },
     {
       "ID": 38040200,
       "Entries": [
-        "毒沼か…"
+        "The Poison Swamp..."
       ]
     },
     {
       "ID": 38040201,
       "Entries": [
-        "沈むからなあ…"
+        "It's like quicksand in there..."
       ]
     },
     {
       "ID": 38040202,
       "Entries": [
-        "うーむ…"
+        "Mmm..."
       ]
     },
     {
       "ID": 38040300,
       "Entries": [
-        "うーむ…うーむ…"
+        "Mmm..."
       ]
     },
     {
       "ID": 38040301,
       "Entries": [
-        "！お、おお！"
+        "Mm! Oh-hoh!"
       ]
     },
     {
       "ID": 38040302,
       "Entries": [
-        "貴公か。どうしたのだ？"
+        "What's on your mind, friend?"
       ]
     },
     {
       "ID": 38040303,
       "Entries": [
-        "まさか…苔か？"
+        "You've brought moss, perchance?"
       ]
     },
     {
       "ID": 38040400,
       "Entries": [
-        "うわっ"
+        "Yeeg!"
       ]
     },
     {
       "ID": 38040410,
       "Entries": [
-        "うおっ"
+        "Whoa!"
       ]
     },
     {
       "ID": 38040420,
       "Entries": [
-        "なっ"
+        "Wha!"
       ]
     },
     {
       "ID": 38040430,
       "Entries": [
-        "どうしたっ"
+        "Why, are you...!"
       ]
     },
     {
       "ID": 38040500,
       "Entries": [
-        "ようし、わかった！"
+        "That's your game, is it?"
       ]
     },
     {
       "ID": 38040501,
       "Entries": [
-        "貴公がその気なら、手加減せぬわ！"
+        "Well, I'm certainly not backing down!"
       ]
     },
     {
       "ID": 38040502,
       "Entries": [
-        "騎士の力を見せてやろうぞ！"
+        "By the honour of my knighthood!"
       ]
     },
     {
       "ID": 38040600,
       "Entries": [
-        "私としたことが…"
+        "Heavens, me..."
       ]
     },
     {
       "ID": 38040601,
       "Entries": [
-        "リンよぅ…"
+        "My dear little Lin..."
       ]
     },
     {
       "ID": 38060000,
       "Entries": [
-        "グゥ…グゥ…"
+        "Sng...sng..."
       ]
     },
     {
       "ID": 38060001,
       "Entries": [
-        "フゴーッ"
+        "Zzzzzz..."
       ]
     },
     {
       "ID": 38060100,
       "Entries": [
-        "！お、おお！"
+        "Mm! Oh-hoh!"
       ]
     },
     {
       "ID": 38060101,
       "Entries": [
-        "貴公か。すまぬ。私としたことが、考え耽っていたら、うとうとしてしまった"
+        "Excuse me. I was so absorbed in thought, I just drifted away."
       ]
     },
     {
       "ID": 38060102,
       "Entries": [
-        "どうも温かいところはいかんな…それで、どうしたのだ？"
+        "It must be the warmth. Well, what's on your mind?"
       ]
     },
     {
       "ID": 38060103,
       "Entries": [
-        "いや、言わずとも分かるぞ。あの化け物どもに難儀しているのだろう？"
+        "No, don't tell me. Those monsters making life difficult for you?"
       ]
     },
     {
       "ID": 38060104,
       "Entries": [
-        "なに、恥じることは無い。私も同じだ"
+        "You need not be ashamed. We are in the same boat."
       ]
     },
     {
       "ID": 38060105,
       "Entries": [
-        "…だが、貴公には色々と世話になったこともある"
+        "...You know, I really have run up quite a debt to you."
       ]
     },
     {
       "ID": 38060106,
       "Entries": [
-        "…時がきたのかもしれんな"
+        "...Perhaps the time has come..."
       ]
     },
     {
       "ID": 38060107,
       "Entries": [
-        "…"
+        "..."
       ]
     },
     {
       "ID": 38060200,
       "Entries": [
-        "…"
+        "..."
       ]
     },
     {
       "ID": 38060201,
       "Entries": [
-        "貴公、提案がある。聞いてくれるか"
+        "Friend, I have an idea. A good one, really."
       ]
     },
     {
       "ID": 38060202,
       "Entries": [
-        "…私が化け物どもに突撃する。貴公は、隙を見て逃げてくれ"
+        "...I will rush those dire fiends, and you can slip away in the\nconfusion."
       ]
     },
     {
       "ID": 38060203,
       "Entries": [
-        "なあに、貴公には、色々と世話になったからな"
+        "Please, friend, I owe you much more than this."
       ]
     },
     {
       "ID": 38060204,
       "Entries": [
-        "お礼に、カタリナの騎士の力をみせつけねば、武門の名折れと言うものだ"
+        "By the honour of the knights of Catarina, allow me to assist you."
       ]
     },
     {
       "ID": 38060205,
       "Entries": [
-        "…いくぞ。遅れるなよ！"
+        "And now, I go! Don't be slow!"
       ]
     },
     {
       "ID": 38060220,
       "Entries": [
-        "ウワァァァァァァァ！"
+        "Hrgrraaaaggh!"
       ]
     },
     {
       "ID": 38060221,
       "Entries": [
-        "どうりゃぁぁぁぁっ！"
+        "Hiyaaaaaah!"
       ]
     },
     {
       "ID": 38060222,
       "Entries": [
-        "どうした！こっちだぞ、化け物どもが！"
+        "C'mon! Over here, you fiends!"
       ]
     },
     {
       "ID": 38060223,
       "Entries": [
-        "死にくされ！"
+        "Perish, foul creatures!"
       ]
     },
     {
       "ID": 38060224,
       "Entries": [
-        "カタリナを、ジークマイヤーを舐めるなよ！"
+        "I am Siegmeyer of Catarina, and you shall feel my wrath!"
       ]
     },
     {
       "ID": 38060300,
       "Entries": [
-        "…"
+        "..."
       ]
     },
     {
       "ID": 38060301,
       "Entries": [
-        "おお、貴公か…"
+        "Oh, there you are."
       ]
     },
     {
       "ID": 38060302,
       "Entries": [
-        "！まさか…あの化け物どもを倒したのか！"
+        "Wait!...Did you defeat those dire creatures?"
       ]
     },
     {
       "ID": 38060303,
       "Entries": [
-        "そうか、さすが貴公だ…さすがだ…"
+        "Outstanding...You never fail to impress."
       ]
     },
     {
       "ID": 38060304,
       "Entries": [
-        "いや、ありがとう。カタリナのジークマイヤー、貴公に礼を言おう"
+        "Well, wonderful. This knight of Catarina thanks you."
       ]
     },
     {
       "ID": 38060305,
       "Entries": [
-        "これは感謝の気持ちだ。受け取ってくれ"
+        "Take this, as a token of my gratitude."
       ]
     },
     {
       "ID": 38060320,
       "Entries": [
-        "貴公にはずっと礼ばかりだな"
+        "I feel like I'm always thanking you..."
       ]
     },
     {
       "ID": 38060321,
       "Entries": [
-        "私は、何もできん…"
+        "I curse my own inability."
       ]
     },
     {
       "ID": 38060400,
       "Entries": [
-        "ハァ…ハァ…"
+        "Hng...hng..."
       ]
     },
     {
       "ID": 38060401,
       "Entries": [
-        "なんだ、貴公、逃げて、いなかったのか…"
+        "Why, you! Didn't you get away?"
       ]
     },
     {
       "ID": 38060402,
       "Entries": [
-        "いや、むしろ助け、られたか…"
+        "Well, you've saved me, once again..."
       ]
     },
     {
       "ID": 38060403,
       "Entries": [
-        "すまんのう、貴公には、世話ばかり、最後まで…"
+        "Dear me, what can I say? I have failed you..."
       ]
     },
     {
       "ID": 38060404,
       "Entries": [
-        "グフッ…ゲハッ…"
+        "Hrgph...Aggkt..."
       ]
     },
     {
       "ID": 38060405,
       "Entries": [
-        "ああ、リンよぅ…"
+        "My dear little Lin..."
       ]
     },
     {
       "ID": 38060500,
       "Entries": [
-        "ハァ…ハァ…"
+        "Hng...hng..."
       ]
     },
     {
       "ID": 38060501,
       "Entries": [
-        "なんだ、貴公、逃げて、いなかったのか…"
+        "But, you! Didn't you get away?"
       ]
     },
     {
       "ID": 38060502,
       "Entries": [
-        "いや、むしろ助け、られたか…"
+        "Well, you've saved me, once again..."
       ]
     },
     {
       "ID": 38060503,
       "Entries": [
-        "だが、よかった…疲れた…"
+        "Thank goodness...I'm exhausted..."
       ]
     },
     {
       "ID": 38060504,
       "Entries": [
-        "私は、少し眠るよ"
+        "I think I'll have a rest."
       ]
     },
     {
       "ID": 38060505,
       "Entries": [
-        "なあに、どこでも寝るのが、私の特技さ…"
+        "Don't you worry, the ground below me is my pillow."
       ]
     },
     {
       "ID": 38060506,
       "Entries": [
-        "すぐに回復する…"
+        "I'll recover shortly..."
       ]
     },
     {
       "ID": 38060600,
       "Entries": [
-        "うわっ"
+        "Yeeg!"
       ]
     },
     {
       "ID": 38060610,
       "Entries": [
-        "うおっ"
+        "Whoa!"
       ]
     },
     {
       "ID": 38060620,
       "Entries": [
-        "なっ"
+        "Wha!"
       ]
     },
     {
       "ID": 38060630,
       "Entries": [
-        "どうしたっ"
+        "Why, are you...!"
       ]
     },
     {
       "ID": 38060700,
       "Entries": [
-        "ようし、わかった！"
+        "That's your game, is it?"
       ]
     },
     {
       "ID": 38060701,
       "Entries": [
-        "貴公がその気なら、手加減せぬわ！"
+        "Well, I'm certainly not backing down!"
       ]
     },
     {
       "ID": 38060702,
       "Entries": [
-        "騎士の力を見せてやろうぞ！"
+        "By the honour of my knighthood!"
       ]
     },
     {
       "ID": 38060800,
       "Entries": [
-        "私としたことが…"
+        "Heavens, me..."
       ]
     },
     {
       "ID": 38060801,
       "Entries": [
-        "リンよぅ…"
+        "My dear little Lin..."
       ]
     },
     {
       "ID": 38070000,
       "Entries": [
-        "おお、貴公。望外だ、こんなところで会えるとは"
+        "Well! Fancy meeting you here."
       ]
     },
     {
       "ID": 38070001,
       "Entries": [
-        "上では色々と世話になったからな。感謝しているよ"
+        "You did much for me up above. I am grateful."
       ]
     },
     {
       "ID": 38070002,
       "Entries": [
-        "あと、それとだ…"
+        "You know, I was thinking..."
       ]
     },
     {
       "ID": 38070003,
       "Entries": [
-        "よく思索してみたんだが、古城の門は…"
+        "The gates at the old fortress..."
       ]
     },
     {
       "ID": 38070004,
       "Entries": [
-        "ありゃあ、貴公の仕業じゃないのか？"
+        "Was that your doing?"
       ]
     },
     {
       "ID": 38070020,
       "Entries": [
-        "そうか、やはりそうだったか！"
+        "Yes! I knew it!"
       ]
     },
     {
       "ID": 38070021,
       "Entries": [
-        "私も、できすぎた偶然だとは思っていたんだ"
+        "It seemed like an unlikely coincidence."
       ]
     },
     {
       "ID": 38070022,
       "Entries": [
-        "いや、ありがとう。カタリナのジークマイヤー、改めて貴公に礼を言おう"
+        "Well, am I fortunate! This knight of Catarina thanks you\nsincerely."
       ]
     },
     {
       "ID": 38070023,
       "Entries": [
-        "これは感謝の気持ちだ。受け取ってくれ"
+        "Please take this, as a token of my gratitude."
       ]
     },
     {
       "ID": 38070040,
       "Entries": [
-        "そうなのか？"
+        "Is that so?"
       ]
     },
     {
       "ID": 38070041,
       "Entries": [
-        "では…まあいい。不思議なこともあるものだな…"
+        "Hmm, no matter. Stranger things have happened."
       ]
     },
     {
       "ID": 38070042,
       "Entries": [
-        "やはり果報は待つものか…"
+        "Sometimes one only has to give it some time."
       ]
     },
     {
       "ID": 38070100,
       "Entries": [
-        "おお、貴公か"
+        "There you are."
       ]
     },
     {
       "ID": 38070101,
       "Entries": [
-        "私は、もうすぐ下に向かうつもりだ"
+        "I'll be heading down below shortly."
       ]
     },
     {
       "ID": 38070102,
       "Entries": [
-        "上には、目指すものは、何も無かったからな"
+        "There's nothing worthwhile up above."
       ]
     },
     {
       "ID": 38070103,
       "Entries": [
-        "なあに、探索は英雄の嗜みさ。覚悟はできている"
+        "No worries! Adventuring is my life; I'm prepared for the worst."
       ]
     },
     {
       "ID": 38070104,
       "Entries": [
-        "ガハハハハ"
+        "Hah hah hah hah!"
       ]
     },
     {
       "ID": 38070200,
       "Entries": [
-        "おお、貴公！無事だったか"
+        "Hello, friend. Still holding up?"
       ]
     },
     {
       "ID": 38070201,
       "Entries": [
-        "あの時の礼がまだだったからな。待っていたんだ"
+        "I owe you much. I was hoping that you would come."
       ]
     },
     {
       "ID": 38070202,
       "Entries": [
-        "ありがとう。結局、貴公に助けられた。カタリナのジークマイヤー、改めて貴公に礼を言おう"
+        "So that I could say thank you, for saving me. From one brave\nknight to another."
       ]
     },
     {
       "ID": 38070203,
       "Entries": [
-        "これは感謝の気持ちだ。頼むから受け取ってくれ"
+        "Please, take this, as a token of my gratitude."
       ]
     },
     {
       "ID": 38070210,
       "Entries": [
-        "ああ、よかった。これで心残りはない"
+        "This is a relief. Now I have no regrets."
       ]
     },
     {
       "ID": 38070211,
       "Entries": [
-        "最後の探索に出かけるとしよう…"
+        "I shall depart for my final adventure..."
       ]
     },
     {
       "ID": 38070300,
       "Entries": [
-        "おお、貴公か"
+        "Oh, hello, friend."
       ]
     },
     {
       "ID": 38070301,
       "Entries": [
-        "私は、もうすぐ最後の探索に向かう"
+        "I am preparing for my final adventure."
       ]
     },
     {
       "ID": 38070302,
       "Entries": [
-        "貴公も…無事でな"
+        "Wherever you go, may you be safe."
       ]
     },
     {
       "ID": 38070303,
       "Entries": [
-        "貴公を、本当の英雄だと思っているよ"
+        "You are a true hero, to be sure."
       ]
     },
     {
       "ID": 38070400,
       "Entries": [
-        "おお、貴公か"
+        "Oh, hello, friend."
       ]
     },
     {
       "ID": 38070401,
       "Entries": [
-        "…実は、少し前に、娘に会ってな…"
+        "...My daughter risked life and limb, just to find me..."
       ]
     },
     {
       "ID": 38070402,
       "Entries": [
-        "妻の遺言を、伝えてくれてな…不死でもないのに、なんてことを…"
+        "...to deliver her mother's last words...And the poor girl's not\neven Undead!"
       ]
     },
     {
       "ID": 38070403,
       "Entries": [
-        "ハァ…"
+        "Sigh..."
       ]
     },
     {
       "ID": 38070404,
       "Entries": [
-        "育て方を間違ったのか…"
+        "Heavens, I never asked her to do that..."
       ]
     },
     {
       "ID": 38070500,
       "Entries": [
-        "うわっ"
+        "Yeeg!"
       ]
     },
     {
       "ID": 38070510,
       "Entries": [
-        "うおっ"
+        "Whoa!"
       ]
     },
     {
       "ID": 38070520,
       "Entries": [
-        "なっ"
+        "Wha!"
       ]
     },
     {
       "ID": 38070530,
       "Entries": [
-        "どうしたっ"
+        "Why, are you...!"
       ]
     },
     {
       "ID": 38070600,
       "Entries": [
-        "ようし、わかった！"
+        "That's your game, is it?"
       ]
     },
     {
       "ID": 38070601,
       "Entries": [
-        "貴公がその気なら、手加減せぬわ！"
+        "Well, I'm certainly not backing down!"
       ]
     },
     {
       "ID": 38070602,
       "Entries": [
-        "騎士の力を見せてやろうぞ！"
+        "By the honour of my knighthood!"
       ]
     },
     {
       "ID": 38070700,
       "Entries": [
-        "私としたことが…"
+        "Heavens, me..."
       ]
     },
     {
       "ID": 38070701,
       "Entries": [
-        "リンよぅ…"
+        "My dear little Lin..."
       ]
     },
     {
       "ID": 39000000,
       "Entries": [
-        "…あなたが、助けてくれたのですか？ありがとうございます"
+        "It was you who rescued me? Why, thank you."
       ]
     },
     {
       "ID": 39000001,
       "Entries": [
-        "私は、カタリナのジークリンデ"
+        "I am Sieglinde of Catarina."
       ]
     },
     {
       "ID": 39000002,
       "Entries": [
-        "なんだか分からないうちに、結晶に囚われて…"
+        "I don't know how I ended up in that crystal..."
       ]
     },
     {
       "ID": 39000003,
       "Entries": [
-        "意外と快適だけれど、動けないし、困っていたのです"
+        "It wasn't terrible in there, but I could hardly move."
       ]
     },
     {
       "ID": 39000004,
       "Entries": [
-        "あなたには、お礼をしなければいけませんね"
+        "I must think of some way to repay you."
       ]
     },
     {
       "ID": 39000100,
       "Entries": [
-        "そうだ！もしかして、父をご存知じゃありませんか？"
+        "Oh! Have you seen my father?"
       ]
     },
     {
       "ID": 39000101,
       "Entries": [
-        "私と同じ甲冑なので、目立つと思うんですが…"
+        "You wouldn't miss him. A suit of armour, just like mine?"
       ]
     },
     {
       "ID": 39000120,
       "Entries": [
-        "そうですか！よかった、やはり父も、この国に来ているのですね"
+        "Thank goodness! I knew he was here somewhere."
       ]
     },
     {
       "ID": 39000121,
       "Entries": [
-        "よし！じゃあ、私は父を探します。重ね重ね、ありがとうございました"
+        "Well then, now I must find him. Thanks again, truly."
       ]
     },
     {
       "ID": 39000122,
       "Entries": [
-        "…でも、父はどこか抜けているので、じっとしていてくれるとよいのですけど…"
+        "Now if he'll just stay put, and keep out of trouble."
       ]
     },
     {
       "ID": 39000140,
       "Entries": [
-        "そうですか…。では、もし父を見かけたら、伝えてください"
+        "Yes, I see...But if you should happen to bump into him,"
       ]
     },
     {
       "ID": 39000141,
       "Entries": [
-        "ジークリンデが探していたと。あなたはどこか抜けているので、じっとしていて下さいと"
+        "tell him that Sieglinde is on her way, and that he ought to just\nstay put."
       ]
     },
     {
       "ID": 39000142,
       "Entries": [
-        "すみませんが、よろしくお願いします"
+        "And again, thank you kindly."
       ]
     },
     {
       "ID": 39000230,
       "Entries": [
-        "何を！"
+        "What in the...!"
       ]
     },
     {
       "ID": 39000240,
       "Entries": [
-        "どうしたんですか！"
+        "What the devil?!"
       ]
     },
     {
       "ID": 39000300,
       "Entries": [
-        "分かりました"
+        "Yes, now I see."
       ]
     },
     {
       "ID": 39000301,
       "Entries": [
-        "あたなは、危険な人です"
+        "You are one of the bad ones."
       ]
     },
     {
       "ID": 39000302,
       "Entries": [
-        "だったら、容赦しませんよ"
+        "Then, there's only one thing to do with you."
       ]
     },
     {
       "ID": 39000400,
       "Entries": [
-        "ああ、そんな…"
+        "Oh, how can this be...!"
       ]
     },
     {
       "ID": 39000401,
       "Entries": [
-        "父さん…"
+        "...dear Father..."
       ]
     },
     {
       "ID": 39000500,
       "Entries": [
-        "心配しないで。私が殺してあげるわ、何度だって…"
+        "Rest assured. I will kill you as many times as it takes."
       ]
     },
     {
       "ID": 39020000,
       "Entries": [
-        "お久しぶりです"
+        "Oh, hello again."
       ]
     },
     {
       "ID": 39020001,
       "Entries": [
-        "お互い、まだ無事で何よりですね"
+        "We're both managing quite well, aren't we?"
       ]
     },
     {
       "ID": 39020002,
       "Entries": [
-        "実は、まだ父を見つけられないのですが、何かご存知じゃありませんか？"
+        "But I haven't found my father yet. Have you seen him?"
       ]
     },
     {
       "ID": 39020020,
       "Entries": [
-        "そうですか！では、そちらに行ってみます"
+        "Really! Then I must be off."
       ]
     },
     {
       "ID": 39020021,
       "Entries": [
-        "それにしても、あなたにもご迷惑をかけて…困った人です。じっとしていてくれるとよいのですけど…"
+        "I'm sorry he's caused you trouble...He has a knack for that. If\nhe'd just stay put..."
       ]
     },
     {
       "ID": 39020040,
       "Entries": [
-        "そうですか…。わかりました"
+        "Yes, I see. Well, I had to ask."
       ]
     },
     {
       "ID": 39020041,
       "Entries": [
-        "もう少し探してみます。ありがとうございました"
+        "I will continue searching a bit longer. Thank you so much."
       ]
     },
     {
       "ID": 39020100,
       "Entries": [
-        "お久しぶりです。またお会いできましたね"
+        "Well, hello again!"
       ]
     },
     {
       "ID": 39020101,
       "Entries": [
-        "やっと、父を見つけました"
+        "I have finally located my father."
       ]
     },
     {
       "ID": 39020102,
       "Entries": [
-        "あなたにも、何度もお世話になったそうで…ありがとうございます"
+        "All of your help was invaluable to us...Thank you so much."
       ]
     },
     {
       "ID": 39020103,
       "Entries": [
-        "おかげさまで、母の言葉を伝えられました…"
+        "I was finally able to pass on my mother's last words."
       ]
     },
     {
       "ID": 39020200,
       "Entries": [
-        "父ですか？最後の探索に向かう、と言ってました"
+        "My father? He went on his final adventure."
       ]
     },
     {
       "ID": 39020201,
       "Entries": [
-        "いいんです。それが父ですし、不死になっても父らしくて…嬉しいくらいです"
+        "Don't worry, that's just the way he is. Undead or no. Sort of\nreassuring, really."
       ]
     },
     {
       "ID": 39020202,
       "Entries": [
-        "もし父が、心を亡くしたら、何度でも、私が殺せばいいんですから…"
+        "If he goes Hollow, I'll just have to kill him again."
       ]
     },
     {
       "ID": 39020330,
       "Entries": [
-        "何を！"
+        "What in the...!"
       ]
     },
     {
       "ID": 39020340,
       "Entries": [
-        "どうしたんですか！"
+        "What the devil?!"
       ]
     },
     {
       "ID": 39020400,
       "Entries": [
-        "分かりました"
+        "Yes, now I see."
       ]
     },
     {
       "ID": 39020401,
       "Entries": [
-        "あたなは、危険な人です"
+        "You are one of the bad ones."
       ]
     },
     {
       "ID": 39020402,
       "Entries": [
-        "だったら、容赦しませんよ"
+        "Then, there's only one thing to do with you."
       ]
     },
     {
       "ID": 39020500,
       "Entries": [
-        "ああ、そんな…"
+        "Oh, how can this be...!"
       ]
     },
     {
       "ID": 39020501,
       "Entries": [
-        "父さん…"
+        "...dear Father..."
       ]
     },
     {
       "ID": 39020600,
       "Entries": [
-        "心配しないで。私が殺してあげるわ、何度だって…"
+        "Rest assured. I will kill you as many times as it takes."
       ]
     },
     {
       "ID": 39030000,
       "Entries": [
-        "父は…この亡者は…もう動きません。誰にも迷惑をかけない"
+        "My father...all Hollow now...has been subdued. He will cause no\nmore trouble."
       ]
     },
     {
       "ID": 39030001,
       "Entries": [
-        "これで、やっと終わり…私は、カタリナに帰ります"
+        "It's finally over...I will return to Catarina."
       ]
     },
     {
       "ID": 39030002,
       "Entries": [
-        "あなたには、色々とお世話になりました。私はもう、十分なお助けができませんが"
+        "You assisted us both greatly. I can hardly return the favour,"
       ]
     },
     {
       "ID": 39030003,
       "Entries": [
-        "受け取ってください。私たちには、もう不要なものです"
+        "but please accept this. It's of no use to me now."
       ]
     },
     {
       "ID": 39030100,
       "Entries": [
-        "ああ、お父様…お父様…"
+        "Oh, father...dear father..."
       ]
     },
     {
       "ID": 39030101,
       "Entries": [
-        "（嗚咽）"
+        "Sob..."
       ]
     },
     {
       "ID": 39030230,
       "Entries": [
-        "何を！"
+        "What in the...!"
       ]
     },
     {
       "ID": 39030240,
       "Entries": [
-        "どうしたんですか！"
+        "What the devil?!"
       ]
     },
     {
       "ID": 39030300,
       "Entries": [
-        "分かりました"
+        "Yes, now I see."
       ]
     },
     {
       "ID": 39030301,
       "Entries": [
-        "あたなは、危険な人です"
+        "You are one of the bad ones."
       ]
     },
     {
       "ID": 39030302,
       "Entries": [
-        "だったら、容赦しませんよ"
+        "Then, there's only one thing to do with you."
       ]
     },
     {
       "ID": 39030400,
       "Entries": [
-        "ああ、そんな…"
+        "Oh, how can this be...!"
       ]
     },
     {
       "ID": 39030401,
       "Entries": [
-        "父さん…"
+        "...dear Father..."
       ]
     },
     {
       "ID": 39030500,
       "Entries": [
-        "心配しないで。私が殺してあげるわ、何度だって…"
+        "Rest assured. I will kill you as many times as it takes."
       ]
     },
     {
       "ID": 40000000,
       "Entries": [
-        "ん？貴公、まだ人だな？"
+        "Oh? Still human, are you?"
       ]
     },
     {
       "ID": 40000001,
       "Entries": [
-        "では話は早い。助けてくれないか？"
+        "Then I am in luck. Could you help me?"
       ]
     },
     {
       "ID": 40000002,
       "Entries": [
-        "見ての通り閉じ込められて、どうしようもないんだ"
+        "As you can see I am stuck, without recourse."
       ]
     },
     {
       "ID": 40000020,
       "Entries": [
-        "頼む。このままでは、騎士として使命も果たせない"
+        "I entreat you. Have pity on this powerless knight."
       ]
     },
     {
       "ID": 40000021,
       "Entries": [
-        "それがどれ程の無念か…貴公にも分かるだろう？"
+        "Surely you can imagine the depth of such dejection?"
       ]
     },
     {
       "ID": 40000040,
       "Entries": [
-        "頼む。私も騎士の端くれ、それなりの謝礼も用意するつもりだ"
+        "Please, I have duties to fulfil, and I will reward you\nhandsomely."
       ]
     },
     {
       "ID": 40000041,
       "Entries": [
-        "どうだ？貴公にとっても悪い話ではないだろう？"
+        "Well? I am certain you stand to benefit."
       ]
     },
     {
       "ID": 40000060,
       "Entries": [
-        "おい！貴公！"
+        "Why! You!"
       ]
     },
     {
       "ID": 40000061,
       "Entries": [
-        "どこへ行くんだ！私の話を聞け！"
+        "Do not run away! Hear me out!"
       ]
     },
     {
       "ID": 40000080,
       "Entries": [
-        "おお、貴公、戻ってきてくれたか"
+        "Ahh, you have come back."
       ]
     },
     {
       "ID": 40000081,
       "Entries": [
-        "頼む。私を助けてくれ"
+        "I beg of you. Help me."
       ]
     },
     {
       "ID": 40000100,
       "Entries": [
-        "ありがとう、助かった"
+        "Thank you, yes, sincerely."
       ]
     },
     {
       "ID": 40000101,
       "Entries": [
-        "私はカリムの騎士ロートレク"
+        "I am Knight Lautrec of Carim."
       ]
     },
     {
       "ID": 40000102,
       "Entries": [
-        "貴公には感謝している。礼は後ほどさせてもらうよ"
+        "I truly appreciate this, and I guarantee a reward, only later."
       ]
     },
     {
       "ID": 40000200,
       "Entries": [
-        "貴公、すまんな、礼は後ほどだ"
+        "Yes, very sorry, your reward will have to wait."
       ]
     },
     {
       "ID": 40000201,
       "Entries": [
-        "解放されたばかりなんだ、少し時間をくれてもいいだろう"
+        "I have just been freed. Allow me some time."
       ]
     },
     {
       "ID": 40000220,
       "Entries": [
-        "これで自由だ。使命を果たすこともできる…"
+        "I am free. Now I can get back to work..."
       ]
     },
     {
       "ID": 40000221,
       "Entries": [
-        "クックックックッ…"
+        "Keh heh heh heh..."
       ]
     },
     {
       "ID": 40000340,
       "Entries": [
-        "ほう、なんのつもりだ？"
+        "Well, what have we here?"
       ]
     },
     {
       "ID": 40000360,
       "Entries": [
-        "貴公、わかっているのか？"
+        "Keh keh keh. Are you sure about this?"
       ]
     },
     {
       "ID": 40000400,
       "Entries": [
-        "なるほど、仕方ない"
+        "You leave me no choice."
       ]
     },
     {
       "ID": 40000401,
       "Entries": [
-        "感謝していたのだがな…"
+        "I was once grateful to you,"
       ]
     },
     {
       "ID": 40000402,
       "Entries": [
-        "急ぐこともあるまいに！"
+        "But if this is our fate, so be it!"
       ]
     },
     {
       "ID": 40000410,
       "Entries": [
-        "なるほど、仕方ない"
+        "You leave me no choice."
       ]
     },
     {
       "ID": 40000411,
       "Entries": [
-        "急ぐこともあるまいに！"
+        "But if this is our fate, so be it!"
       ]
     },
     {
       "ID": 40000500,
       "Entries": [
-        "き、貴公…"
+        "You despicable..."
       ]
     },
     {
       "ID": 40000501,
       "Entries": [
-        "ばかな、この私が…"
+        "...Curses...How could I..."
       ]
     },
     {
       "ID": 40010000,
       "Entries": [
-        "ああ、貴公か"
+        "Ahh, hello there."
       ]
     },
     {
       "ID": 40010001,
       "Entries": [
-        "あの時の礼なら用意した、受け取ってくれ"
+        "I have your reward. Please accept it."
       ]
     },
     {
       "ID": 40010010,
       "Entries": [
-        "貴公には感謝しているぞ。私を解放してくれてな…"
+        "I am grateful to you. For freeing me..."
       ]
     },
     {
       "ID": 40010011,
       "Entries": [
-        "クックックックッ…"
+        "Keh heh heh heh..."
       ]
     },
     {
       "ID": 40010012,
       "Entries": [
-        "…不満か？だが、人の好意は素直に受けるものだぞ"
+        "...Not enough for you? Well, let's not be greedy, now..."
       ]
     },
     {
       "ID": 40010013,
       "Entries": [
-        "クックックックッ…"
+        "Keh heh heh heh..."
       ]
     },
     {
       "ID": 40010020,
       "Entries": [
-        "ん、貴公…その顔は…"
+        "By the Lords...Your face..."
       ]
     },
     {
       "ID": 40010021,
       "Entries": [
-        "フン、もはや人間性も限界と見えるな"
+        "Hmmm... Your humanity is really slipping."
       ]
     },
     {
       "ID": 40010022,
       "Entries": [
-        "だが、分からんね。人間性など、そのあたりの愚図が無駄に持っているじゃあないか"
+        "But there are methods. Most fools have more humanity than they\nknow what to do with."
       ]
     },
     {
       "ID": 40010023,
       "Entries": [
-        "貴公と愚図ども、その価値など、比べるべくもないと思うがねえ…"
+        "Now, who do you imagine will make the best use of it, hmm?"
       ]
     },
     {
       "ID": 40010080,
       "Entries": [
-        "ああ、貴公か。久しぶりだな"
+        "Well, where have you been?"
       ]
     },
     {
       "ID": 40010081,
       "Entries": [
-        "お互い無事でなによりだな。うれしいよ"
+        "I am glad to see you are safe."
       ]
     },
     {
       "ID": 40010100,
       "Entries": [
-        "ん、貴公、何か用か？"
+        "Hm, you again? What is it?"
       ]
     },
     {
       "ID": 40010101,
       "Entries": [
-        "お互い明日も知れぬ身だ。すぎた馴れ合いはなしにしておこうぜ"
+        "Our futures are murky. Let's not be too friendly, now."
       ]
     },
     {
       "ID": 40010120,
       "Entries": [
-        "ああ、貴公か"
+        "Oh, hello."
       ]
     },
     {
       "ID": 40010121,
       "Entries": [
-        "私はそろそろ、別の場所に向かおうと思う"
+        "I'm considering a change of location..."
       ]
     },
     {
       "ID": 40010122,
       "Entries": [
-        "詳しくは貴公にも言えないが、上にちょっと目的があってな…"
+        "I have a rather, pressing matter to attend to up above."
       ]
     },
     {
       "ID": 40010123,
       "Entries": [
-        "あの火防女にも世話になったが…もう不要か…"
+        "That Keeper has served me well, but...enough with her..."
       ]
     },
     {
       "ID": 40010124,
       "Entries": [
-        "クックックックッ…"
+        "Keh heh heh heh..."
       ]
     },
     {
       "ID": 40010140,
       "Entries": [
-        "…貴公…"
+        "...You..."
       ]
     },
     {
       "ID": 40010141,
       "Entries": [
-        "今更何をぬけぬけと"
+        "How dare you come prancing about!"
       ]
     },
     {
       "ID": 40010142,
       "Entries": [
-        "話すことなどない。消えろ"
+        "I have nothing to say. Be gone from my sight."
       ]
     },
     {
       "ID": 40010160,
       "Entries": [
-        "貴公…はじめてだな"
+        "Hello...I don't think we've met."
       ]
     },
     {
       "ID": 40010161,
       "Entries": [
-        "私はカリムの騎士ロートレク"
+        "I am Knight Lautrec of Carim."
       ]
     },
     {
       "ID": 40010162,
       "Entries": [
-        "お互い不死の身だ。まあ、よろしく頼むぜ"
+        "We are both Undead. Perhaps we can help one another."
       ]
     },
     {
       "ID": 40010163,
       "Entries": [
-        "クックックックッ…"
+        "Keh heh heh heh..."
       ]
     },
     {
       "ID": 40010180,
       "Entries": [
-        "ん、貴公、何か用か？"
+        "Hmm, what business do you have?"
       ]
     },
     {
       "ID": 40010181,
       "Entries": [
-        "用が無ければ、賢者は黙っているものだぜ…"
+        "If you have none, then stay silent."
       ]
     },
     {
       "ID": 40010200,
       "Entries": [
-        "ああ、貴公か。久しぶりだな"
+        "Ahh, you certainly are keeping busy."
       ]
     },
     {
       "ID": 40010201,
       "Entries": [
-        "そう言えば、1ついい情報があるんだが、買わないか？"
+        "Care to pay for a useful tip?"
       ]
     },
     {
       "ID": 40010220,
       "Entries": [
-        "さすがだな。賢明な判断だ"
+        "A wise choice, indeed."
       ]
     },
     {
       "ID": 40010221,
       "Entries": [
-        "少し前に、ソルロンドの聖女様ご一行が、この地にやってきたんだが"
+        "Maiden Thorolund and her followers recently arrived in this land,"
       ]
     },
     {
       "ID": 40010222,
       "Entries": [
-        "その聖女様が、地下墓地の更に先で取り残されているそうだ"
+        "but she became stranded deep below the Catacombs."
       ]
     },
     {
       "ID": 40010223,
       "Entries": [
-        "お付は全員、逃げたか、死んで亡者になったか…まあ、どちらにしろ、今は1人らしい"
+        "Her followers either fled, or were reduced to Hollows...Leaving\nMaiden Thorolund all alone."
       ]
     },
     {
       "ID": 40010224,
       "Entries": [
-        "なあ、いい情報だろう？若い聖職者は、人間性をたっぷりと持っているからな…"
+        "Not a bad tip, huh? A nubile cleric would be replete with\nhumanity..."
       ]
     },
     {
       "ID": 40010240,
       "Entries": [
-        "ほう、そうか"
+        "Oh, really?"
       ]
     },
     {
       "ID": 40010241,
       "Entries": [
-        "まあ、無理にとは言わんよ。無理にとはな…"
+        "Well, suit yourself. Only trying to help."
       ]
     },
     {
       "ID": 40010260,
       "Entries": [
-        "ん？さっきの情報か？"
+        "Hm? That tip I gave you?"
       ]
     },
     {
       "ID": 40010261,
       "Entries": [
-        "逃げ出しだジジイから聞いたのさ"
+        "Ahh, I heard it from a fleeing old man."
       ]
     },
     {
       "ID": 40010262,
       "Entries": [
-        "あの野郎、上等な風をしやがって、とんだ下種野郎だったぜ！"
+        "That poor bastard! All his robes and trinkets won't help him now!"
       ]
     },
     {
       "ID": 40010263,
       "Entries": [
-        "クーハッハッハッハッ！"
+        "Kwah hah hah hah hah!"
       ]
     },
     {
       "ID": 40010340,
       "Entries": [
-        "ほう、なんのつもりだ？"
+        "Well, what have we here?"
       ]
     },
     {
       "ID": 40010360,
       "Entries": [
-        "貴公、わかっているのか？"
+        "Keh keh keh. Are you sure about this?"
       ]
     },
     {
       "ID": 40010400,
       "Entries": [
-        "なるほど、仕方ない"
+        "You leave me no choice."
       ]
     },
     {
       "ID": 40010401,
       "Entries": [
-        "感謝していたのだがな…"
+        "I was once grateful to you,"
       ]
     },
     {
       "ID": 40010402,
       "Entries": [
-        "急ぐこともあるまいに！"
+        "But if this is our fate, so be it!"
       ]
     },
     {
       "ID": 40010410,
       "Entries": [
-        "なるほど、仕方ない"
+        "You leave me no choice."
       ]
     },
     {
       "ID": 40010411,
       "Entries": [
-        "急ぐこともあるまいに！"
+        "But if this is our fate, so be it!"
       ]
     },
     {
       "ID": 40010500,
       "Entries": [
-        "き、貴公…"
+        "You despicable..."
       ]
     },
     {
       "ID": 40010501,
       "Entries": [
-        "ばかな、この私が…"
+        "...Curses...How could I..."
       ]
     },
     {
@@ -16480,97 +16480,97 @@
     {
       "ID": 40020000,
       "Entries": [
-        "き、貴公…まさかこんなところまで…"
+        "Why, you...How far will you come?!"
       ]
     },
     {
       "ID": 40020001,
       "Entries": [
-        "…頼む、見逃してくれ…"
+        "...Please, leave me alone..."
       ]
     },
     {
       "ID": 40020002,
       "Entries": [
-        "私が貴公に、何をしたというのだ…"
+        "What have I done to you?"
       ]
     },
     {
       "ID": 40020003,
       "Entries": [
-        "…なあ、頼む…"
+        "...Please, I beg of you..."
       ]
     },
     {
       "ID": 40020100,
       "Entries": [
-        "チィッ"
+        "Tsk!"
       ]
     },
     {
       "ID": 40020101,
       "Entries": [
-        "逃がしてはくれんというわけか…"
+        "You won't let me be?"
       ]
     },
     {
       "ID": 40020102,
       "Entries": [
-        "ならば仕方ない！返り討ちにするまでだ！"
+        "Then I have no choice! You will regret this!"
       ]
     },
     {
       "ID": 40020103,
       "Entries": [
-        "抱かれのロートレクを舐めるなよ！"
+        "How dare you insult Lautrec the Embraced!"
       ]
     },
     {
       "ID": 40020104,
       "Entries": [
-        "女神の加護を！"
+        "May the Goddess have Mercy upon you."
       ]
     },
     {
       "ID": 40020200,
       "Entries": [
-        "ほう、貴公か…"
+        "Well, look at you."
       ]
     },
     {
       "ID": 40020201,
       "Entries": [
-        "多少は賢いかと思ったが、そうでもなかったようだな"
+        "I thought you were wiser, but I thought wrong!"
       ]
     },
     {
       "ID": 40020202,
       "Entries": [
-        "哀れだよ。炎に向かう蛾のようのだ"
+        "Tis a terrible pity. Like a moth flittering towards a flame."
       ]
     },
     {
       "ID": 40020203,
       "Entries": [
-        "そう思うだろ？なぁ？あんた達"
+        "You fellows? No? Don't you agree?"
       ]
     },
     {
       "ID": 40020300,
       "Entries": [
-        "ほう、またやってきたぞ…"
+        "So, here we go again!"
       ]
     },
     {
       "ID": 40020301,
       "Entries": [
-        "英雄気取りの大馬鹿が、随分と多いと見える"
+        "How many times will these lambs rush to slaughter?"
       ]
     },
     {
       "ID": 40020302,
       "Entries": [
-        "さあ、ぶっ殺しちまおうぜ、あんた達"
+        "Well, let's get it over with."
       ]
     },
     {
@@ -16594,6739 +16594,6739 @@
     {
       "ID": 41000000,
       "Entries": [
-        "話は、聞かせてもらったぜ"
+        "I've heard all about you."
       ]
     },
     {
       "ID": 41000001,
       "Entries": [
-        "俺は、東のシバ。実戦部隊のリーダーだ"
+        "I'm Shiva of the East, captain of the brigade."
       ]
     },
     {
       "ID": 41000002,
       "Entries": [
-        "召喚されたときじゃあ、ろくに話もできんのでな"
+        "Let's teach you the clan basics now,"
       ]
     },
     {
       "ID": 41000003,
       "Entries": [
-        "まずは挨拶と…団のやり方を、伝えておこう"
+        "as there is no time to chat in the midst of fighting."
       ]
     },
     {
       "ID": 41000004,
       "Entries": [
-        "とは言え、大層な掟なんてものはない"
+        "Except there's little in the form of rules, you hear?"
       ]
     },
     {
       "ID": 41000005,
       "Entries": [
-        "各々好きなように戦い、狩る。獲物も早い者勝ち。それが、俺たちの流儀だ"
+        "Fight and hunt as you like. Whoever's fastest gets the prey.\nThat's the way we do it."
       ]
     },
     {
       "ID": 41000006,
       "Entries": [
-        "ただ…白猫も言っただろうが、いかなる理由があれ、裏切りは、許されない"
+        "Only...Don't forget what Alvina said. Traitors aren't given a\nsecond chance, for any reason."
       ]
     },
     {
       "ID": 41000007,
       "Entries": [
-        "…それだけだ"
+        "That's about it, then."
       ]
     },
     {
       "ID": 41000008,
       "Entries": [
-        "まあ、気楽にやればいい"
+        "Don't worry, it's a good old time, isn't it?"
       ]
     },
     {
       "ID": 41000009,
       "Entries": [
-        "久しぶりの仲間だ…よろしく頼むぜ"
+        "Great to have you with us. Good hunting to you."
       ]
     },
     {
       "ID": 41000100,
       "Entries": [
-        "ああ、奴にも気づいたのか。さすがだな"
+        "Ah, did you notice that one? Sharp eyes!"
       ]
     },
     {
       "ID": 41000101,
       "Entries": [
-        "あいつも、団の仲間だ。俺と同じく、東からきた"
+        "He's one of the clan. From the East, like myself."
       ]
     },
     {
       "ID": 41000102,
       "Entries": [
-        "影のようだが、腕は立つ"
+        "Always slinking in the shadows, but he's a tough one."
       ]
     },
     {
       "ID": 41000103,
       "Entries": [
-        "…楽しみにしてな"
+        "You'll see what I mean."
       ]
     },
     {
       "ID": 41000104,
       "Entries": [
-        "ククククククッ"
+        "Hah hah hah hah!"
       ]
     },
     {
       "ID": 41000200,
       "Entries": [
-        "焦るなよ"
+        "Don't worry, now."
       ]
     },
     {
       "ID": 41000201,
       "Entries": [
-        "必要とあれば、お呼びがかかる"
+        "You'll be called in soon enough."
       ]
     },
     {
       "ID": 41000202,
       "Entries": [
-        "せっかちは貰いが少ないぜ"
+        "Hunters with patience score the best kills."
       ]
     },
     {
       "ID": 41000300,
       "Entries": [
-        "グッ"
+        "Hrg!"
       ]
     },
     {
       "ID": 41000310,
       "Entries": [
-        "ムッ"
+        "Mnph!"
       ]
     },
     {
       "ID": 41000320,
       "Entries": [
-        "何を！"
+        "Why, you dirty...!"
       ]
     },
     {
       "ID": 41000330,
       "Entries": [
-        "血迷ったか！"
+        "Have you lost it?"
       ]
     },
     {
       "ID": 41000400,
       "Entries": [
-        "早速裏切りとは、見上げたことだ！"
+        "Turning on us from the very start?"
       ]
     },
     {
       "ID": 41000401,
       "Entries": [
-        "冥土の土産だ！シバの豪剣を拝むがいい！"
+        "Have a look at my sword, for it's the last thing you'll see!"
       ]
     },
     {
       "ID": 41000500,
       "Entries": [
-        "おうらぁっ！"
+        "Hiyaah!"
       ]
     },
     {
       "ID": 41000501,
       "Entries": [
-        "どうりゃあっ！"
+        "Haaah!"
       ]
     },
     {
       "ID": 41000502,
       "Entries": [
-        "うおうりゃあっ！"
+        "Hiiyah!"
       ]
     },
     {
       "ID": 41000600,
       "Entries": [
-        "愚かな…"
+        "You poor fool..."
       ]
     },
     {
       "ID": 41000601,
       "Entries": [
-        "これで、お前も、追われる身だぞ…"
+        "You won't be able to run far enough..."
       ]
     },
     {
       "ID": 41000700,
       "Entries": [
-        "亡者が…"
+        "You sick Hollow..."
       ]
     },
     {
       "ID": 41000701,
       "Entries": [
-        "二度とよみがえるなよ…"
+        "Don't you ever come round again."
       ]
     },
     {
       "ID": 41010000,
       "Entries": [
-        "よう、あんたか"
+        "Hello again."
       ]
     },
     {
       "ID": 41010001,
       "Entries": [
-        "団の者と森以外で会うのは、妙なものだな…"
+        "Strange to meet away from the clan and the forest."
       ]
     },
     {
       "ID": 41010002,
       "Entries": [
-        "だが、丁度いい。あんた、武具を買わないか？"
+        "But while you're here, how about some equipment?"
       ]
     },
     {
       "ID": 41010003,
       "Entries": [
-        "俺は、武具好きなんだが…さすがに少し持て余し気味でな"
+        "I love collecting these things, but I can only keep so many."
       ]
     },
     {
       "ID": 41010004,
       "Entries": [
-        "あんたなら仲間だ。格安で譲ってもいいぜ"
+        "And, you know, you are a friend. I'll sell them cheap."
       ]
     },
     {
       "ID": 41010100,
       "Entries": [
-        "よう、またあんたか"
+        "We meet again."
       ]
     },
     {
       "ID": 41010101,
       "Entries": [
-        "武具が入用なら、相談にのるぜ"
+        "I have the equipment, if you have the need."
       ]
     },
     {
       "ID": 41010200,
       "Entries": [
-        "よう、あんた。また会ったな"
+        "Well, there you are again."
       ]
     },
     {
       "ID": 41010201,
       "Entries": [
-        "少し前に召喚されてな。掘り出し物があるんだ"
+        "I've culled my best picks from my last summoning."
       ]
     },
     {
       "ID": 41010202,
       "Entries": [
-        "よければ、見ていかないか"
+        "Have a look, will you?"
       ]
     },
     {
       "ID": 41010300,
       "Entries": [
-        "あんた…結構な好き者なんだな"
+        "I see you have a sharp eye for trinkets."
       ]
     },
     {
       "ID": 41010301,
       "Entries": [
-        "嬉しいよ。また会おうぜ"
+        "Suits me fine. I'll be seeing you."
       ]
     },
     {
       "ID": 41010400,
       "Entries": [
-        "じゃあな。また森で会おうぜ"
+        "Right then. I'll see you in the forest."
       ]
     },
     {
       "ID": 41010500,
       "Entries": [
-        "じゃあな。また会おうぜ"
+        "Right then. I'll be seeing you."
       ]
     },
     {
       "ID": 41010600,
       "Entries": [
-        "あんた、混沌の刃の話を、聞いたことはないか？"
+        "Have you heard of Chaos Blade?"
       ]
     },
     {
       "ID": 41010601,
       "Entries": [
-        "古い不死の匠、誠の手になる、斑竜紋の名剣さ"
+        "The legendary sword of the ancient Undead master Makoto, its\nblade a swirling vortex."
       ]
     },
     {
       "ID": 41010602,
       "Entries": [
-        "この地にあると聞き、ずっと探しているのだが…見つからなくてな…"
+        "I heard it's somewhere around here, but I can't find it."
       ]
     },
     {
       "ID": 41010603,
       "Entries": [
-        "…まったく、あれが手に入るなら…"
+        "...It's all I could ever wish for..."
       ]
     },
     {
       "ID": 41010604,
       "Entries": [
-        "…手段など選ばぬものを…"
+        "...I'd do anything to have it..."
       ]
     },
     {
       "ID": 41010700,
       "Entries": [
-        "おお、あんた！"
+        "Why, look at you!"
       ]
     },
     {
       "ID": 41010701,
       "Entries": [
-        "ちょっと待ってくれ！"
+        "Just wait will you!"
       ]
     },
     {
       "ID": 41010702,
       "Entries": [
-        "その刀は！それは…混沌の刃じゃあないか…"
+        "Your sword! Is it not... the Chaos Blade...?"
       ]
     },
     {
       "ID": 41010703,
       "Entries": [
-        "俺は、もうずっと、その刀を探していたんだ"
+        "I've been searching for her for ages!"
       ]
     },
     {
       "ID": 41010704,
       "Entries": [
-        "…お願いだ。十分な礼はさせてもらう。俺に…その刀を譲ってくれないか？"
+        "...I beg of you, and I promise repay you...Will you give the\nsword to me?"
       ]
     },
     {
       "ID": 41010800,
       "Entries": [
-        "おお、そうか！感謝するぞ！"
+        "Excellent! Much gratitude!"
       ]
     },
     {
       "ID": 41010801,
       "Entries": [
-        "これは約束の礼だ。とっておいてくれ"
+        "As promised, this is for you. Go ahead, take it."
       ]
     },
     {
       "ID": 41010810,
       "Entries": [
-        "ああ、これが、混沌の刃か…素晴らしい竜紋だ…素晴らしい"
+        "Ahh, splendid, the Chaos Blade...Look into the\nvortex...Wonderful..."
       ]
     },
     {
       "ID": 41010811,
       "Entries": [
-        "素晴らしすぎる…"
+        "Simply wonderful..."
       ]
     },
     {
       "ID": 41010812,
       "Entries": [
-        "ああ…ああ…"
+        "Oh my, oh my..."
       ]
     },
     {
       "ID": 41010813,
       "Entries": [
-        "これは…こいつの価値は…"
+        "But the sword's true value...hmm..."
       ]
     },
     {
       "ID": 41010814,
       "Entries": [
-        "人を斬らねば、分からないのかも、しれないなあ…"
+        "Can't be known without a good killing..."
       ]
     },
     {
       "ID": 41010900,
       "Entries": [
-        "…そうか。それでは…仕方ないな"
+        "...Yes, quite alright, I cannot blame you."
       ]
     },
     {
       "ID": 41010901,
       "Entries": [
-        "その刀、今は、あんたのものだからな…"
+        "The blade is yours, after all."
       ]
     },
     {
       "ID": 41010902,
       "Entries": [
-        "…武士らしく、潔く…"
+        "...So, I will do the honourable thing..."
       ]
     },
     {
       "ID": 41010903,
       "Entries": [
-        "…殺して奪うとしよう"
+        "...And kill you for it..."
       ]
     },
     {
       "ID": 41011000,
       "Entries": [
-        "避けるな！おとなしくしろッ！"
+        "Don't you run away! Be still you rat!"
       ]
     },
     {
       "ID": 41011001,
       "Entries": [
-        "切られろ！切られろおっ！"
+        "Taste my blade, taste it, you devil!"
       ]
     },
     {
       "ID": 41011002,
       "Entries": [
-        "ウヒーッ！"
+        "Hee hee!"
       ]
     },
     {
       "ID": 41011003,
       "Entries": [
-        "ウヒヒーーッ！"
+        "Hee, hee hee hee!"
       ]
     },
     {
       "ID": 41011100,
       "Entries": [
-        "俺を舐めた報いだ…"
+        "This is what you get for crossing me."
       ]
     },
     {
       "ID": 41011101,
       "Entries": [
-        "冥土の土産に、シバの豪剣を拝むがいい…"
+        "Have a look at my sword, for it's the last thing you'll see!"
       ]
     },
     {
       "ID": 41011200,
       "Entries": [
-        "赤い…血の色だ…"
+        "Red...the colour of blood..."
       ]
     },
     {
       "ID": 41011201,
       "Entries": [
-        "ウ…ヒッ…、ヒッ…"
+        "Hee hee...hee..."
       ]
     },
     {
       "ID": 41011300,
       "Entries": [
-        "ば、ばかな…"
+        "By the devils..."
       ]
     },
     {
       "ID": 41011301,
       "Entries": [
-        "だが、これでお前も、追われる身だぞ…"
+        "You won't be able to run far enough..."
       ]
     },
     {
       "ID": 41011400,
       "Entries": [
-        "素晴らしい刀だ…蕩けるようだ…"
+        "What a wonderful specimen...Like slicing through butter..."
       ]
     },
     {
       "ID": 41011401,
       "Entries": [
-        "ウヒ、ウヒヒ、ウヒーッヒッヒッヒッヒッ！"
+        "Hee, hee, nee hee hee!"
       ]
     },
     {
       "ID": 41011500,
       "Entries": [
-        "欲をかくから、そういうことになる…"
+        "Your ambitions have sealed your fate."
       ]
     },
     {
       "ID": 41011501,
       "Entries": [
-        "だが、俺が裏切り者とはな…"
+        "But, who'd have thought I'd be the traitor?"
       ]
     },
     {
       "ID": 41011502,
       "Entries": [
-        "まあ、それも面白いか…"
+        "Sometimes you never know, do you..."
       ]
     },
     {
       "ID": 41011503,
       "Entries": [
-        "ククククククッ"
+        "Keh heh heh heh!"
       ]
     },
     {
       "ID": 41011600,
       "Entries": [
-        "グッ"
+        "Hrg!"
       ]
     },
     {
       "ID": 41011610,
       "Entries": [
-        "ムッ"
+        "Mnph!"
       ]
     },
     {
       "ID": 41011620,
       "Entries": [
-        "何を！"
+        "Why, you dirty...!"
       ]
     },
     {
       "ID": 41011630,
       "Entries": [
-        "血迷ったか！"
+        "Have you lost it?"
       ]
     },
     {
       "ID": 41011700,
       "Entries": [
-        "裏切りとは、見上げたことだ！"
+        "You have some guts, to turn on us!"
       ]
     },
     {
       "ID": 41011701,
       "Entries": [
-        "冥土の土産だ！シバの豪剣を拝むがいい！"
+        "Have a look at my sword, for it's the last thing you'll see!"
       ]
     },
     {
       "ID": 41011800,
       "Entries": [
-        "おうらぁっ！"
+        "Hiyaah!"
       ]
     },
     {
       "ID": 41011801,
       "Entries": [
-        "どうりゃあっ！"
+        "Haaah!"
       ]
     },
     {
       "ID": 41011802,
       "Entries": [
-        "うおうりゃあっ！"
+        "Hiiyah!"
       ]
     },
     {
       "ID": 41011900,
       "Entries": [
-        "愚かな…"
+        "You poor fool..."
       ]
     },
     {
       "ID": 41011901,
       "Entries": [
-        "これで、お前も、追われる身だぞ…"
+        "You won't be able to run far enough..."
       ]
     },
     {
       "ID": 41012000,
       "Entries": [
-        "亡者が…"
+        "You sick Hollow..."
       ]
     },
     {
       "ID": 41012001,
       "Entries": [
-        "二度とよみがえるなよ…"
+        "Don't you ever come round again."
       ]
     },
     {
       "ID": 42000000,
       "Entries": [
-        "よう、あんた。どうやらまともみたいだな"
+        "Good day! You look reasonably sane!"
       ]
     },
     {
       "ID": 42000001,
       "Entries": [
-        "こんな地下墓地に用があるなんて、聖職者か何かか？"
+        "What are you doing in the Catacombs? Are you a cleric or\nsomething?"
       ]
     },
     {
       "ID": 42000020,
       "Entries": [
-        "やっぱりそうか"
+        "Yes, I imagined as much."
       ]
     },
     {
       "ID": 42000021,
       "Entries": [
-        "あんたたちの使命とやらは分からんが、せいぜい頑張ってくれや"
+        "Best of luck with your pilgrimages or missions or whatever you\ndo."
       ]
     },
     {
       "ID": 42000022,
       "Entries": [
-        "こんな場所だ。足元には気をつけてな…"
+        "This place is treacherous. Do watch your step, eh?"
       ]
     },
     {
       "ID": 42000023,
       "Entries": [
-        "ヘヘヘヘッ…"
+        "Heh heh heh..."
       ]
     },
     {
       "ID": 42000040,
       "Entries": [
-        "なんだ、ちがうのか"
+        "No? Well, that's strange."
       ]
     },
     {
       "ID": 42000041,
       "Entries": [
-        "だとしたら、物好きなことだな。わざわざこんな辛気臭い場所に"
+        "Ohhh, I know what it is. You've come for the trinkets, haven't\nyou?"
       ]
     },
     {
       "ID": 42000042,
       "Entries": [
-        "まあ、どうでもいいか"
+        "Well, whatever it is..."
       ]
     },
     {
       "ID": 42000043,
       "Entries": [
-        "こんな場所だ。足元には気をつけてな…"
+        "This place is treacherous. Do watch your step."
       ]
     },
     {
       "ID": 42000044,
       "Entries": [
-        "ヘヘヘヘッ…"
+        "Heh heh heh..."
       ]
     },
     {
       "ID": 42000100,
       "Entries": [
-        "なんだ？まだ何か用でもあるのか？"
+        "Yeah? What is it now?"
       ]
     },
     {
       "ID": 42000101,
       "Entries": [
-        "あいにく、俺はないぜ。こんな場所だ、無駄話はなしにしようや"
+        "Enough with the chit-chat. In a place like this, we need to stay\non our toes."
       ]
     },
     {
       "ID": 42000200,
       "Entries": [
-        "お、おう、あんた、どうしたんだ？"
+        "Ah, oh! Well, well, how are you, then?"
       ]
     },
     {
       "ID": 42000201,
       "Entries": [
-        "俺は、まあなんだ、迷っちまってよ"
+        "I, uh, sort of lost my way, yes..."
       ]
     },
     {
       "ID": 42000202,
       "Entries": [
-        "この場所に出たところで、別にレバーなんて、ちらとも触ってないわけだが…"
+        "But when I came here, I didn't touch any levers, no, not me!"
       ]
     },
     {
       "ID": 42000203,
       "Entries": [
-        "なんだか険しい感じだな？なにか、いやなことでもあったのかい？"
+        "Very peculiar, isn't it? Wait, did something happen to you?"
       ]
     },
     {
       "ID": 42000204,
       "Entries": [
-        "そんな顔をするなよ。俺はパッチ。鉄壁のパッチって呼ばれてる"
+        "Hey, don't look at me like that. I'm Trusty Patches, the\none-and-only!"
       ]
     },
     {
       "ID": 42000205,
       "Entries": [
-        "これは近づきのしるしだ。とっといてくれ"
+        "Here, everything's good with us, eh? Aww, c'mon, take it!"
       ]
     },
     {
       "ID": 42000210,
       "Entries": [
-        "ヘヘッ、よろしく頼むぜ…"
+        "Heh heh. We'll be wonderful friends."
       ]
     },
     {
       "ID": 42000211,
       "Entries": [
-        "ヘヘヘヘッ…"
+        "Heh heh heh..."
       ]
     },
     {
       "ID": 42000300,
       "Entries": [
-        "だから、どうしたんだ？"
+        "Oh, does it really matter that much?"
       ]
     },
     {
       "ID": 42000301,
       "Entries": [
-        "参ったな。何を疑われているのか、さっぱり分からないぜ？"
+        "C'mon, now. What exactly do you think I did?"
       ]
     },
     {
       "ID": 42000302,
       "Entries": [
-        "おかしな奴だな…"
+        "You're not making sense, my friend."
       ]
     },
     {
       "ID": 42000303,
       "Entries": [
-        "ヘヘヘヘッ…"
+        "Heh heh heh..."
       ]
     },
     {
       "ID": 42000400,
       "Entries": [
-        "お、おう、あんた、どうしたんだ？"
+        "Ah, oh! Well, how are you, then?"
       ]
     },
     {
       "ID": 42000401,
       "Entries": [
-        "…さっき、間違ってレバーを触っちまったんだが…"
+        "...I slipped and flipped that lever, you see..."
       ]
     },
     {
       "ID": 42000402,
       "Entries": [
-        "…まさか、あんたに何か迷惑でも？"
+        "...It didn't cause you any trouble, by chance?"
       ]
     },
     {
       "ID": 42000500,
       "Entries": [
-        "そ、そりゃあ、本当か！？"
+        "Are you certain?!"
       ]
     },
     {
       "ID": 42000501,
       "Entries": [
-        "いやあ、いやあ、そりゃあすまん。すまなかった。このとおりだ"
+        "Well, that's a fine shame. Oh, I'm truly sorry, really!"
       ]
     },
     {
       "ID": 42000502,
       "Entries": [
-        "だけど、実際のところ、あんたまだ落っこちてないんだろ？"
+        "But, wait now, you didn't actually fall down, then?"
       ]
     },
     {
       "ID": 42000503,
       "Entries": [
-        "なら、よかった。ギリギリセーフじゃないか。ノーカウントだ、ノーカウント"
+        "Well, why didn't you tell me sooner! All's well that ends well!"
       ]
     },
     {
       "ID": 42000504,
       "Entries": [
-        "ミスは誰にでもある。仕方が無かったんだ"
+        "Everybody makes mistakes. I'm not above it all, I swear!"
       ]
     },
     {
       "ID": 42000505,
       "Entries": [
-        "俺はパッチ。鉄壁のパッチって呼ばれてる"
+        "I'm Trusty Patches, the one-and-only!"
       ]
     },
     {
       "ID": 42000506,
       "Entries": [
-        "そうだ！これは、仲直りのしるしだ"
+        "I know! This should make up for it."
       ]
     },
     {
       "ID": 42000510,
       "Entries": [
-        "お互い、不死の追われ者同士、分かり合えるだろう？"
+        "We're on the same side! Undead outcasts!"
       ]
     },
     {
       "ID": 42000511,
       "Entries": [
-        "なあ、あんた…"
+        "Fantastic, isn't it?"
       ]
     },
     {
       "ID": 42000512,
       "Entries": [
-        "ヘヘヘヘッ…"
+        "Heh heh heh..."
       ]
     },
     {
       "ID": 42000600,
       "Entries": [
-        "へえ、そうか…そうだったか"
+        "Oh, really? Yes, I see...Righty-oh!"
       ]
     },
     {
       "ID": 42000601,
       "Entries": [
-        "だったらいいんだ、別に、何の問題もない"
+        "Then, everything's good, isn't it?"
       ]
     },
     {
       "ID": 42000602,
       "Entries": [
-        "俺はパッチ。鉄壁のパッチって呼ばれてる"
+        "I'm Trusty Patches, the one-and-only!"
       ]
     },
     {
       "ID": 42000603,
       "Entries": [
-        "不死の追われ者同士、なかよくやろうぜ、兄弟"
+        "You and I, just a couple of Undead outcasts, right mate?"
       ]
     },
     {
       "ID": 42000604,
       "Entries": [
-        "ヘヘヘヘッ…"
+        "Heh heh heh..."
       ]
     },
     {
       "ID": 42000650,
       "Entries": [
-        "へえ、そうか…そうだったか"
+        "Oh, really? Yes, I see...Righty-oh!"
       ]
     },
     {
       "ID": 42000651,
       "Entries": [
-        "だったらいいんだ、別に、何の問題もない"
+        "Then, everything's good, isn't it?"
       ]
     },
     {
       "ID": 42000652,
       "Entries": [
-        "俺はパッチ。鉄壁のパッチって呼ばれてる"
+        "I'm Trusty Patches, the one-and-only!"
       ]
     },
     {
       "ID": 42000653,
       "Entries": [
-        "不死の追われ者同士、なかよくやろうぜ、ハニー"
+        "You and I, just a couple of Undead outcasts, right my darling?"
       ]
     },
     {
       "ID": 42000654,
       "Entries": [
-        "ヘヘヘヘッ…"
+        "Heh heh heh..."
       ]
     },
     {
       "ID": 42000700,
       "Entries": [
-        "だから、言ってるだろ！"
+        "Oh, will you come off it, now!"
       ]
     },
     {
       "ID": 42000701,
       "Entries": [
-        "ギリギリセーフ、ノーカウントだ、ノーカウント"
+        "You're fine and well, so what's the difference!"
       ]
     },
     {
       "ID": 42000702,
       "Entries": [
-        "あんまりしつこいと、嫌われるぜ"
+        "Nobody likes a crybaby, you know?"
       ]
     },
     {
       "ID": 42000703,
       "Entries": [
-        "ヘヘヘヘッ…"
+        "Heh heh heh..."
       ]
     },
     {
       "ID": 42000840,
       "Entries": [
-        "痛エッ！"
+        "Oww!"
       ]
     },
     {
       "ID": 42000850,
       "Entries": [
-        "何するんだ！"
+        "What the devil!"
       ]
     },
     {
       "ID": 42000860,
       "Entries": [
-        "やめてくれ！"
+        "Please, no!"
       ]
     },
     {
       "ID": 42000900,
       "Entries": [
-        "そうかい、そうかい、そうくるかい"
+        "All right, all right, if that's the way it is!"
       ]
     },
     {
       "ID": 42000901,
       "Entries": [
-        "心の狭い野郎だな！"
+        "You silly little bastard!"
       ]
     },
     {
       "ID": 42000902,
       "Entries": [
-        "だったら、俺にも考えがあるぜ！"
+        "Well, I've had enough of you!"
       ]
     },
     {
       "ID": 42000903,
       "Entries": [
-        "聖職者風情が！死に腐れ！"
+        "Take your higher cause and stuff it, you lousy charlatan!"
       ]
     },
     {
       "ID": 42000920,
       "Entries": [
-        "そうかい、そうかい、そうくるかい"
+        "All right, all right, if that's the way it is!"
       ]
     },
     {
       "ID": 42000921,
       "Entries": [
-        "心の狭い野郎だな！"
+        "You silly little bastard!"
       ]
     },
     {
       "ID": 42000922,
       "Entries": [
-        "だったら、俺にも考えがあるぜ！"
+        "Well, I've had enough of you!"
       ]
     },
     {
       "ID": 42000923,
       "Entries": [
-        "不能野郎が！死に腐れ！"
+        "You lousy good-for-nothing! Wallow in your spit!"
       ]
     },
     {
       "ID": 42000950,
       "Entries": [
-        "そうかい、そうかい、そうくるかい"
+        "All right, all right, if that's the way it is!"
       ]
     },
     {
       "ID": 42000951,
       "Entries": [
-        "心の狭い女だな！"
+        "You impossible little wench!"
       ]
     },
     {
       "ID": 42000952,
       "Entries": [
-        "だったら、俺にも考えがあるぜ！"
+        "Well, I've had enough of you!"
       ]
     },
     {
       "ID": 42000953,
       "Entries": [
-        "聖職者風情が！死に腐れ！"
+        "Take your higher cause and stuff it, you lousy charlatan!"
       ]
     },
     {
       "ID": 42000970,
       "Entries": [
-        "そうかい、そうかい、そうくるかい"
+        "All right, all right, if that's the way it is!"
       ]
     },
     {
       "ID": 42000971,
       "Entries": [
-        "心の狭い女だな！"
+        "You impossible little wench!"
       ]
     },
     {
       "ID": 42000972,
       "Entries": [
-        "だったら、俺にも考えがあるぜ！"
+        "Well, I've had enough of you!"
       ]
     },
     {
       "ID": 42000973,
       "Entries": [
-        "売女が！死に腐れ！"
+        "You filthy wench! You'll get what you deserve!"
       ]
     },
     {
       "ID": 42001000,
       "Entries": [
-        "畜生…だめか…"
+        "Curses...I'm finished..."
       ]
     },
     {
       "ID": 42001001,
       "Entries": [
-        "俺がなにをしたって…"
+        "What did I ever..."
       ]
     },
     {
       "ID": 42001100,
       "Entries": [
-        "ふう…正義は勝つ、さ…"
+        "Phew...The righteous prevail, again..."
       ]
     },
     {
       "ID": 42001101,
       "Entries": [
-        "悪く思うなよ。兄弟"
+        "Hey, don't blame me, mate."
       ]
     },
     {
       "ID": 42001110,
       "Entries": [
-        "ふう…正義は勝つ、さ…"
+        "Phew...The righteous prevail, again..."
       ]
     },
     {
       "ID": 42001111,
       "Entries": [
-        "悪く思うなよ。ハニー"
+        "Hey, don't blame me, me old darling."
       ]
     },
     {
       "ID": 42001240,
       "Entries": [
-        "なんだっ？痛エッ！"
+        "What?! Oww!"
       ]
     },
     {
       "ID": 42001250,
       "Entries": [
-        "おいっ！やめろっ！"
+        "Oi! Put an end to that!"
       ]
     },
     {
       "ID": 42001260,
       "Entries": [
-        "やめろって！"
+        "Stop that!"
       ]
     },
     {
       "ID": 42001300,
       "Entries": [
-        "畜生、なんだってんだ"
+        "Curses, what's wrong with you!"
       ]
     },
     {
       "ID": 42001301,
       "Entries": [
-        "やるしかねえのか！ついてねえな！"
+        "Well, if that's what it has to be! Why you..."
       ]
     },
     {
       "ID": 42001400,
       "Entries": [
-        "畜生が…なんだってんだ…"
+        "Curses! How in the..."
       ]
     },
     {
       "ID": 42001401,
       "Entries": [
-        "ついてねえ…ついてねえよ…"
+        "What did I do? What...did...I...do?!"
       ]
     },
     {
       "ID": 42001500,
       "Entries": [
-        "…あんた、おかしいのか…"
+        "What happened to you?"
       ]
     },
     {
       "ID": 42001501,
       "Entries": [
-        "まったく、なんだってんだ、一体…"
+        "Curses, you left me no choice..."
       ]
     },
     {
       "ID": 42010000,
       "Entries": [
-        "よう、あんた。どうやらまともみたいだな"
+        "Good day! You look reasonably sane!"
       ]
     },
     {
       "ID": 42010001,
       "Entries": [
-        "こんな地下墓地の奥に用があるなんて、聖職者か何かか？"
+        "What are you doing in the Catacombs? Are you a cleric or\nsomething?"
       ]
     },
     {
       "ID": 42010100,
       "Entries": [
-        "やっぱりそうか"
+        "Yes, I guessed as much."
       ]
     },
     {
       "ID": 42010101,
       "Entries": [
-        "…だったら、いいことを教えてやるよ"
+        "Well, here's a tip."
       ]
     },
     {
       "ID": 42010102,
       "Entries": [
-        "あの穴の下に、たんまりとお宝が見えるんだ"
+        "There's a stash of treasure right down that hole."
       ]
     },
     {
       "ID": 42010103,
       "Entries": [
-        "俺が最初に見つけたんだが…他ならぬ聖職者様だ"
+        "I found it first, but...well, you're the cleric, right?"
       ]
     },
     {
       "ID": 42010104,
       "Entries": [
-        "娑婆でも、あんたたちには、色々と世話になったしな…譲らせてもらうぜ"
+        "I owe you for all that, er, praying and what not...I'll give you\nfirst pick."
       ]
     },
     {
       "ID": 42010105,
       "Entries": [
-        "とりあえず覗いてみろよ、すげえお宝だぜ"
+        "Well, go on, have a look. It'll shimmer you blind."
       ]
     },
     {
       "ID": 42010106,
       "Entries": [
-        "ヘヘヘヘッ…"
+        "Heh heh heh..."
       ]
     },
     {
       "ID": 42010200,
       "Entries": [
-        "なんだ、ちがうのか"
+        "No? Really?"
       ]
     },
     {
       "ID": 42010201,
       "Entries": [
-        "…だったら、いいことを教えてやるよ"
+        "Then I'd have no qualms telling you,"
       ]
     },
     {
       "ID": 42010202,
       "Entries": [
-        "あの穴の下に、たんまりとお宝が見えるんだ"
+        "there's a fine stash of treasure right down that hole."
       ]
     },
     {
       "ID": 42010203,
       "Entries": [
-        "俺が最初に見つけたんだが…折角の縁だ、山分けしてもいいんだぜ？"
+        "I found it first, but...well, we're friends now, so I'll split it\nwith you!"
       ]
     },
     {
       "ID": 42010204,
       "Entries": [
-        "まあ、とりあえず覗いてみろよ、すげえお宝だぜ"
+        "In any case, have a look, it'll shimmer you blind!"
       ]
     },
     {
       "ID": 42010205,
       "Entries": [
-        "ヘヘヘヘッ…"
+        "Heh heh heh..."
       ]
     },
     {
       "ID": 42010300,
       "Entries": [
-        "おお、誰かと思えば、あんただったか！"
+        "What, you again? Well, well!"
       ]
     },
     {
       "ID": 42010301,
       "Entries": [
-        "久しぶりだな。無事だったんだな"
+        "Where have you been? Any tidings, hmm?"
       ]
     },
     {
       "ID": 42010302,
       "Entries": [
-        "それよりあんた、丁度いいところにきた"
+        "Oh, you came at the perfect time."
       ]
     },
     {
       "ID": 42010303,
       "Entries": [
-        "あの穴の下に、たんまりとお宝が見えるんだ"
+        "There's a fine stash of treasure right down that hole."
       ]
     },
     {
       "ID": 42010304,
       "Entries": [
-        "俺が最初に見つけたんだが…他ならぬ聖職者様だ"
+        "I found it first, but...well, you're the cleric, right?"
       ]
     },
     {
       "ID": 42010305,
       "Entries": [
-        "娑婆でも、あんたたちには、色々と世話になったしな…譲らせてもらうぜ"
+        "I owe you for all that... praying and what not...look I'll give\nyou first pick."
       ]
     },
     {
       "ID": 42010306,
       "Entries": [
-        "とりあえず覗いてみろよ、すげえお宝だぜ"
+        "Well, go on, have a look. It'll shimmer you blind."
       ]
     },
     {
       "ID": 42010307,
       "Entries": [
-        "ヘヘヘヘッ…"
+        "Heh heh heh..."
       ]
     },
     {
       "ID": 42010400,
       "Entries": [
-        "おお、誰かと思えば、あんただったか！"
+        "What, you again? Well, well!"
       ]
     },
     {
       "ID": 42010401,
       "Entries": [
-        "久しぶりだな。無事で何よりだ、兄弟"
+        "You've been a stranger. Ah, good to see you're well, mate."
       ]
     },
     {
       "ID": 42010402,
       "Entries": [
-        "それよりあんた、丁度いいところにきた"
+        "Oh right, you came at the perfect time."
       ]
     },
     {
       "ID": 42010403,
       "Entries": [
-        "あの穴の下に、たんまりとお宝が見えるんだ"
+        "There's a fine stash of treasure right down that hole."
       ]
     },
     {
       "ID": 42010404,
       "Entries": [
-        "俺が最初に見つけたんだが…折角の縁だ、山分けしてもいいんだぜ？"
+        "I found it first, but...well, we're friends now. I'll split it\nwith you!"
       ]
     },
     {
       "ID": 42010405,
       "Entries": [
-        "まあ、とりあえず覗いてみろよ、すげえお宝だぜ"
+        "In any case, have a look, it'll shimmer you blind!"
       ]
     },
     {
       "ID": 42010406,
       "Entries": [
-        "ヘヘヘヘッ…"
+        "Heh heh heh..."
       ]
     },
     {
       "ID": 42010450,
       "Entries": [
-        "おお、誰かと思えば、あんただったか！"
+        "What, you again? Well, well!"
       ]
     },
     {
       "ID": 42010451,
       "Entries": [
-        "久しぶりだな。無事で何よりだ、ハニー"
+        "You've been a stranger. Ah it's good to see you're well, my\ndarling."
       ]
     },
     {
       "ID": 42010452,
       "Entries": [
-        "それよりあんた、丁度いいところにきた"
+        "Oh right, you came at the perfect time."
       ]
     },
     {
       "ID": 42010453,
       "Entries": [
-        "あの穴の下に、たんまりとお宝が見えるんだ"
+        "There's a fine stash of treasure right down that hole."
       ]
     },
     {
       "ID": 42010454,
       "Entries": [
-        "俺が最初に見つけたんだが…折角の縁だ、山分けしてもいいんだぜ？"
+        "I found it first, but...well, we're friends now. I'll split it\nwith you!"
       ]
     },
     {
       "ID": 42010455,
       "Entries": [
-        "まあ、とりあえず覗いてみろよ、すげえお宝だぜ"
+        "In any case, have a look, it'll shimmer you blind!"
       ]
     },
     {
       "ID": 42010456,
       "Entries": [
-        "ヘヘヘヘッ…"
+        "Heh heh heh..."
       ]
     },
     {
       "ID": 42010500,
       "Entries": [
-        "ほら、あの穴だ。近づいて覗いてみろよ"
+        "There, that hole. Take a closer look."
       ]
     },
     {
       "ID": 42010600,
       "Entries": [
-        "どうしたんだ？"
+        "What's your problem?"
       ]
     },
     {
       "ID": 42010601,
       "Entries": [
-        "まずあの穴を覗いて、お宝を確認してみろって"
+        "Take a peep in the hole, and check out that treasure!"
       ]
     },
     {
       "ID": 42010700,
       "Entries": [
-        "へヘッ、ざまあみやがれ"
+        "Heh heh, you got what you deserve!"
       ]
     },
     {
       "ID": 42010701,
       "Entries": [
-        "俺は、聖職者ってのが、うじ虫より嫌いなんだ"
+        "You damn clerics, you're worse than maggots!"
       ]
     },
     {
       "ID": 42010702,
       "Entries": [
-        "どうせあくどく儲けてるんだろ？あんたの死体から、全部剥いでやるからよ！"
+        "You must be loaded! I'll strip your corpse clean!"
       ]
     },
     {
       "ID": 42010703,
       "Entries": [
-        "ウヒャヒャヒャヒャッ！"
+        "Nyah hah hah hah!"
       ]
     },
     {
       "ID": 42010800,
       "Entries": [
-        "へヘッ、悪く思うなよ"
+        "Heh heh, this is what I do, my friend."
       ]
     },
     {
       "ID": 42010801,
       "Entries": [
-        "あんたの死体から剥いだお宝、せいぜい高く売ってやるからよ"
+        "The trinkets I'll be stripping off your corpse; that's the real\ntreasure!"
       ]
     },
     {
       "ID": 42010802,
       "Entries": [
-        "ウヒャヒャヒャヒャッ！"
+        "Nyah hah hah hah!"
       ]
     },
     {
       "ID": 42010900,
       "Entries": [
-        "…あ、あんた…"
+        "...Oh, you, I..."
       ]
     },
     {
       "ID": 42010901,
       "Entries": [
-        "まあ、落ち着いて話をきいてくれ"
+        "Well, let's just calm down. Talk about things..."
       ]
     },
     {
       "ID": 42010902,
       "Entries": [
-        "俺が悪かった。悪気はなかったんだ"
+        "I did you wrong. But, I didn't mean it."
       ]
     },
     {
       "ID": 42010903,
       "Entries": [
-        "ただ、ちょっと、魔が差したって言うか…"
+        "These...temptations, they can, well, overcome me..."
       ]
     },
     {
       "ID": 42010904,
       "Entries": [
-        "な、わかるだろ？よくあるだろ？許してくれよ"
+        "You know what I mean? Don't you? Please forgive me."
       ]
     },
     {
       "ID": 42010905,
       "Entries": [
-        "同じ不死の追われ者、俺とあんたの仲じゃあないか！"
+        "You and me, we're jolly Undead outcasts, aren't we?"
       ]
     },
     {
       "ID": 42011000,
       "Entries": [
-        "おお、そうか！許してくれるか！"
+        "Oh, brilliant! A second chance! Wonderful!"
       ]
     },
     {
       "ID": 42011001,
       "Entries": [
-        "いやあ、やっぱり話がわかるな、あんたは"
+        "I had a feeling you'd understand, I did."
       ]
     },
     {
       "ID": 42011002,
       "Entries": [
-        "いや、さすがだよ。俺にはまねできねえ。これからも仲良くやろうぜ"
+        "But if I were in your shoes...Ooh! Who knows what I'd have done?\nBut now...We're friends again, eh?"
       ]
     },
     {
       "ID": 42011003,
       "Entries": [
-        "ヘヘヘヘッ…"
+        "Heh heh heh..."
       ]
     },
     {
       "ID": 42011100,
       "Entries": [
-        "そんな、おい、冗談は顔だけにしようぜ"
+        "Oh, for heaven's sake, let's not mope about, eh?"
       ]
     },
     {
       "ID": 42011101,
       "Entries": [
-        "あんたまだ生きてるし、俺だって謝ってるじゃあないか"
+        "You're still alive, I've said I'm sorry!"
       ]
     },
     {
       "ID": 42011102,
       "Entries": [
-        "そうだ！これは、俺の気持ちだ。だから、なあ、分かるだろう？"
+        "Wait, I know! Here, take this. It proves something, doesn't it?"
       ]
     },
     {
       "ID": 42011110,
       "Entries": [
-        "ヘヘヘヘッ…"
+        "Heh heh heh..."
       ]
     },
     {
       "ID": 42011200,
       "Entries": [
-        "へえ、あんた、戻れたのか"
+        "Blimey, how did you..."
       ]
     },
     {
       "ID": 42011201,
       "Entries": [
-        "クソほどしぶといものなんだなぁ…"
+        "You weren't supposed to survive that..."
       ]
     },
     {
       "ID": 42011202,
       "Entries": [
-        "いいだろう。俺が引導を渡してやるよ"
+        "Well, no matter. I'll settle this once and for all."
       ]
     },
     {
       "ID": 42011203,
       "Entries": [
-        "腐れ聖職者風情が！"
+        "You lousy self-righteous cleric!"
       ]
     },
     {
       "ID": 42011300,
       "Entries": [
-        "俺が悪かったよ。悪気はなかったんだ"
+        "I did you wrong. But, I didn't mean it."
       ]
     },
     {
       "ID": 42011301,
       "Entries": [
-        "ただ、ちょっと、魔が差したって言うか…"
+        "These...temptations, they can overcome me..."
       ]
     },
     {
       "ID": 42011302,
       "Entries": [
-        "な、わかるだろ？あんたなら"
+        "You know what I mean? Don't you? Please, forgive me."
       ]
     },
     {
       "ID": 42011440,
       "Entries": [
-        "痛エッ！"
+        "Oww!"
       ]
     },
     {
       "ID": 42011450,
       "Entries": [
-        "何するんだ！"
+        "What the devil!"
       ]
     },
     {
       "ID": 42011460,
       "Entries": [
-        "やめてくれ！"
+        "Please, no!"
       ]
     },
     {
       "ID": 42011500,
       "Entries": [
-        "そうかい、そうかい、そうくるかい"
+        "All right, all right, if that's the way it is!"
       ]
     },
     {
       "ID": 42011501,
       "Entries": [
-        "心の狭い野郎だな！"
+        "You silly little bastard!"
       ]
     },
     {
       "ID": 42011502,
       "Entries": [
-        "だったら、俺にも考えがあるぜ！"
+        "Well, I've had enough of you!"
       ]
     },
     {
       "ID": 42011503,
       "Entries": [
-        "聖職者風情が！死に腐れ！"
+        "Take your higher cause and stuff it, you lousy charlatan!"
       ]
     },
     {
       "ID": 42011520,
       "Entries": [
-        "そうかい、そうかい、そうくるかい"
+        "All right, all right, if that's the way it is!"
       ]
     },
     {
       "ID": 42011521,
       "Entries": [
-        "心の狭い野郎だな！"
+        "You silly little bastard!"
       ]
     },
     {
       "ID": 42011522,
       "Entries": [
-        "だったら、俺にも考えがあるぜ！"
+        "Well, I've had enough of you!"
       ]
     },
     {
       "ID": 42011523,
       "Entries": [
-        "不能野郎が！死に腐れ！"
+        "You lousy good-for-nothing! Wallow in your spit!"
       ]
     },
     {
       "ID": 42011550,
       "Entries": [
-        "そうかい、そうかい、そうくるかい"
+        "All right, all right, if that's the way it is!"
       ]
     },
     {
       "ID": 42011551,
       "Entries": [
-        "心の狭い女だな！"
+        "You impossible little wench!"
       ]
     },
     {
       "ID": 42011552,
       "Entries": [
-        "だったら、俺にも考えがあるぜ！"
+        "Well, I've had enough of you!"
       ]
     },
     {
       "ID": 42011553,
       "Entries": [
-        "聖職者風情が！死に腐れ！"
+        "Take your higher cause and stuff it, you lousy charlatan!"
       ]
     },
     {
       "ID": 42011570,
       "Entries": [
-        "そうかい、そうかい、そうくるかい"
+        "All right, all right, if that's the way it is!"
       ]
     },
     {
       "ID": 42011571,
       "Entries": [
-        "心の狭い女だな！"
+        "You impossible little wench!"
       ]
     },
     {
       "ID": 42011572,
       "Entries": [
-        "だったら、俺にも考えがあるぜ！"
+        "Well, I've had enough of you!"
       ]
     },
     {
       "ID": 42011573,
       "Entries": [
-        "売女が！死に腐れ！"
+        "You filthy wench! You'll get what you deserve!"
       ]
     },
     {
       "ID": 42011600,
       "Entries": [
-        "畜生…だめか…"
+        "Curses...I'm finished..."
       ]
     },
     {
       "ID": 42011601,
       "Entries": [
-        "俺がなにをしたって…"
+        "What did I ever..."
       ]
     },
     {
       "ID": 42011700,
       "Entries": [
-        "ふう…正義は勝つ、さ…"
+        "Phew...The righteous prevail, again..."
       ]
     },
     {
       "ID": 42011701,
       "Entries": [
-        "悪く思うなよ。兄弟"
+        "Hey, don't blame me, mate."
       ]
     },
     {
       "ID": 42011750,
       "Entries": [
-        "ふう…正義は勝つ、さ…"
+        "Phew...The righteous prevail, again..."
       ]
     },
     {
       "ID": 42011751,
       "Entries": [
-        "悪く思うなよ。ハニー"
+        "Hey, don't blame me, me old darling."
       ]
     },
     {
       "ID": 42011840,
       "Entries": [
-        "なんだっ？痛エッ！"
+        "What?! Oww!"
       ]
     },
     {
       "ID": 42011850,
       "Entries": [
-        "おいっ！やめろっ！"
+        "Oi! Put an end to that!"
       ]
     },
     {
       "ID": 42011860,
       "Entries": [
-        "やめろって！"
+        "Stop that!"
       ]
     },
     {
       "ID": 42011900,
       "Entries": [
-        "畜生、なんだってんだ"
+        "Curses, what's wrong with you!"
       ]
     },
     {
       "ID": 42011901,
       "Entries": [
-        "やるしかねえのか！ついてねえな！"
+        "Well, if that's what it has to be! Why you..."
       ]
     },
     {
       "ID": 42012000,
       "Entries": [
-        "畜生が…なんだってんだ…"
+        "Curses! How in the..."
       ]
     },
     {
       "ID": 42012001,
       "Entries": [
-        "ついてねえ…ついてねえよ…"
+        "What did I do? What...did...I...do?!"
       ]
     },
     {
       "ID": 42012100,
       "Entries": [
-        "…あんた、おかしいのか…"
+        "What happened to you?"
       ]
     },
     {
       "ID": 42012101,
       "Entries": [
-        "まったく、なんだってんだ、一体…"
+        "Curses, you left me no choice..."
       ]
     },
     {
       "ID": 42020000,
       "Entries": [
-        "おう、またあんたか。よく会うな"
+        "Oh, we meet again. How many of you are there?"
       ]
     },
     {
       "ID": 42020001,
       "Entries": [
-        "だが、丁度よかった"
+        "You've come at the perfect time."
       ]
     },
     {
       "ID": 42020002,
       "Entries": [
-        "追い剥ぎ稼業はやめにした。まじめな商いをはじめたんだ"
+        "I'm done with the looting. I'm a humble merchant now!"
       ]
     },
     {
       "ID": 42020003,
       "Entries": [
-        "もちろん、お宝だらけさ。あんたになら、格安で譲ってやる"
+        "And wondrous treasures, have I! At a special price for you."
       ]
     },
     {
       "ID": 42020004,
       "Entries": [
-        "いいから、ちょっと見てみろよ"
+        "There you are, have a nice look at them."
       ]
     },
     {
       "ID": 42020005,
       "Entries": [
-        "別に、穴に落とそうってんじゃないんだ"
+        "Oh relax, no more funny business out of me, my friend!"
       ]
     },
     {
       "ID": 42020100,
       "Entries": [
-        "おう、またあんたか。奇遇だな"
+        "Oh, you again. Fancy that."
       ]
     },
     {
       "ID": 42020101,
       "Entries": [
-        "だが、丁度よかった"
+        "You've come at the perfect time."
       ]
     },
     {
       "ID": 42020102,
       "Entries": [
-        "凄いお宝を仕入れたんだ"
+        "Some new gems have come my way."
       ]
     },
     {
       "ID": 42020103,
       "Entries": [
-        "あんたのために、とっておいたのさ。特別だぜ、兄弟"
+        "I saved them specially, just for you, mate."
       ]
     },
     {
       "ID": 42020150,
       "Entries": [
-        "おう、またあんたか。奇遇だな"
+        "Oh, you again. Fancy that."
       ]
     },
     {
       "ID": 42020151,
       "Entries": [
-        "だが、丁度よかった"
+        "You've come at the perfect time."
       ]
     },
     {
       "ID": 42020152,
       "Entries": [
-        "凄いお宝を仕入れたんだ"
+        "Some new gems have come my way."
       ]
     },
     {
       "ID": 42020153,
       "Entries": [
-        "あんたのために、とっておいたのさ。特別だぜ、ハニー"
+        "I saved them specially, just for you, my darling."
       ]
     },
     {
       "ID": 42020200,
       "Entries": [
-        "お、あんた。またきたな"
+        "Oh, there you are again."
       ]
     },
     {
       "ID": 42020201,
       "Entries": [
-        "信頼のパッチ商店にようこそだ"
+        "Welcome to Trusty Patches' Trove of Treasures."
       ]
     },
     {
       "ID": 42020202,
       "Entries": [
-        "いつもながら、決して損はさせないぜ"
+        "We chop prices, not limbs!"
       ]
     },
     {
       "ID": 42020300,
       "Entries": [
-        "…なんだ、買わないのか？"
+        "What, nothing appeals to you?"
       ]
     },
     {
       "ID": 42020301,
       "Entries": [
-        "しょうがねえ、モノの価値の分からない奴だな…"
+        "Well, you must have poor taste."
       ]
     },
     {
       "ID": 42020400,
       "Entries": [
-        "…おいおい、しけてんなあ"
+        "Come on, you can do better than that."
       ]
     },
     {
       "ID": 42020401,
       "Entries": [
-        "貧乏は癖になるぜ。ほどほどにしとけよ…まったく…"
+        "Nobody likes a tightwad, you hear me?"
       ]
     },
     {
       "ID": 42020500,
       "Entries": [
-        "どうだ？すごいもんだったろう？"
+        "Right? Good stuff, eh?"
       ]
     },
     {
       "ID": 42020501,
       "Entries": [
-        "俺様に感謝して欲しいもんだな"
+        "Don't you forget who got it for you!"
       ]
     },
     {
       "ID": 42020502,
       "Entries": [
-        "ヘヘヘヘッ…"
+        "Heh heh heh..."
       ]
     },
     {
       "ID": 42020600,
       "Entries": [
-        "どうだい？満足したかい？"
+        "How is it? Fine stuff, eh?"
       ]
     },
     {
       "ID": 42020601,
       "Entries": [
-        "遠慮なく感謝していいんだぜ？"
+        "Don't forget to thank me."
       ]
     },
     {
       "ID": 42020700,
       "Entries": [
-        "そういえば、あんた、抱かれのロートレクを知ってるかい？"
+        "Oi, have you met Lautrec the Embraced?"
       ]
     },
     {
       "ID": 42020701,
       "Entries": [
-        "兄弟だから忠告するが、あいつは…いかれてるぜ"
+        "Believe me on this one, bruv...He's completely mad."
       ]
     },
     {
       "ID": 42020702,
       "Entries": [
-        "人の命なんてなんとも思っちゃいねえ"
+        "He wouldn't think twice about cutting somebody down."
       ]
     },
     {
       "ID": 42020703,
       "Entries": [
-        "人間性を溜め込んだら、気をつけな…"
+        "So watch out for him, especially if you've humanity to spare."
       ]
     },
     {
       "ID": 42020750,
       "Entries": [
-        "そういえば、あんた、抱かれのロートレクを知ってるかい？"
+        "Oi, have you met Lautrec the Embraced?"
       ]
     },
     {
       "ID": 42020751,
       "Entries": [
-        "ハニーだから忠告するが、あいつは…いかれてるぜ"
+        "Believe me on this one, my love...He's completely mad."
       ]
     },
     {
       "ID": 42020752,
       "Entries": [
-        "人の命なんてなんとも思っちゃいねえ"
+        "He wouldn't think twice about cutting somebody down."
       ]
     },
     {
       "ID": 42020753,
       "Entries": [
-        "人間性を溜め込んだら、気をつけな…"
+        "So watch out for him, especially if you've humanity to spare."
       ]
     },
     {
       "ID": 42020800,
       "Entries": [
-        "そういえば、あんた、エセ聖職者のペトルスを知ってるかい？"
+        "Oi, have you met Petrus, that self-proclaimed cleric?"
       ]
     },
     {
       "ID": 42020801,
       "Entries": [
-        "兄弟だから忠告するが、あいつは…クソだぜ"
+        "Believe me on this one, bruv...The man is scum."
       ]
     },
     {
       "ID": 42020802,
       "Entries": [
-        "善人ぶった上っ面に騙されるなよ"
+        "Don't you be fooled by his claims to do good."
       ]
     },
     {
       "ID": 42020803,
       "Entries": [
-        "聖職者ってのは、みんなそうだ…"
+        "They're all the same, those rotten clerics."
       ]
     },
     {
       "ID": 42020850,
       "Entries": [
-        "そういえば、あんた、エセ聖職者のペトルスを知ってるかい？"
+        "Oi, have you met Petrus, that self-proclaimed cleric?"
       ]
     },
     {
       "ID": 42020851,
       "Entries": [
-        "ハニーだから忠告するが、あいつは…クソだぜ"
+        "Believe me on this one, my love...The man is scum."
       ]
     },
     {
       "ID": 42020852,
       "Entries": [
-        "善人ぶった上っ面に騙されるなよ"
+        "Don't you be fooled by his claims to do good."
       ]
     },
     {
       "ID": 42020853,
       "Entries": [
-        "聖職者ってのは、みんなそうだ…"
+        "They're all the same, those rotten clerics."
       ]
     },
     {
       "ID": 42020900,
       "Entries": [
-        "そういえば、あんた、太陽大好きのソラールを知ってるかい？"
+        "Here, have you met that sunbathing Solaire?"
       ]
     },
     {
       "ID": 42020901,
       "Entries": [
-        "兄弟だから忠告するが、あいつは…本物の馬鹿だぜ"
+        "Believe me on this one, bruv...He's a complete idiot."
       ]
     },
     {
       "ID": 42020902,
       "Entries": [
-        "ただ、馬鹿なりに、腕っ節だけはそれなりだからな"
+        "But he happens to be an awfully strong idiot."
       ]
     },
     {
       "ID": 42020903,
       "Entries": [
-        "うまく話をあわせて、利用してやればいいさ"
+        "Just nod your head, and keep him on your side!"
       ]
     },
     {
       "ID": 42020904,
       "Entries": [
-        "ウヒャヒャヒャヒャッ！"
+        "Nyah hah hah hah!"
       ]
     },
     {
       "ID": 42020950,
       "Entries": [
-        "そういえば、あんた、太陽大好きのソラールを知ってるかい？"
+        "Here, have you met that sunbathing Solaire?"
       ]
     },
     {
       "ID": 42020951,
       "Entries": [
-        "ハニーだから忠告するが、あいつは…本物の馬鹿だぜ"
+        "Believe me on this one, my love...He's a complete idiot."
       ]
     },
     {
       "ID": 42020952,
       "Entries": [
-        "ただ、馬鹿なりに、腕っ節だけはそれなりだからな"
+        "But he happens to be an awfully strong idiot."
       ]
     },
     {
       "ID": 42020953,
       "Entries": [
-        "うまく話をあわせて、利用してやればいいさ"
+        "Just nod your head, and keep him on your side!"
       ]
     },
     {
       "ID": 42020954,
       "Entries": [
-        "ウヒャヒャヒャヒャッ！"
+        "Nyah hah hah hah!"
       ]
     },
     {
       "ID": 42021000,
       "Entries": [
-        "そういえば、あんた、田舎者のシバを知ってるかい？"
+        "Here, have you met that backwoods Shiva?"
       ]
     },
     {
       "ID": 42021001,
       "Entries": [
-        "兄弟だから忠告するが、あいつは…やばいぜ"
+        "Believe me on this one, bruv...The man is trouble."
       ]
     },
     {
       "ID": 42021002,
       "Entries": [
-        "俺には分かるんだ。あれは…"
+        "I can see it in his eyes. I just can."
       ]
     },
     {
       "ID": 42021003,
       "Entries": [
-        "間違いねえ"
+        "Hmph, No doubt about it. Watch him."
       ]
     },
     {
       "ID": 42021050,
       "Entries": [
-        "そういえば、あんた、田舎者のシバを知ってるかい？"
+        "Here, have you met that backwoods Shiva?"
       ]
     },
     {
       "ID": 42021051,
       "Entries": [
-        "ハニーだから忠告するが、あいつは…やばいぜ"
+        "Believe me on this one, my love...The man is trouble."
       ]
     },
     {
       "ID": 42021052,
       "Entries": [
-        "俺には分かるんだ。あれは…"
+        "I can see it in his eyes. I just can."
       ]
     },
     {
       "ID": 42021053,
       "Entries": [
-        "間違いねえ"
+        "Hmph, No doubt about it. Watch him."
       ]
     },
     {
       "ID": 42021060,
       "Entries": [
-        "追い剥ぎ稼業はやめにした。まじめな商いをはじめたんだ"
+        "I'm done with the looting. I'm a humble merchant now!"
       ]
     },
     {
       "ID": 42021061,
       "Entries": [
-        "もちろん、お宝だらけさ。あんたになら、格安で譲ってやる"
+        "And wondrous treasures, have I! At a special price for you."
       ]
     },
     {
       "ID": 42021140,
       "Entries": [
-        "痛エッ！"
+        "Oww!"
       ]
     },
     {
       "ID": 42021150,
       "Entries": [
-        "何するんだ！"
+        "What the devil!"
       ]
     },
     {
       "ID": 42021160,
       "Entries": [
-        "やめてくれ！"
+        "Please, no!"
       ]
     },
     {
       "ID": 42021200,
       "Entries": [
-        "そうかい、そうかい、そうくるかい"
+        "All right, all right, if that's the way it is!"
       ]
     },
     {
       "ID": 42021201,
       "Entries": [
-        "心の狭い野郎だな！"
+        "You silly little bastard!"
       ]
     },
     {
       "ID": 42021202,
       "Entries": [
-        "心の狭い女だな！"
+        "You impossible little wench!"
       ]
     },
     {
       "ID": 42021203,
       "Entries": [
-        "だったら、俺にも考えがあるぜ！"
+        "Well, I've had enough of you!"
       ]
     },
     {
       "ID": 42021204,
       "Entries": [
-        "聖職者風情が！死に腐れ！"
+        "Take your higher cause and stuff it, you lousy charlatan!"
       ]
     },
     {
       "ID": 42021205,
       "Entries": [
-        "不能野郎が！死に腐れ！"
+        "You lousy good-for-nothing! Wallow in your spit!"
       ]
     },
     {
       "ID": 42021206,
       "Entries": [
-        "売女が！死に腐れ！"
+        "You filthy wench! You'll get what you deserve!"
       ]
     },
     {
       "ID": 42021300,
       "Entries": [
-        "畜生…だめか…"
+        "Curses...I'm finished..."
       ]
     },
     {
       "ID": 42021301,
       "Entries": [
-        "俺がなにをしたって…"
+        "What did I ever..."
       ]
     },
     {
       "ID": 42021400,
       "Entries": [
-        "ふう…正義は勝つ、さ…"
+        "Phew...The righteous prevail, again..."
       ]
     },
     {
       "ID": 42021401,
       "Entries": [
-        "悪く思うなよ。兄弟"
+        "Hey, don't blame me, mate."
       ]
     },
     {
       "ID": 42021402,
       "Entries": [
-        "悪く思うなよ。ハニー"
+        "Hey, don't blame me, me old darling."
       ]
     },
     {
       "ID": 42021540,
       "Entries": [
-        "なんだっ？痛エッ！"
+        "What?! Oww!"
       ]
     },
     {
       "ID": 42021550,
       "Entries": [
-        "おいっ！やめろっ！"
+        "Oi! Put an end to that!"
       ]
     },
     {
       "ID": 42021560,
       "Entries": [
-        "やめろって！"
+        "Stop that!"
       ]
     },
     {
       "ID": 42021600,
       "Entries": [
-        "畜生、なんだってんだ"
+        "Curses, what's wrong with you!"
       ]
     },
     {
       "ID": 42021601,
       "Entries": [
-        "やるしかねえのか！ついてねえな！"
+        "Well, if that's what it has to be! Why you..."
       ]
     },
     {
       "ID": 42021700,
       "Entries": [
-        "畜生が…なんだってんだ…"
+        "Curses! How in the..."
       ]
     },
     {
       "ID": 42021701,
       "Entries": [
-        "ついてねえ…ついてねえよ…"
+        "What did I do? What...did...I...do?!"
       ]
     },
     {
       "ID": 42021800,
       "Entries": [
-        "…あんた、おかしいのか…"
+        "What happened to you?"
       ]
     },
     {
       "ID": 42021801,
       "Entries": [
-        "まったく、なんだってんだ、一体…"
+        "Curses, you left me no choice..."
       ]
     },
     {
       "ID": 43000000,
       "Entries": [
-        "グオオ…グゴオ…（いびき）"
+        "Hmgg...Hmgg..."
       ]
     },
     {
       "ID": 43000100,
       "Entries": [
-        "おお、お主か。目覚ましの鐘を鳴らしたのは"
+        "Ahh, hello. Was it you who rang the Bell of Awakening?"
       ]
     },
     {
       "ID": 43000101,
       "Entries": [
-        "わしは世界の蛇、王の探索者フラムト。大王グウィンの親友じゃ"
+        "I am the primordial serpent, Kingseeker Frampt, close friend of\nthe Great Lord Gwyn."
       ]
     },
     {
       "ID": 43000102,
       "Entries": [
-        "目覚ましの鐘を鳴らした、不死人の勇者よ"
+        "Chosen Undead, who has rung the Bell of Awakening."
       ]
     },
     {
       "ID": 43000103,
       "Entries": [
-        "お主に、不死の使命を伝えたい"
+        "I wish to elucidate your fate,"
       ]
     },
     {
       "ID": 43000104,
       "Entries": [
-        "よいかな？"
+        "Do you seek such enlightenment?"
       ]
     },
     {
       "ID": 43000120,
       "Entries": [
-        "よかろう。ならば伝えよう"
+        "Very well. Then I am pleased to share."
       ]
     },
     {
       "ID": 43000121,
       "Entries": [
-        "不死人の勇者よ。お主の使命は…大王グウィンを継ぐことじゃ"
+        "Chosen Undead. Your fate...is to succeed the Great Lord Gwyn."
       ]
     },
     {
       "ID": 43000122,
       "Entries": [
-        "かの王を継ぎ、再び火を熾し、闇をはらい、不死の徴をはらうことじゃ"
+        "So that you may link the Fire, cast away the Dark, and undo the\ncurse of the Undead."
       ]
     },
     {
       "ID": 43000123,
       "Entries": [
-        "そのためには、まず、王都アノール・ロンドで、王の器を手に入れねばならぬ"
+        "To this end, you must visit Anor Londo, and acquire the\nLordvessel."
       ]
     },
     {
       "ID": 43000140,
       "Entries": [
-        "なんと…おどろきじゃ"
+        "By the Lords...Are you certain?"
       ]
     },
     {
       "ID": 43000141,
       "Entries": [
-        "だが、まあ、そうかもしれん"
+        "Well, perhaps I was wrong."
       ]
     },
     {
       "ID": 43000142,
       "Entries": [
-        "使命の不死は1人。お主が違うというだけのことじゃ…好きにするといい"
+        "There can be only one chosen Undead. I will continue my\nsearch...You are freed from duty."
       ]
     },
     {
       "ID": 43000143,
       "Entries": [
-        "だが、折角、目覚ましの鐘を鳴らしたのじゃ"
+        "But then again, you did ring the Bell of Awakening."
       ]
     },
     {
       "ID": 43000144,
       "Entries": [
-        "わしはしばらくここにいる。心変わりしたら、声をかけるがよい"
+        "I will stay here a while. Speak with me if you should change your\nmind."
       ]
     },
     {
       "ID": 43000200,
       "Entries": [
-        "おお、お主か。目覚ましの鐘を鳴らしたのは"
+        "Ahh, hello. Was it you who rang the Bell of Awakening?"
       ]
     },
     {
       "ID": 43000201,
       "Entries": [
-        "わしは世界の蛇、王の探索者フラムト。大王グウィンの親友じゃ"
+        "I am the primordial serpent, Kingseeker Frampt, close friend of\nthe Great Lord Gwyn."
       ]
     },
     {
       "ID": 43000202,
       "Entries": [
-        "目覚ましの鐘を鳴らした、不死人の勇者よ"
+        "Chosen Undead, who has rung the Bell of Awakening."
       ]
     },
     {
       "ID": 43000203,
       "Entries": [
-        "お主に、不死の使命を伝えたい"
+        "I wish to elucidate your fate,"
       ]
     },
     {
       "ID": 43000204,
       "Entries": [
-        "お主ら不死が現れた、世界の理由じゃ"
+        "and the very reason your kind have appeared."
       ]
     },
     {
       "ID": 43000205,
       "Entries": [
-        "不死人の勇者よ。お主の使命は…大王グウィンを継ぐことじゃ"
+        "Chosen Undead. Your fate...is to succeed the Great Lord Gwyn."
       ]
     },
     {
       "ID": 43000206,
       "Entries": [
-        "かの王を継ぎ、再び火を熾し、闇をはらい、不死の徴をはらうことじゃ"
+        "So that you may link the Fire, cast away the Dark, and undo the\ncurse of the Undead."
       ]
     },
     {
       "ID": 43000207,
       "Entries": [
-        "それでは、その器のあるべき場所に、お主を案内しよう"
+        "Now, let us take that vessel on a journey."
       ]
     },
     {
       "ID": 43000208,
       "Entries": [
-        "準備はよいな。では、じっとしておれよ！"
+        "I assume that you are ready. Now, be still!"
       ]
     },
     {
       "ID": 43000250,
       "Entries": [
-        "よかろう。ならば伝えよう"
+        "Very well. Then I am pleased to share."
       ]
     },
     {
       "ID": 43000251,
       "Entries": [
-        "不死人の勇者よ。お主の使命は…大王グウィンを継ぐことじゃ"
+        "Chosen Undead. Your fate...is to succeed the Great Lord Gwyn."
       ]
     },
     {
       "ID": 43000252,
       "Entries": [
-        "かの王を継ぎ、再び火を熾し、闇をはらい、不死の徴をはらうことじゃ"
+        "So that you may link the Fire, cast away the Dark, and undo the\ncurse of the Undead."
       ]
     },
     {
       "ID": 43000253,
       "Entries": [
-        "そのためには、まず、王都アノール・ロンドで、王の器を手に入れねばならぬ"
+        "To this end, you must visit Anor Londo, and acquire the\nLordvessel."
       ]
     },
     {
       "ID": 43000290,
       "Entries": [
-        "そうじゃ。1つ、伝えておこう"
+        "Ahh, one other thing."
       ]
     },
     {
       "ID": 43000291,
       "Entries": [
-        "お主が、不死として人であるため、人間性を欲すのならば"
+        "You will require humanity to remain yourself while Undead."
       ]
     },
     {
       "ID": 43000292,
       "Entries": [
-        "わしが願いをかなえてやろう"
+        "This I can provide you,"
       ]
     },
     {
       "ID": 43000293,
       "Entries": [
-        "不死として得た、ソウルの力と引き換えに、じゃがな…"
+        "but only in trade for souls."
       ]
     },
     {
       "ID": 43000300,
       "Entries": [
-        "お主、息災でなによりじゃ"
+        "I am pleased to see you well."
       ]
     },
     {
       "ID": 43000301,
       "Entries": [
-        "何か火急の用かのう？"
+        "Is it something urgent?"
       ]
     },
     {
       "ID": 43000350,
       "Entries": [
-        "お主、息災でなによりじゃ"
+        "I am pleased to see you well."
       ]
     },
     {
       "ID": 43000351,
       "Entries": [
-        "何か火急の用かのう？"
+        "Is it something urgent?"
       ]
     },
     {
       "ID": 43000400,
       "Entries": [
-        "グオオ…グゴオ…（いびき）"
+        "Hmgg...Hmgg..."
       ]
     },
     {
       "ID": 43000500,
       "Entries": [
-        "…ん？むむ、大丈夫、大丈夫じゃ"
+        "...Hm? No, no, I'm fine, I'm fine."
       ]
     },
     {
       "ID": 43000501,
       "Entries": [
-        "わしはしっかりとおきておるぞ"
+        "Well and wide awake!"
       ]
     },
     {
       "ID": 43000502,
       "Entries": [
-        "老蛇扱いするでないわい"
+        "Do not treat me like an old withering snake."
       ]
     },
     {
       "ID": 43000600,
       "Entries": [
-        "お主、どうしたのじゃ？"
+        "What brings you here?"
       ]
     },
     {
       "ID": 43000601,
       "Entries": [
-        "その姿は…亡者そのものではないか"
+        "By the Lords, you may as well be a Hollow."
       ]
     },
     {
       "ID": 43000602,
       "Entries": [
-        "使命も難しかろう。はやく、人に還るがよい"
+        "This will not do. Your humanity requires replenishment."
       ]
     },
     {
       "ID": 43000700,
       "Entries": [
-        "ほう、お主、どうしたのじゃ？"
+        "What brings you here?"
       ]
     },
     {
       "ID": 43000701,
       "Entries": [
-        "心変わり、不死の使命を聞く気になったのかな？"
+        "Had a change of heart about your fate as an Undead?"
       ]
     },
     {
       "ID": 43000800,
       "Entries": [
-        "センの古城は、人が神の国に至る試練、罠の道じゃ"
+        "Those who seek the Realm of Lords must brave Sen's Fortress, a\ndeadly house of traps."
       ]
     },
     {
       "ID": 43000801,
       "Entries": [
-        "かつて、何人もの使命者が挑み、誰も戻らなんだ"
+        "Many have gone before you, but none have returned."
       ]
     },
     {
       "ID": 43000802,
       "Entries": [
-        "お主は、久しぶりの使命者じゃ。気をつけるのじゃぞ"
+        "Fate has chosen you, but proceed with caution."
       ]
     },
     {
       "ID": 43000850,
       "Entries": [
-        "センの古城は、人が神の国に至る試練、罠の道じゃ"
+        "Those who seek the Realm of Lords must brave Sen's Fortress, a\ndeadly house of traps."
       ]
     },
     {
       "ID": 43000851,
       "Entries": [
-        "かつて、何人もの使命者が挑み、誰も戻らなんだ"
+        "Many have gone before you, but none have returned."
       ]
     },
     {
       "ID": 43000852,
       "Entries": [
-        "お主は、久しぶりの使命者じゃ。気をつけるのじゃぞ"
+        "Fate has chosen you, but proceed with caution."
       ]
     },
     {
       "ID": 43000900,
       "Entries": [
-        "さらばじゃ"
+        "Farewell."
       ]
     },
     {
       "ID": 43000901,
       "Entries": [
-        "不死の勇者よ。わしはここで待っておるぞ"
+        "Chosen Undead. I remain here, and await thee."
       ]
     },
     {
       "ID": 43000950,
       "Entries": [
-        "さらばじゃ"
+        "Farewell."
       ]
     },
     {
       "ID": 43000951,
       "Entries": [
-        "不死の勇者よ。わしはここで待っておるぞ"
+        "Chosen Undead. I remain here, and await thee."
       ]
     },
     {
       "ID": 43001000,
       "Entries": [
-        "おお！お主、でかしたな！まさか、王の器を持ち帰るとは！"
+        "Heavens! You have done it! You have retrieved the Lordvessel!"
       ]
     },
     {
       "ID": 43001001,
       "Entries": [
-        "1000年を越え、ずっと探し求めていた者が、やっと現れたか！"
+        "After a thousand years! It is you, it is really you!"
       ]
     },
     {
       "ID": 43001002,
       "Entries": [
-        "ウオオオオーーーーーン！"
+        "Hraaaoogggh!"
       ]
     },
     {
       "ID": 43001003,
       "Entries": [
-        "ウオオオオーーーーーン！"
+        "Hraaaoogggh!"
       ]
     },
     {
       "ID": 43001004,
       "Entries": [
-        "…"
+        "..."
       ]
     },
     {
       "ID": 43001005,
       "Entries": [
-        "すまん、少し興奮してしまった"
+        "Forgive me. I really should calm down."
       ]
     },
     {
       "ID": 43001006,
       "Entries": [
-        "それでは、その器のあるべき場所に、お主を案内しよう"
+        "Now, let us take that vessel on a journey."
       ]
     },
     {
       "ID": 43001007,
       "Entries": [
-        "準備はよいな。では、じっとしておれよ！"
+        "I assume that you are ready. Now, be still!"
       ]
     },
     {
       "ID": 43001010,
       "Entries": [
-        "ここは、大王グウィンの後継を迎える、神域じゃ"
+        "This is the Firelink Chamber, for the successor of Lord Gwyn."
       ]
     },
     {
       "ID": 43001011,
       "Entries": [
-        "さあ、その台に、王の器を置くがよい"
+        "Now, place the Lordvessel on the altar."
       ]
     },
     {
       "ID": 43001100,
       "Entries": [
-        "どうしたのじゃ。その台に、王の器を置くがよい"
+        "What is it? Place the Lordvessel on the altar."
       ]
     },
     {
       "ID": 43001101,
       "Entries": [
-        "ここまできて躊躇するものでもないじゃろう"
+        "No reason for pause at this point."
       ]
     },
     {
       "ID": 43001200,
       "Entries": [
-        "よろしい"
+        "Very well."
       ]
     },
     {
       "ID": 43001201,
       "Entries": [
-        "では、わしフラムトが、王の器であるお主に、探索者として次の使命を伝えよう"
+        "As Kingseeker, I shall now instruct you, the Lord's successor, in\nyour next task."
       ]
     },
     {
       "ID": 43001202,
       "Entries": [
-        "お主が、大王グウィンを継ぐには、偉大なソウルでその器を満たさねばらぬ"
+        "To achieve your fate, fill the vessel with powerful souls,"
       ]
     },
     {
       "ID": 43001203,
       "Entries": [
-        "だが、かの王のソウルは、際立って巨大なもの…"
+        "commensurate to the great soul of Gwyn."
       ]
     },
     {
       "ID": 43001204,
       "Entries": [
-        "よって、王の器を満たしうるソウルを持つものは、幾人も無い"
+        "Scarce few possess such brilliant souls."
       ]
     },
     {
       "ID": 43001205,
       "Entries": [
-        "すなわち、グウィンと同じ要のソウルの王、墓王ニトとイザリスの魔女"
+        "Gravelord Nito, the Witch of Izalith,"
       ]
     },
     {
       "ID": 43001206,
       "Entries": [
-        "そして、グウィンのソウルを分け与えられた、小ロンドの王たちと…"
+        "the Four Kings of New Londo, who inherited the shards of Gwyn's\nsoul..."
       ]
     },
     {
       "ID": 43001207,
       "Entries": [
-        "かつての大王の盟友、白竜シース…"
+        "and Lord Gwyn's former confidant, Seath the Scaleless."
       ]
     },
     {
       "ID": 43001208,
       "Entries": [
-        "王の器を満たすためには、それらすべてのソウルが必要じゃ"
+        "All of their souls are required to satiate the Lordvessel."
       ]
     },
     {
       "ID": 43001209,
       "Entries": [
-        "…"
+        "..."
       ]
     },
     {
       "ID": 43001210,
       "Entries": [
-        "よいかな"
+        "Are you ready?"
       ]
     },
     {
       "ID": 43001211,
       "Entries": [
-        "それでは、戻るとしよう。じっとしておれよ！"
+        "Then we shall return. Stay still for a moment!"
       ]
     },
     {
       "ID": 43001300,
       "Entries": [
-        "目的のソウルを持つものたちは、何れも、既に役目を追え、あるいは道を誤っておる"
+        "The beings who possess these souls have outlived their\nusefulness, or have chosen the path of the wicked."
       ]
     },
     {
       "ID": 43001301,
       "Entries": [
-        "それらを倒し、ソウルを奪うことは、世界の蛇が認める、正しい行為なのじゃ"
+        "As the primordial serpent, I implore you to defeat them, and\nclaim their souls."
       ]
     },
     {
       "ID": 43001302,
       "Entries": [
-        "お主が気にかけることなど、なにもない。迷うでないぞ"
+        "Let there be no guilt; let there be no vacillation."
       ]
     },
     {
       "ID": 43001350,
       "Entries": [
-        "目的のソウルを持つものたちは、何れも、既に役目を追え、あるいは道を誤っておる"
+        "The beings who possess these souls have outlived their\nusefulness, or have chosen the path of the wicked."
       ]
     },
     {
       "ID": 43001351,
       "Entries": [
-        "それらを倒し、ソウルを奪うことは、世界の蛇が認める、正しい行為なのじゃ"
+        "As the primordial serpent, I implore you to defeat them, and\nclaim their souls."
       ]
     },
     {
       "ID": 43001352,
       "Entries": [
-        "お主が気にかけることなど、なにもない。迷うでないぞ"
+        "Let there be no guilt; let there be no vacillation."
       ]
     },
     {
       "ID": 43001400,
       "Entries": [
-        "よかろう"
+        "Very well."
       ]
     },
     {
       "ID": 43001401,
       "Entries": [
-        "では、じっとしておれよ！"
+        "Then, stay still for a moment!"
       ]
     },
     {
       "ID": 43001500,
       "Entries": [
-        "もうよいのか"
+        "Are you ready?"
       ]
     },
     {
       "ID": 43001501,
       "Entries": [
-        "それでは、戻るとしよう。じっとしておれよ！"
+        "Then we shall return. Stay still, then!"
       ]
     },
     {
       "ID": 43001600,
       "Entries": [
-        "おお…おお…"
+        "Ahh...ohh!"
       ]
     },
     {
       "ID": 43001601,
       "Entries": [
-        "遂に、王の器が満ちた…"
+        "The Lordvessel is satiated..."
       ]
     },
     {
       "ID": 43001602,
       "Entries": [
-        "すばらしい…お主は正に、グウィンの後継、新しい大王じゃ…"
+        "Magnificent...You are the righteous successor to Gwyn, the new\nGreat Lord."
       ]
     },
     {
       "ID": 43001603,
       "Entries": [
-        "だが、探索者の役目は、ここまでじゃ…"
+        "And I am Kingseeker no more..."
       ]
     },
     {
       "ID": 43001604,
       "Entries": [
-        "お主に出会って、楽しかった"
+        "Your acquaintance was an honour."
       ]
     },
     {
       "ID": 43001605,
       "Entries": [
-        "やはりわしは、人が好きじゃ"
+        "I must admit, I am fond of you humans."
       ]
     },
     {
       "ID": 43001606,
       "Entries": [
-        "成就を、願っているぞ…"
+        "May you enjoy serendipity,"
       ]
     },
     {
       "ID": 43001607,
       "Entries": [
-        "火の時代を終わらせてはならぬ…"
+        "And may the Age of Fire perpetuate."
       ]
     },
     {
       "ID": 43001700,
       "Entries": [
-        "むっ！"
+        "Hmg!"
       ]
     },
     {
       "ID": 43001710,
       "Entries": [
-        "ぬっ！"
+        "Hrg!"
       ]
     },
     {
       "ID": 43001720,
       "Entries": [
-        "おっ！"
+        "Agh!"
       ]
     },
     {
       "ID": 43001730,
       "Entries": [
-        "うおっ！"
+        "Ooph!"
       ]
     },
     {
       "ID": 43001800,
       "Entries": [
-        "やめろ！"
+        "Cease."
       ]
     },
     {
       "ID": 43001801,
       "Entries": [
-        "やめんか！"
+        "Enough."
       ]
     },
     {
       "ID": 43001802,
       "Entries": [
-        "この愚か者が！"
+        "Infidel."
       ]
     },
     {
       "ID": 43001900,
       "Entries": [
-        "愚か者が…お主などが、不死の英雄であるはずもない"
+        "You sorry fool...You could not be the Chosen one."
       ]
     },
     {
       "ID": 43001901,
       "Entries": [
-        "もうよい…もう眠り、再びの目覚めを待つとしよう…"
+        "Enough...I shall slumber, until I am awakened again..."
       ]
     },
     {
       "ID": 43011700,
       "Entries": [
-        "むっ！"
+        "Hmg!"
       ]
     },
     {
       "ID": 43011710,
       "Entries": [
-        "ぬっ！"
+        "Hrg!"
       ]
     },
     {
       "ID": 43011720,
       "Entries": [
-        "おっ！"
+        "Agh!"
       ]
     },
     {
       "ID": 43011730,
       "Entries": [
-        "うおっ！"
+        "Ooph!"
       ]
     },
     {
       "ID": 43011800,
       "Entries": [
-        "やめろ！"
+        "Cease."
       ]
     },
     {
       "ID": 43011801,
       "Entries": [
-        "やめんか！"
+        "Enough."
       ]
     },
     {
       "ID": 43011802,
       "Entries": [
-        "この愚か者が！"
+        "Infidel."
       ]
     },
     {
       "ID": 43011900,
       "Entries": [
-        "愚か者が…お主などが、不死の英雄であるはずもない"
+        "You sorry fool...You could not be the Chosen one."
       ]
     },
     {
       "ID": 43011901,
       "Entries": [
-        "もうよい…もう眠り、再びの目覚めを待つとしよう…"
+        "Enough...I shall slumber, until I am awakened again..."
       ]
     },
     {
       "ID": 44000000,
       "Entries": [
-        "…ようこそ、不死の勇者よ"
+        "Greetings, Undead warrior."
       ]
     },
     {
       "ID": 44000001,
       "Entries": [
-        "我は、世界の蛇、闇撫でのカアス"
+        "I am the primordial serpent Darkstalker Kaathe."
       ]
     },
     {
       "ID": 44000002,
       "Entries": [
-        "貴公ら人を導き、真実を伝える者だ"
+        "I can guide thee, and illuminate the truth."
       ]
     },
     {
       "ID": 44000003,
       "Entries": [
-        "四人の小王を滅ぼした、不死の勇者よ。知りたくはないか？"
+        "Undead Warrior, conqueror of the Four Kings; is this not your\nwish?"
       ]
     },
     {
       "ID": 44000004,
       "Entries": [
-        "貴公ら人と、不死の真実を"
+        "To know the truth of men, and the Undead?"
       ]
     },
     {
       "ID": 44000010,
       "Entries": [
-        "…ようこそ、不死の勇者よ"
+        "Greetings, Undead warrior."
       ]
     },
     {
       "ID": 44000011,
       "Entries": [
-        "我は、世界の蛇、闇撫でのカアス"
+        "I am the primordial serpent Darkstalker Kaathe."
       ]
     },
     {
       "ID": 44000012,
       "Entries": [
-        "貴公ら人を導き、真実を伝える者だ"
+        "I can guide thee, and illuminate the truth."
       ]
     },
     {
       "ID": 44000013,
       "Entries": [
-        "では、我は隠さず真実を語ろう"
+        "The truth I shall share, without sentiment."
       ]
     },
     {
       "ID": 44000014,
       "Entries": [
-        "…かつて火のはじまり、貴公ら人の先祖は"
+        "After the advent of Fire, the ancient Lords found the three\nsouls. "
       ]
     },
     {
       "ID": 44000015,
       "Entries": [
-        "古い王たちの後に、四つ目のソウルを見出した"
+        "But your progenitor found a fourth, unique soul."
       ]
     },
     {
       "ID": 44000016,
       "Entries": [
-        "闇のソウルだ"
+        "The Dark Soul."
       ]
     },
     {
       "ID": 44000017,
       "Entries": [
-        "貴公らの人の先祖は、闇のソウルを得て、火の後を待った"
+        "Your ancestor claimed the Dark Soul, and waited for Fire to\nsubside."
       ]
     },
     {
       "ID": 44000018,
       "Entries": [
-        "やがて火は消え、闇ばかりが残る"
+        "And soon, the flames did fade, and only Dark remained."
       ]
     },
     {
       "ID": 44000019,
       "Entries": [
-        "さすれば、貴公ら人、闇の時代だ"
+        "Thus began the age of men, the Age of Dark."
       ]
     },
     {
       "ID": 44000020,
       "Entries": [
-        "…だが"
+        "However..."
       ]
     },
     {
       "ID": 44000021,
       "Entries": [
-        "王グウィンは、闇を恐れた"
+        "Lord Gwyn trembled at the Dark."
       ]
     },
     {
       "ID": 44000022,
       "Entries": [
-        "火の終わりを恐れ、闇の者たる人を恐れ"
+        "Clinging to his Age of Fire, and in dire fear of humans,"
       ]
     },
     {
       "ID": 44000023,
       "Entries": [
-        "人の間から生まれるであろう、闇の王を恐れ"
+        "and the Dark Lord who would one day be born amongst them,"
       ]
     },
     {
       "ID": 44000024,
       "Entries": [
-        "世界の理を恐れた"
+        "Lord Gwyn resisted the course of nature."
       ]
     },
     {
       "ID": 44000025,
       "Entries": [
-        "だから奴は、火を継ぎ、自らの息子たちに、人を率い、縛らせた"
+        "By sacrificing himself to link the Fire, and commanding his\nchildren to shepherd the humans,"
       ]
     },
     {
       "ID": 44000026,
       "Entries": [
-        "貴公ら人が、すべて忘れ、呆け、闇の王が生まれぬように"
+        "Gwyn has blurred your past, to prevent the birth of the Dark\nLord."
       ]
     },
     {
       "ID": 44000027,
       "Entries": [
-        "…我は世界の蛇"
+        "I am the primordial serpent."
       ]
     },
     {
       "ID": 44000028,
       "Entries": [
-        "正しい時代を、王を探すもの"
+        "I seek to right the wrongs of the past, to discover our true\nLord."
       ]
     },
     {
       "ID": 44000029,
       "Entries": [
-        "だが、もう1人の蛇、フラムトは、理を忘れ、王グウィンの友に堕した"
+        "But the other serpent, Frampt, lost his sense, and befriended\nLord Gwyn."
       ]
     },
     {
       "ID": 44000030,
       "Entries": [
-        "よいか、不死の勇者よ"
+        "Undead Warrior, we stand at a crossroads."
       ]
     },
     {
       "ID": 44000031,
       "Entries": [
-        "我カアスが、貴公に、正しい使命を伝えよう"
+        "Only I know the truth about your fate."
       ]
     },
     {
       "ID": 44000032,
       "Entries": [
-        "理に反して火を継ぎ、今や消えかけの王グウィンを殺し"
+        "You must destroy the fading Lord Gwyn, who has coddled Fire and\nresisted nature,"
       ]
     },
     {
       "ID": 44000033,
       "Entries": [
-        "そして、四人目の王となり、闇の時代をもたらすのだ"
+        "and become the Fourth Lord, so that you may usher in an Age of\nDark!"
       ]
     },
     {
       "ID": 44000100,
       "Entries": [
-        "よい答えだ、不死の勇者よ"
+        "A wise choice, Undead warrior."
       ]
     },
     {
       "ID": 44000101,
       "Entries": [
-        "だが、貴公はまず、我カアスの真実に値するを、証明せねばならん"
+        "Prove you must, that the truth becomes you."
       ]
     },
     {
       "ID": 44000102,
       "Entries": [
-        "アノール・ロンドに向かうがよい"
+        "Seek Anor Londo."
       ]
     },
     {
       "ID": 44000103,
       "Entries": [
-        "そして、グウィンの遺物、王の器を手に入れるのだ"
+        "And claim Gwyn's heirloom, the Lordvessel."
       ]
     },
     {
       "ID": 44000200,
       "Entries": [
-        "よい答えだ、不死の勇者よ"
+        "A wise choice, Undead warrior."
       ]
     },
     {
       "ID": 44000201,
       "Entries": [
-        "だが、貴公はまず、我カアスの真実に値するを、証明せねばならん"
+        "Prove you must, that the truth becomes you."
       ]
     },
     {
       "ID": 44000202,
       "Entries": [
-        "アノール・ロンドに向かうがよい"
+        "Seek Anor Londo."
       ]
     },
     {
       "ID": 44000203,
       "Entries": [
-        "そして、グウィンの遺物、王の器を手に入れるのだ"
+        "And claim Gwyn's heirloom, the Lordvessel."
       ]
     },
     {
       "ID": 44000204,
       "Entries": [
-        "さあ、向かうがよい、不死の勇者よ"
+        "Now go, Undead warrior."
       ]
     },
     {
       "ID": 44000205,
       "Entries": [
-        "そして証明するのだ。貴公が、真実に値することを"
+        "Show the world that the truth becomes you."
       ]
     },
     {
       "ID": 44000400,
       "Entries": [
-        "…"
+        "..."
       ]
     },
     {
       "ID": 44000401,
       "Entries": [
-        "…まあ、よい"
+        "...Very well."
       ]
     },
     {
       "ID": 44000402,
       "Entries": [
-        "久しぶりの勇者だ、しばらくは、待つとしよう"
+        "Warriors as yourself are few. I will be patient."
       ]
     },
     {
       "ID": 44000403,
       "Entries": [
-        "しばらくはな…"
+        "But I cannot wait forever..."
       ]
     },
     {
       "ID": 44000500,
       "Entries": [
-        "貴公…"
+        "Ahh..."
       ]
     },
     {
       "ID": 44000501,
       "Entries": [
-        "貴公が望むのならば、我が力をも授けよう"
+        "If you wish, I shall grant the art of Lifedrain,"
       ]
     },
     {
       "ID": 44000502,
       "Entries": [
-        "闇の王の力、生命喰いの力だ"
+        "the legendary power of the Dark Lord."
       ]
     },
     {
       "ID": 44000503,
       "Entries": [
-        "その力で、不死として人であり続け"
+        "It can preserve your humanity while Undead,"
       ]
     },
     {
       "ID": 44000504,
       "Entries": [
-        "貴公ら人にはめられた、神の枷をはずすがよい"
+        "and cast off the shackles placed upon your brethren."
       ]
     },
     {
       "ID": 44000550,
       "Entries": [
-        "貴公…"
+        "Ahh..."
       ]
     },
     {
       "ID": 44000551,
       "Entries": [
-        "貴公が望むのならば、我が力をも授けよう"
+        "If you wish, I shall grant the art of Lifedrain,"
       ]
     },
     {
       "ID": 44000552,
       "Entries": [
-        "闇の王の力、生命喰いの力だ"
+        "the legendary power of the Dark Lord."
       ]
     },
     {
       "ID": 44000553,
       "Entries": [
-        "その力で、不死として人であり続け"
+        "It can preserve your humanity while Undead,"
       ]
     },
     {
       "ID": 44000554,
       "Entries": [
-        "貴公ら人にはめられた、神の枷をはずすがよい"
+        "and cast off the shackles placed upon your brethren."
       ]
     },
     {
       "ID": 44000600,
       "Entries": [
-        "どうした？"
+        "What is it?"
       ]
     },
     {
       "ID": 44000601,
       "Entries": [
-        "我は貴公の後見"
+        "I am your guardian."
       ]
     },
     {
       "ID": 44000602,
       "Entries": [
-        "なんなりと、望みのたけを申すがよい"
+        "Go on, state your wish."
       ]
     },
     {
       "ID": 44000650,
       "Entries": [
-        "どうした？"
+        "What is it?"
       ]
     },
     {
       "ID": 44000651,
       "Entries": [
-        "我は貴公の後見"
+        "I am your guardian."
       ]
     },
     {
       "ID": 44000652,
       "Entries": [
-        "なんなりと、望みのたけを申すがよい"
+        "Go on, state your wish."
       ]
     },
     {
       "ID": 44000700,
       "Entries": [
-        "どうした？"
+        "What is it?"
       ]
     },
     {
       "ID": 44000701,
       "Entries": [
-        "あるいは、気が変わったのかな？"
+        "Perhaps you have changed your mind?"
       ]
     },
     {
       "ID": 44000800,
       "Entries": [
-        "さらばだ"
+        "Farewell."
       ]
     },
     {
       "ID": 44000850,
       "Entries": [
-        "さらばだ"
+        "Farewell."
       ]
     },
     {
       "ID": 44000900,
       "Entries": [
-        "ふむ…貴公、見事だ"
+        "Hmm...You are astonishing."
       ]
     },
     {
       "ID": 44000901,
       "Entries": [
-        "では、我は隠さず真実を語ろう"
+        "The truth I shall share, without sentiment."
       ]
     },
     {
       "ID": 44000902,
       "Entries": [
-        "…かつて火のはじまり、貴公ら人の先祖は"
+        "After the advent of Fire, the ancient Lords found the three\nsouls. "
       ]
     },
     {
       "ID": 44000903,
       "Entries": [
-        "古い王たちの後に、四つ目のソウルを見出した"
+        "But your progenitor found a fourth, unique soul."
       ]
     },
     {
       "ID": 44000904,
       "Entries": [
-        "闇のソウルだ"
+        "The Dark Soul."
       ]
     },
     {
       "ID": 44000905,
       "Entries": [
-        "貴公らの人の先祖は、闇のソウルを得て、火の後を待った"
+        "Your ancestor claimed the Dark Soul, and waited for Fire to\nsubside."
       ]
     },
     {
       "ID": 44000906,
       "Entries": [
-        "やがて火は消え、闇ばかりが残る"
+        "And soon, the flames did fade, and only Dark remained."
       ]
     },
     {
       "ID": 44000907,
       "Entries": [
-        "さすれば、貴公ら人、闇の時代だ"
+        "Thus began the age of men, the Age of Dark."
       ]
     },
     {
       "ID": 44000908,
       "Entries": [
-        "…だが"
+        "However..."
       ]
     },
     {
       "ID": 44000909,
       "Entries": [
-        "王グウィンは、闇を恐れた"
+        "Lord Gwyn trembled at the Dark."
       ]
     },
     {
       "ID": 44000910,
       "Entries": [
-        "火の終わりを恐れ、闇の者たる人を恐れ"
+        "Clinging to his Age of Fire, and in dire fear of humans,"
       ]
     },
     {
       "ID": 44000911,
       "Entries": [
-        "人の間から生まれるであろう、闇の王を恐れ"
+        "and the Dark Lord who would one day be born amongst them,"
       ]
     },
     {
       "ID": 44000912,
       "Entries": [
-        "世界の理を恐れた"
+        "Lord Gwyn resisted the course of nature."
       ]
     },
     {
       "ID": 44000913,
       "Entries": [
-        "だから奴は、火を継ぎ、自らの息子たちに、人を率い、縛らせた"
+        "By sacrificing himself to link the Fire, and commanding his\nchildren to shepherd the humans,"
       ]
     },
     {
       "ID": 44000914,
       "Entries": [
-        "貴公ら人が、すべて忘れ、呆け、闇の王が生まれぬように"
+        "Gwyn has blurred your past, to prevent the birth of the Dark\nLord."
       ]
     },
     {
       "ID": 44000915,
       "Entries": [
-        "…我は世界の蛇"
+        "I am the primordial serpent."
       ]
     },
     {
       "ID": 44000916,
       "Entries": [
-        "正しい時代を、王を探すもの"
+        "I seek to right the wrongs of the past, to discover our true\nLord."
       ]
     },
     {
       "ID": 44000917,
       "Entries": [
-        "だが、もう1人の蛇、フラムトは、理を忘れ、王グウィンの友に堕した"
+        "But the other serpent, Frampt, lost his sense, and befriended\nLord Gwyn."
       ]
     },
     {
       "ID": 44000918,
       "Entries": [
-        "よいか、不死の勇者よ"
+        "Undead Warrior, we stand at a crossroads."
       ]
     },
     {
       "ID": 44000919,
       "Entries": [
-        "我カアスが、貴公に、正しい使命を伝えよう"
+        "Only I know the truth about your fate."
       ]
     },
     {
       "ID": 44000920,
       "Entries": [
-        "理に反して火を継ぎ、今や消えかけの王グウィンを殺し"
+        "You must destroy the fading Lord Gwyn, who has coddled Fire and\nresisted nature,"
       ]
     },
     {
       "ID": 44000921,
       "Entries": [
-        "そして、四人目の王となり、闇の時代をもたらすのだ"
+        "and become the Fourth Lord, so that you may usher in an Age of\nDark!"
       ]
     },
     {
       "ID": 44001000,
       "Entries": [
-        "よろしい！"
+        "Very well!"
       ]
     },
     {
       "ID": 44001001,
       "Entries": [
-        "されば、我は貴公を、グウィンの棺に導くとしよう"
+        "I shall now guide you to Gwyn's prison."
       ]
     },
     {
       "ID": 44001002,
       "Entries": [
-        "動くでないぞ。我に身を任せればよい"
+        "Be still. Entrust thine flesh to me."
       ]
     },
     {
       "ID": 44001010,
       "Entries": [
-        "…ここが、グウィンの棺だ"
+        "This is Gwyn's prison."
       ]
     },
     {
       "ID": 44001011,
       "Entries": [
-        "さて、王の器を、その台に置くがよい"
+        "Now, place the Lordvessel upon the altar."
       ]
     },
     {
       "ID": 44001100,
       "Entries": [
-        "どうした？王の器を、その台に置くがよい"
+        "What is it? Place the Lordvessel upon the altar."
       ]
     },
     {
       "ID": 44001200,
       "Entries": [
-        "それでよい"
+        "Very well."
       ]
     },
     {
       "ID": 44001201,
       "Entries": [
-        "後は、その器をソウルで満たし、グウィンへの扉を開くだけだ"
+        "Once the vessel is filled with souls, the gate to Gwyn shall\nopen."
       ]
     },
     {
       "ID": 44001202,
       "Entries": [
-        "墓王ニト、イザリスの魔女、それに、あの裏切り者、白竜シース"
+        "Seek Gravelord Nito, the Witch of Izalith, and the traitor Seath\nthe Scaleless."
       ]
     },
     {
       "ID": 44001203,
       "Entries": [
-        "奴らのソウルを集め、この器に献じるのだ"
+        "Fill this vessel with their souls."
       ]
     },
     {
       "ID": 44001204,
       "Entries": [
-        "されば扉は開き…後は、貴公がグウィンを殺せばよい"
+        "Then, the gate will open...so that you may kill Gwyn."
       ]
     },
     {
       "ID": 44001205,
       "Entries": [
-        "…"
+        "..."
       ]
     },
     {
       "ID": 44001206,
       "Entries": [
-        "よろしいか？"
+        "Are you ready?"
       ]
     },
     {
       "ID": 44001207,
       "Entries": [
-        "では、深淵に戻るとしよう。また、我に身を任せればよい"
+        "Then, let us return to the Abyss. Entrust thine flesh to me."
       ]
     },
     {
       "ID": 44001300,
       "Entries": [
-        "なんと！"
+        "Nonsense!"
       ]
     },
     {
       "ID": 44001301,
       "Entries": [
-        "貴公、正気か！なんと嘆かわしい！"
+        "Are you mad! This is deplorable!"
       ]
     },
     {
       "ID": 44001302,
       "Entries": [
-        "もはや神の奴隷か！真実の価値も分からんとは！"
+        "You would rather be a slave? Does the truth mean nothing to you?"
       ]
     },
     {
       "ID": 44001303,
       "Entries": [
-        "まったく！なんと！なんということだ！"
+        "This is unacceptable! Impossible! Unthinkable!"
       ]
     },
     {
       "ID": 44001304,
       "Entries": [
-        "…"
+        "..."
       ]
     },
     {
       "ID": 44001305,
       "Entries": [
-        "…まあ、よい"
+        "...Oh, enough with you."
       ]
     },
     {
       "ID": 44001306,
       "Entries": [
-        "さらばだ、忘れ呆けた愚か者よ"
+        "Farewell, pitiful, unknowing fool."
       ]
     },
     {
       "ID": 44001307,
       "Entries": [
-        "我は再び深淵に潜り、人の王を待つとしよう…"
+        "I shall return to the Abyss, and await the true Lord of Men."
       ]
     },
     {
       "ID": 44001400,
       "Entries": [
-        "よろしい"
+        "Very well."
       ]
     },
     {
       "ID": 44001401,
       "Entries": [
-        "では、動くでないぞ。我に身を任せればよい"
+        "Be still. Entrust thy flesh to me."
       ]
     },
     {
       "ID": 44001500,
       "Entries": [
-        "よろしいか？"
+        "Are you ready?"
       ]
     },
     {
       "ID": 44001501,
       "Entries": [
-        "では、深淵に戻るとしよう。また、我に身を任せればよい"
+        "Then, let us return to the Abyss. Entrust thine flesh to me."
       ]
     },
     {
       "ID": 44001600,
       "Entries": [
-        "見事だ…"
+        "Magnificent."
       ]
     },
     {
       "ID": 44001601,
       "Entries": [
-        "我、世界の蛇の導きに、よくぞ応えた"
+        "You have followed my teachings faithfully."
       ]
     },
     {
       "ID": 44001602,
       "Entries": [
-        "貴公こそ、真に人の王、闇の王よ"
+        "You are the true lord of men, the Dark Lord."
       ]
     },
     {
       "ID": 44001603,
       "Entries": [
-        "さあ、進むがよい。消えかけのグウェンを殺すのだ"
+        "Now, go forth, and rid us of that enfeebled Gwyn."
       ]
     },
     {
       "ID": 44001604,
       "Entries": [
-        "我カアスは、ここで待っているぞ"
+        "I, Kaathe, shall await you here."
       ]
     },
     {
       "ID": 44001700,
       "Entries": [
-        "よくぞ戻られました、我が王よ"
+        "My Lord, bless thy safe return."
       ]
     },
     {
       "ID": 44001701,
       "Entries": [
-        "我ら集い、貴方に仕えます"
+        "We are here to serve Your Highness."
       ]
     },
     {
       "ID": 44001702,
       "Entries": [
-        "それでは、世界に、真の闇を…"
+        "Let true Dark be cast upon the world."
       ]
     },
     {
       "ID": 44001703,
       "Entries": [
-        "我が王よ…"
+        "Our Lord hath returned'st..."
       ]
     },
     {
       "ID": 44001800,
       "Entries": [
-        "不死の勇者よ"
+        "Undead warrior,"
       ]
     },
     {
       "ID": 44001801,
       "Entries": [
-        "今はもう、話すべきではない"
+        "To speak now is premature."
       ]
     },
     {
       "ID": 44001802,
       "Entries": [
-        "すべては、貴公が王の器を持ち帰った、その後だ…"
+        "It begins with your retrieval of the Lordvessel."
       ]
     },
     {
       "ID": 44001850,
       "Entries": [
-        "不死の勇者よ"
+        "Undead warrior,"
       ]
     },
     {
       "ID": 44001851,
       "Entries": [
-        "今はもう、話すべきではない"
+        "To speak now is premature."
       ]
     },
     {
       "ID": 44001852,
       "Entries": [
-        "すべては、貴公が王の器を持ち帰った、その後だ…"
+        "It begins with your retrieval of the Lordvessel."
       ]
     },
     {
       "ID": 44001900,
       "Entries": [
-        "奴らは、だめだった"
+        "They failed me, every last one of them."
       ]
     },
     {
       "ID": 44001901,
       "Entries": [
-        "真実の価値を知らず、ただ力に慢心した"
+        "They were strong, but saw not the truth."
       ]
     },
     {
       "ID": 44001902,
       "Entries": [
-        "…貴公には、期待しておるぞ"
+        "...I am certain that you will prove different."
       ]
     },
     {
       "ID": 44001950,
       "Entries": [
-        "奴らは、だめだった"
+        "They failed me, every last one of them."
       ]
     },
     {
       "ID": 44001951,
       "Entries": [
-        "真実の価値を知らず、ただ力に慢心した"
+        "They were strong, but saw not the truth."
       ]
     },
     {
       "ID": 44001952,
       "Entries": [
-        "…貴公には、期待しておるぞ"
+        "...I am certain that you will prove different."
       ]
     },
     {
       "ID": 44002000,
       "Entries": [
-        "むっ！"
+        "Hmg!"
       ]
     },
     {
       "ID": 44002010,
       "Entries": [
-        "ぬっ！"
+        "Hrg!"
       ]
     },
     {
       "ID": 44002020,
       "Entries": [
-        "おっ！"
+        "Agh!"
       ]
     },
     {
       "ID": 44002030,
       "Entries": [
-        "うおっ！"
+        "Ooph!"
       ]
     },
     {
       "ID": 44002100,
       "Entries": [
-        "やめろ！"
+        "Stop!"
       ]
     },
     {
       "ID": 44002101,
       "Entries": [
-        "やめんか！"
+        "Enough!"
       ]
     },
     {
       "ID": 44002102,
       "Entries": [
-        "この愚か者が！"
+        "Fool!"
       ]
     },
     {
       "ID": 44002200,
       "Entries": [
-        "愚か者が…貴公などが、闇の王であろうはずもない"
+        "Fool...You could not be the Dark Lord."
       ]
     },
     {
       "ID": 44002201,
       "Entries": [
-        "もうよい…さらばだ…"
+        "Enough of this...and farewell to you."
       ]
     },
     {
       "ID": 44002202,
       "Entries": [
-        "我は再び深淵に潜り、人の王を待つとしよう…"
+        "I shall return to the Abyss, and await the true Lord of Men."
       ]
     },
     {
       "ID": 44002300,
       "Entries": [
-        "むっ！"
+        "Hmg!"
       ]
     },
     {
       "ID": 44002310,
       "Entries": [
-        "ぬっ！"
+        "Hrg!"
       ]
     },
     {
       "ID": 44002320,
       "Entries": [
-        "おっ！"
+        "Agh!"
       ]
     },
     {
       "ID": 44002330,
       "Entries": [
-        "うおっ！"
+        "Ooph!"
       ]
     },
     {
       "ID": 44002400,
       "Entries": [
-        "やめろ！"
+        "Stop!"
       ]
     },
     {
       "ID": 44002401,
       "Entries": [
-        "やめんか！"
+        "Enough!"
       ]
     },
     {
       "ID": 44002402,
       "Entries": [
-        "この愚か者が！"
+        "Fool!"
       ]
     },
     {
       "ID": 44002500,
       "Entries": [
-        "愚か者が…貴公などが、闇の王であろうはずもない"
+        "Fool...You could not be the Dark Lord."
       ]
     },
     {
       "ID": 44002501,
       "Entries": [
-        "もうよい…さらばだ…"
+        "Enough of this...and farewell to you."
       ]
     },
     {
       "ID": 44002502,
       "Entries": [
-        "我は再び深淵に潜り、人の王を待つとしよう…"
+        "I shall return to the Abyss, and await the true Lord of Men."
       ]
     },
     {
       "ID": 46000000,
       "Entries": [
-        "あなたは、誰？"
+        "Who art thou?"
       ]
     },
     {
       "ID": 46000001,
       "Entries": [
-        "私たちの仲間では、ないのでしょう？"
+        "One of us, thou art not."
       ]
     },
     {
       "ID": 46000002,
       "Entries": [
-        "もしあやまって、迷い込んだのなら"
+        "If thou hast misstepped into this world,"
       ]
     },
     {
       "ID": 46000003,
       "Entries": [
-        "その先を飛び降りて、戻ってください"
+        "plunge down from the plank, and hurry home."
       ]
     },
     {
       "ID": 46000004,
       "Entries": [
-        "そしてもし、私を求めてきたのなら"
+        "If thou seekest I,"
       ]
     },
     {
       "ID": 46000005,
       "Entries": [
-        "それは許されることでは、ないのです…"
+        "thine desires shall be requited not."
       ]
     },
     {
       "ID": 46000100,
       "Entries": [
-        "あなたは、あなたの世界に戻ってください"
+        "Thou must returneth whence thou came."
       ]
     },
     {
       "ID": 46000101,
       "Entries": [
-        "ここは静かで、皆優しげですが、あなたの世界ではないでしょう？"
+        "This land is peaceful, its inhabitants kind, but thou dost not\nbelong."
       ]
     },
     {
       "ID": 46000102,
       "Entries": [
-        "どうか、その先を飛び降りて、戻ってください"
+        "I beg of thee, plunge down from the plank, and hurry home."
       ]
     },
     {
       "ID": 46000200,
       "Entries": [
-        "あなたも、やはりそうなのですか"
+        "I expected as much from thee."
       ]
     },
     {
       "ID": 46000201,
       "Entries": [
-        "どうして皆、死に急ぐのでしょうか…"
+        "Why dost thee hurry toward thine death?"
       ]
     },
     {
       "ID": 46000300,
       "Entries": [
-        "ああ…"
+        "Ahh..."
       ]
     },
     {
       "ID": 46000301,
       "Entries": [
-        "あなたは、なぜ…何を望むのですか…"
+        "But, why...What seeketh thee?"
       ]
     },
     {
       "ID": 46000400,
       "Entries": [
-        "なぜ、そっとしておいてくれないのです…"
+        "Why could thou not let us be?"
       ]
     },
     {
       "ID": 46000401,
       "Entries": [
-        "そのための、このエレーミアス世界なのでしょう？"
+        "Didst thou not see why Ariamis created this world?"
       ]
     },
     {
       "ID": 47000000,
       "Entries": [
-        "やあ、はじめまして"
+        "Greetings."
       ]
     },
     {
       "ID": 47000001,
       "Entries": [
-        "私はカリムのオズワルド。教戒師さ"
+        "I am Oswald of Carim, the Pardoner."
       ]
     },
     {
       "ID": 47000002,
       "Entries": [
-        "我らの仲間だろう？歓迎するよ"
+        "Thou art a friend. For thee, a warm welcome."
       ]
     },
     {
       "ID": 47000003,
       "Entries": [
-        "君が人として尊厳を保ちたいなら、私に懺悔するとよい"
+        "If thou desireth to preserve thy humanity, then confess thy\nmisdoings to me."
       ]
     },
     {
       "ID": 47000004,
       "Entries": [
-        "あるいは、免罪でも、告罪でも…すべからく、罪は私の領分だよ"
+        "Be it granting absolution, or doling penance; all sin is my\ndomain."
       ]
     },
     {
       "ID": 47000020,
       "Entries": [
-        "やあ、はじめまして"
+        "Greetings."
       ]
     },
     {
       "ID": 47000021,
       "Entries": [
-        "私はカリムのオズワルド。教戒師さ"
+        "I am Oswald of Carim, the Pardoner."
       ]
     },
     {
       "ID": 47000022,
       "Entries": [
-        "君は宗教者ではないようだが…まあ、神は寛大だ"
+        "Thou appearest to lack faith, but the Gods are magnanimous."
       ]
     },
     {
       "ID": 47000023,
       "Entries": [
-        "君が人として尊厳を保ちたいなら、私に懺悔するとよい"
+        "If thou desireth to preserve thy humanity, then confess thy\nmisdoings to me."
       ]
     },
     {
       "ID": 47000024,
       "Entries": [
-        "あるいは、免罪でも、告罪でも…すべからく、罪は私の領分だよ"
+        "Be it granting absolution, or doling penance; all sin is my\ndomain."
       ]
     },
     {
       "ID": 47000100,
       "Entries": [
-        "やあ、また君か"
+        "Greetings, and welcome back."
       ]
     },
     {
       "ID": 47000101,
       "Entries": [
-        "人の尊厳を大事にするのは、よいことだね"
+        "I am pleased to see thee preserving thine humanity."
       ]
     },
     {
       "ID": 47000200,
       "Entries": [
-        "やあ、君か。久しぶりだな"
+        "Greetings, and a pleasure to see thee again."
       ]
     },
     {
       "ID": 47000201,
       "Entries": [
-        "私の助けが必要なのだろう？遠慮することはない"
+        "Art thou in need of mine assistance? Do not be bashful."
       ]
     },
     {
       "ID": 47000300,
       "Entries": [
-        "ああ、君か。どうやら、ぎりぎりのようじゃないか"
+        "Greetings. Just in time, art thee not?"
       ]
     },
     {
       "ID": 47000400,
       "Entries": [
-        "ああ、君か。まさか亡者になってしまうとはな"
+        "Greetings. Well, I did'st not expect to find thee Hollow."
       ]
     },
     {
       "ID": 47000500,
       "Entries": [
-        "人間らしさが欲しければ、いつでもおいでなさい"
+        "When thou art in need of humanity, thou shalt be welcome."
       ]
     },
     {
       "ID": 47000501,
       "Entries": [
-        "私が懺悔を聞いてあげますよ"
+        "I always have an ear for confession."
       ]
     },
     {
       "ID": 47000502,
       "Entries": [
-        "ウフフフフフッ…"
+        "Heh heh heh heh..."
       ]
     },
     {
       "ID": 47000600,
       "Entries": [
-        "罪を侵したら、またおいでなさい"
+        "If thou commiteth a crime, bring thyself back here."
       ]
     },
     {
       "ID": 47000601,
       "Entries": [
-        "何事も、許されない罪などありませんよ…"
+        "There is no misdoing that I cannot undo!"
       ]
     },
     {
       "ID": 47000602,
       "Entries": [
-        "クックックックッ…"
+        "Keh heh heh heh..."
       ]
     },
     {
       "ID": 47000700,
       "Entries": [
-        "告罪符が入用とは…君も、よくよく「善人」ですね…"
+        "Stocking up on Indictments? How honourable of you."
       ]
     },
     {
       "ID": 47000701,
       "Entries": [
-        "ウフフフフフッ…"
+        "Heh heh heh heh..."
       ]
     },
     {
       "ID": 47000800,
       "Entries": [
-        "またいつでもおいでなさい"
+        "Thou art welcome anytime."
       ]
     },
     {
       "ID": 47000801,
       "Entries": [
-        "人に罪はつきものですからね…"
+        "It is only human to commit a sin..."
       ]
     },
     {
       "ID": 47000802,
       "Entries": [
-        "ウフフフフフッ…"
+        "Heh heh heh heh..."
       ]
     },
     {
       "ID": 47000900,
       "Entries": [
-        "ウッ"
+        "Ooph!"
       ]
     },
     {
       "ID": 47000910,
       "Entries": [
-        "グッ"
+        "Hrgt!"
       ]
     },
     {
       "ID": 47000920,
       "Entries": [
-        "ツウッ！"
+        "Arg!"
       ]
     },
     {
       "ID": 47000930,
       "Entries": [
-        "うわっ！"
+        "Oog!"
       ]
     },
     {
       "ID": 47000940,
       "Entries": [
-        "何をします！"
+        "By the Lords!"
       ]
     },
     {
       "ID": 47001000,
       "Entries": [
-        "わかりました…"
+        "Thou hast made thyself clear."
       ]
     },
     {
       "ID": 47001001,
       "Entries": [
-        "そのつもりなら、仕方ありません"
+        "And thou leaveth me no choice."
       ]
     },
     {
       "ID": 47001002,
       "Entries": [
-        "後でゆっくり懺悔なさい！"
+        "I shall accept thy next confession, in the hereafter!"
       ]
     },
     {
       "ID": 47001100,
       "Entries": [
-        "後悔、しますよ…"
+        "Thou shalt regret this..."
       ]
     },
     {
       "ID": 47001101,
       "Entries": [
-        "消えぬ罪に、怯えなさい…"
+        "Fear thine indelible wrongdoings..."
       ]
     },
     {
       "ID": 47001200,
       "Entries": [
-        "まったく、困った人です"
+        "Much trouble hast thou caus'd."
       ]
     },
     {
       "ID": 47001201,
       "Entries": [
-        "弱いものだ。罪の重さに耐えられませんか…"
+        "Thou was weak in spirit, broken by the weight of thy sin."
       ]
     },
     {
       "ID": 47001300,
       "Entries": [
-        "やあ、はじめまして"
+        "Greetings."
       ]
     },
     {
       "ID": 47001301,
       "Entries": [
-        "私はカリムのオズワルド。教戒師さ"
+        "I am Oswald of Carim, the pardoner."
       ]
     },
     {
       "ID": 47001302,
       "Entries": [
-        "我らの仲間だろう？歓迎するよ"
+        "Thou art a friend. For thee, a warm welcome."
       ]
     },
     {
       "ID": 47001303,
       "Entries": [
-        "免罪の懺悔かな？それとも告罪？…すべからく、罪は私の領分だよ"
+        "Cometh thou to confess? Or to accuse? For indeed all sin is my\ndomain."
       ]
     },
     {
       "ID": 47001400,
       "Entries": [
-        "やあ、はじめまして"
+        "Greetings."
       ]
     },
     {
       "ID": 47001401,
       "Entries": [
-        "私はカリムのオズワルド。教戒師さ"
+        "I am Oswald of Carim, the pardoner."
       ]
     },
     {
       "ID": 47001402,
       "Entries": [
-        "君は宗教者ではないようだが…まあ、神は寛大だ"
+        "Thou appearest to lack faith, yet magnanimous are the Gods."
       ]
     },
     {
       "ID": 47001403,
       "Entries": [
-        "免罪の懺悔かな？それとも告罪？…すべからく、罪は私の領分だよ"
+        "Cometh thou to confess? Or to accuse? For indeed all sin is my\ndomain."
       ]
     },
     {
       "ID": 47001600,
       "Entries": [
-        "やあ、また君か"
+        "Good tidings, thou art welcome."
       ]
     },
     {
       "ID": 47001601,
       "Entries": [
-        "深く罪を思うのは、よいことだね"
+        "Laudable is thy dedication to sin."
       ]
     },
     {
       "ID": 47001700,
       "Entries": [
-        "ほう…"
+        "Hmm..."
       ]
     },
     {
       "ID": 47001701,
       "Entries": [
-        "ソルロンドのペトルスと、知り合いなのですか"
+        "Hast thou acquaintance with Petrus of Thorolund?"
       ]
     },
     {
       "ID": 47001702,
       "Entries": [
-        "確かに、あなたとは気が合うのかもしれませんね"
+        "I wager you two hath likely found much in common."
       ]
     },
     {
       "ID": 47001703,
       "Entries": [
-        "彼もまた、罪の深い男ですから…"
+        "For is he not too drenched in sin..."
       ]
     },
     {
       "ID": 47001704,
       "Entries": [
-        "ウフフフフフッ…"
+        "Heh heh heh heh..."
       ]
     },
     {
       "ID": 48000000,
       "Entries": [
-        "ほう、あんた、新顔だね"
+        "Is it not so that thou art new."
       ]
     },
     {
       "ID": 48000001,
       "Entries": [
-        "あたしを見つけるなんて、やるじゃないか"
+        "Thou fared well to find me."
       ]
     },
     {
       "ID": 48000002,
       "Entries": [
-        "まあ、大方あんたも、騎士アルトリウスの噂を聞きつけてきたんだろう？"
+        "But cometh thee not for the grave of Sir Artorias?"
       ]
     },
     {
       "ID": 48000003,
       "Entries": [
-        "でも、すっぱりと諦めるんだね"
+        "My advice true, forget this! "
       ]
     },
     {
       "ID": 48000004,
       "Entries": [
-        "アルトリウスの伝承なんて、実際なんでもありゃあしない"
+        "The legend of Artorias art none but a fabrication."
       ]
     },
     {
       "ID": 48000005,
       "Entries": [
-        "…ただの御伽話だよ…"
+        "...Traversing the dark? 'Tis but a fairy tale."
       ]
     },
     {
       "ID": 48000006,
       "Entries": [
-        "礼ってものがあれば、そんなもののために英雄の墓を穢すこともない。そうだろう？"
+        "Have thine own respect, go not yonder knocking for nothing, I\nsay!"
       ]
     },
     {
       "ID": 48000100,
       "Entries": [
-        "ほう、あんた、面白いね。気に入ったよ"
+        "Well indeed, thou art a strange one! Nevertheless, I feel some\nliking for thee."
       ]
     },
     {
       "ID": 48000101,
       "Entries": [
-        "あたしは黒い森のアルヴィナ"
+        "I'm Alvina of the Darkroot Wood."
       ]
     },
     {
       "ID": 48000102,
       "Entries": [
-        "この森で、墓を穢す侵入者を狩る、狩猟団の長だよ"
+        "I command a clan of hunters who track down defilers of the forest\ngraves."
       ]
     },
     {
       "ID": 48000103,
       "Entries": [
-        "どうだい？あんた、あたしたちの仲間にならないかい？"
+        "What dost thou say? Wilt thou not join us?"
       ]
     },
     {
       "ID": 48000104,
       "Entries": [
-        "あんたなら大歓迎さ"
+        "Oh yes, I believe we would suit thee well."
       ]
     },
     {
       "ID": 48000200,
       "Entries": [
-        "おお、そうかい！"
+        "I am very glad!"
       ]
     },
     {
       "ID": 48000201,
       "Entries": [
-        "だったら決まりだ。早速、誓約を交わそうじゃないか"
+        "And now thou art one of us! Let us establish a Covenant."
       ]
     },
     {
       "ID": 48000210,
       "Entries": [
-        "それと、指輪を渡しておくよ"
+        "And here, taketh this ring."
       ]
     },
     {
       "ID": 48000220,
       "Entries": [
-        "あんたがこの指輪をしていれば、あたしはあんたを召喚できる"
+        "If thou weareth that ring, it allows for thine summoning."
       ]
     },
     {
       "ID": 48000221,
       "Entries": [
-        "侵入者を感じたら召喚するから"
+        "If mine senses reveal intruders, then I will summon thee."
       ]
     },
     {
       "ID": 48000222,
       "Entries": [
-        "あとは好きなように戦って、そいつを追い返してもらえばいい"
+        "Fend them off sir, I beseech only this."
       ]
     },
     {
       "ID": 48000223,
       "Entries": [
-        "他にも、何人か召喚するだろうから、協力するのもいいだろう"
+        "I shall summon others, who will by their honour work tirelessly\nwith thee."
       ]
     },
     {
       "ID": 48000224,
       "Entries": [
-        "報酬もあるし、奪ったものは、全部自分のものにして構わない"
+        "Thou shalt receive great reward, and whatsoever ye shall pillage\nwill be thine own."
       ]
     },
     {
       "ID": 48000225,
       "Entries": [
-        "簡単な話だろう？"
+        "A true agreement, not so?"
       ]
     },
     {
       "ID": 48000226,
       "Entries": [
-        "…ただ、1つだけ掟がある"
+        "But thou must heed the golden rule..."
       ]
     },
     {
       "ID": 48000227,
       "Entries": [
-        "団は家族だ。裏切りは許されない、絶対にね"
+        "The clan is thine own family. To thine kinsmen forever stay true."
       ]
     },
     {
       "ID": 48000228,
       "Entries": [
-        "それだけは覚えておきな"
+        "Dare'st not in any attempt to double-cross. Have no doubt, such\nwretchedness, never will we tolerate."
       ]
     },
     {
       "ID": 48000300,
       "Entries": [
-        "おお、あんたかい。調子はどうだい？"
+        "Ah, thou dost cometh. How fares ye?"
       ]
     },
     {
       "ID": 48000301,
       "Entries": [
-        "あんたには期待してるんだ。しっかり働いとくれよ"
+        "My hopes for thee are of the highest. Do not such a hope shatter\nwith foul disproportion."
       ]
     },
     {
       "ID": 48000302,
       "Entries": [
-        "ああ、これは餞別だよ。とっておきな"
+        "Ah yes, here is thine reward. It is for thee, take it!"
       ]
     },
     {
       "ID": 48000303,
       "Entries": [
-        "亡者になんかなるんじゃないよ"
+        "Make no attempt to show thineself as Hollow!"
       ]
     },
     {
       "ID": 48000320,
       "Entries": [
-        "おお、あんたかい。調子はどうだい？"
+        "Ah, thou dost cometh. How fares ye?"
       ]
     },
     {
       "ID": 48000321,
       "Entries": [
-        "あんたには期待してるんだ。しっかり働いとくれよ"
+        "My hopes for thee are of the highest. Do not such a hope shatter\nwith foul disproportion."
       ]
     },
     {
       "ID": 48000400,
       "Entries": [
-        "おお、あんたかい！"
+        "Oh, thou art present!"
       ]
     },
     {
       "ID": 48000401,
       "Entries": [
-        "きいたよ。すごいらしいじゃないか"
+        "I have heard murmuring about thee. I like that which I hear!"
       ]
     },
     {
       "ID": 48000402,
       "Entries": [
-        "やっぱりあたしの目利きは確かだったね！"
+        "I felt of thou indeed as a special one!"
       ]
     },
     {
       "ID": 48000403,
       "Entries": [
-        "只者じゃあないと思ってたのさ"
+        "The very moment mine eyes first set upon thee."
       ]
     },
     {
       "ID": 48000404,
       "Entries": [
-        "これは特別報酬だよ。とっておきな"
+        "Here's a precious reward. It is for thee, take it."
       ]
     },
     {
       "ID": 48000405,
       "Entries": [
-        "もっと活躍しておくれよ"
+        "May thine skill earn thee many more!"
       ]
     },
     {
       "ID": 48000500,
       "Entries": [
-        "ああ、そうかい。残念だよ"
+        "Oh, I see. 'Tis a pity indeed."
       ]
     },
     {
       "ID": 48000501,
       "Entries": [
-        "けど、あんたの自由だ。仕方ないね"
+        "But this is thine stubborn choice alone. I cannot enforce it upon\nthee."
       ]
     },
     {
       "ID": 48000502,
       "Entries": [
-        "気が変わったら、また声をかけておくれよ"
+        "If thine mind should be alter'd, forsooth speak to me once more."
       ]
     },
     {
       "ID": 48000600,
       "Entries": [
-        "おお、あんたかい"
+        "Oh, thou art here."
       ]
     },
     {
       "ID": 48000601,
       "Entries": [
-        "あたしたちの仲間になる件、考え直してくれたのかい？"
+        "Tell me thou hast thought on't once more and will join us?"
       ]
     },
     {
       "ID": 48000700,
       "Entries": [
-        "ふうん、そうかい"
+        "Hmm, I see. A result most heathenish and gross."
       ]
     },
     {
       "ID": 48000701,
       "Entries": [
-        "だったら、もう話すことはないね"
+        "Then there is nothing more to say about this tedious reckoning."
       ]
     },
     {
       "ID": 48000702,
       "Entries": [
-        "出ていきな。目障りだよ"
+        "Be gone from here. Pernicious caitiff."
       ]
     },
     {
       "ID": 48000800,
       "Entries": [
-        "ひっひっひ、ひーっひっひ！"
+        "Dee hee hee, dee hee hee!"
       ]
     },
     {
       "ID": 48000801,
       "Entries": [
-        "愚かだねえ！愚かだねえ！"
+        "What a fool we have, what a wretched fool we have!"
       ]
     },
     {
       "ID": 48000900,
       "Entries": [
-        "ああ、あんたかい…"
+        "Oh, it is thee..."
       ]
     },
     {
       "ID": 48000901,
       "Entries": [
-        "家族を裏切ったんだ、覚悟はできているね"
+        "Thine kinsmen are betrayed by thee. This doth bode most badly. "
       ]
     },
     {
       "ID": 48000902,
       "Entries": [
-        "これからずっと、あんたは仲間に襲われつづける"
+        "No rest will ease thy rotten soul whilst there is one clansman\nliving..."
       ]
     },
     {
       "ID": 48000903,
       "Entries": [
-        "気の休まるときなんて、永遠にありはしないよ…"
+        "Forever tormented thou shalt be by our very howls..."
       ]
     },
     {
       "ID": 48000904,
       "Entries": [
-        "あんたは、家族を裏切ったんだ…"
+        "Hellish villain, thou hast used us most foully, thine own\nfamily..."
       ]
     },
     {
       "ID": 48000905,
       "Entries": [
-        "容赦しないよ…"
+        "For thee, no mercy shall be shown."
       ]
     },
     {
       "ID": 48001000,
       "Entries": [
-        "そういえば…"
+        "Perchance..."
       ]
     },
     {
       "ID": 48001001,
       "Entries": [
-        "あんた、シバには会ったのかい？"
+        "Hast thou met Shiva?"
       ]
     },
     {
       "ID": 48001002,
       "Entries": [
-        "遠い東の出身らしいけど、すこぶる有能でね。今では団のリーダー格なのさ"
+        "A lad cometh from the far East, strong of arm; now a clan leader\nof ours."
       ]
     },
     {
       "ID": 48001003,
       "Entries": [
-        "…だけどね"
+        "...And yet..."
       ]
     },
     {
       "ID": 48001004,
       "Entries": [
-        "ありゃあ、何かを隠してるね。あたしには分かる"
+        "Still I feel that boy hides something. Of that I am certain."
       ]
     },
     {
       "ID": 48001005,
       "Entries": [
-        "まさか、団を裏切ることはないだろうが…あんたも、気を抜かないことさ"
+        "Small fear that he will use us badly...Yet on guard we must stay."
       ]
     },
     {
       "ID": 48001006,
       "Entries": [
-        "シバにも、影のように従う、あの男にもね…"
+        "And that man that clingeth to Shiva like some shadow...ensure\nthou dost treat him with the same caution."
       ]
     },
     {
       "ID": 52000000,
       "Entries": [
-        "…"
+        "..."
       ]
     },
     {
       "ID": 52000100,
       "Entries": [
-        "…"
+        "..."
       ]
     },
     {
       "ID": 55000000,
       "Entries": [
-        "ねえ、ねえ"
+        "You, you."
       ]
     },
     {
       "ID": 55000001,
       "Entries": [
-        "あったかちょうだい"
+        "Give me, warm."
       ]
     },
     {
       "ID": 55000002,
       "Entries": [
-        "ふわふわちょうだい"
+        "Give me, soft."
       ]
     },
     {
       "ID": 55000100,
       "Entries": [
-        "ねえ！ねえ！"
+        "You! You!"
       ]
     },
     {
       "ID": 55000101,
       "Entries": [
-        "あったかちょうだい！"
+        "Give me! Warm!"
       ]
     },
     {
       "ID": 55000102,
       "Entries": [
-        "ふわふわちょうだい！"
+        "Give me! Soft!"
       ]
     },
     {
       "ID": 55000200,
       "Entries": [
-        "ねえ、ねえ"
+        "No, no."
       ]
     },
     {
       "ID": 55000201,
       "Entries": [
-        "それ、ちがうよ"
+        "That, no."
       ]
     },
     {
       "ID": 55000202,
       "Entries": [
-        "あったかじゃ、ないよ"
+        "That no warm."
       ]
     },
     {
       "ID": 55000203,
       "Entries": [
-        "ふわふわじゃ、ないよ"
+        "That no soft."
       ]
     },
     {
       "ID": 55000300,
       "Entries": [
-        "ねえ、ねえ"
+        "No, no."
       ]
     },
     {
       "ID": 55000301,
       "Entries": [
-        "それ、ちがうよ"
+        "Not that one."
       ]
     },
     {
       "ID": 55000302,
       "Entries": [
-        "もう、いらないよ"
+        "Enough, enough."
       ]
     },
     {
       "ID": 56000000,
       "Entries": [
-        "スー、スー（寝息）"
+        "...Mmn...ahh..."
       ]
     },
     {
       "ID": 56000010,
       "Entries": [
-        "…ああっ…（寝言）"
+        "...Aah...mmn..."
       ]
     },
     {
       "ID": 56000020,
       "Entries": [
-        "…ううっ…（寝言）"
+        "...Hmm...mm..."
       ]
     },
     {
       "ID": 56000100,
       "Entries": [
-        "…笑わないで、聞いてください"
+        "...This may strike thine ear as somewhat peculiar, but..."
       ]
     },
     {
       "ID": 56000101,
       "Entries": [
-        "ずっと昔、故郷ウーラシールで、深淵の化け物に襲われたとき"
+        "Long ago, in my homeland of Oolacile,\nI was beset by a creature from the Abyss."
       ]
     },
     {
       "ID": 56000102,
       "Entries": [
-        "高名な騎士、アルトリウス様に、救って頂いたのです"
+        "I would have perished then,\nwere it not for the great knight Artorias."
       ]
     },
     {
       "ID": 56000103,
       "Entries": [
-        "お恥ずかしい話、私は気を無くしていて…あまりよく覚えていないのですが"
+        "In truth, I saw little of what transpired,\nfor mine senses were already fled!"
       ]
     },
     {
       "ID": 56000104,
       "Entries": [
-        "その、そのときのアルトリウス様の…ご気配というか、そういったものが…"
+        "But even still, there was something about Artorias...\nA certain balance of the humours..."
       ]
     },
     {
       "ID": 56000105,
       "Entries": [
-        "貴方に、とてもよく似ていたように思うのです"
+        "...That quite perfectly fits your semblance."
       ]
     },
     {
       "ID": 56000106,
       "Entries": [
-        "だから、もしや、あの時も貴方が…"
+        "Heavens, could it be that..."
       ]
     },
     {
       "ID": 56000107,
       "Entries": [
-        "…"
+        "..."
       ]
     },
     {
       "ID": 56000108,
       "Entries": [
-        "いえ、そんなことはありませんよね。あれは何百年も前、ウーラシールでのことです"
+        "Oh, dear me. That was Oolacile,\nmany centuries ago."
       ]
     },
     {
       "ID": 56000109,
       "Entries": [
-        "おかしなことを申しました。お忘れください"
+        "Please excuse my fanciful musings. "
       ]
     },
     {
       "ID": 56000200,
       "Entries": [
-        "先日は、おかしなことを申しまして、すみませんでした"
+        "Excuse me for such whimsical utterances."
       ]
     },
     {
       "ID": 56000201,
       "Entries": [
-        "でも、本当に不思議なことです"
+        "Only, it was so very odd..."
       ]
     },
     {
       "ID": 56000202,
       "Entries": [
-        "貴方と、アルトリウス様。私を救って下さったお二人に、同じご気配を感じるのですから"
+        "You, and Artorias. I owe my life to each of you.\nAnd both seem to share some resonance of sorts..."
       ]
     },
     {
       "ID": 56000203,
       "Entries": [
-        "もしかしたら、英雄とは、そのようなものなのかもしれませんね…"
+        "Perhaps it is the nature of true greatness."
       ]
     },
     {
       "ID": 56000300,
       "Entries": [
-        "…以前、深淵の化け物に襲われた話をいたしましたが"
+        "I still think on that creature from the Abyss that preyed upon me."
       ]
     },
     {
       "ID": 56000301,
       "Entries": [
-        "その時、私は気を失くしていて…でも、ひとつだけ、覚えている感情があるんです"
+        "My faculties were far from lucid, but I quite clearly sensed certain emotions."
       ]
     },
     {
       "ID": 56000302,
       "Entries": [
-        "強く、懐かしむ感情…戻らない幸福と、その思い出の品…それを求める思い…"
+        "A wrenching nostalgia, a lost joy, an object of obsession,\nand a sincere hope to reclaim it..."
       ]
     },
     {
       "ID": 56000303,
       "Entries": [
-        "あれは、もしかしたら、深淵の化け物のものでしょうか…"
+        "Could these thoughts belong to the beast from the Abyss?"
       ]
     },
     {
       "ID": 56000304,
       "Entries": [
-        "あのような感情を抱くものを、化け物と呼んでよいのでしょうか…"
+        "But if that were true, then perhaps it is no beast after all?"
       ]
     },
     {
       "ID": 56000305,
       "Entries": [
-        "ああ、おかしな話をすみません"
+        "Oh, please forgive my ramblings."
       ]
     },
     {
       "ID": 56000306,
       "Entries": [
-        "でも、私は、分からないのです…"
+        "It's just that, I wish to know the truth."
       ]
     },
     {
       "ID": 56000307,
       "Entries": [
-        "誰も、優しいエリザベスも、教えてはくれないものですから…"
+        "And no one, not even loving Elizabeth, will tell me."
       ]
     },
     {
       "ID": 56005000,
       "Entries": [
-        "グゥッ…"
+        "Aah..."
       ]
     },
     {
       "ID": 56005010,
       "Entries": [
-        "キャアッ！"
+        "Eek!"
       ]
     },
     {
       "ID": 57000000,
       "Entries": [
-        "…誰かは知らぬが、近づかないほうがよい…"
+        "...Whatever thou art, stay away..."
       ]
     },
     {
       "ID": 57000001,
       "Entries": [
-        "…俺はもうすぐ、闇に…人に…"
+        "...Soon, I will be consumed..."
       ]
     },
     {
       "ID": 57000002,
       "Entries": [
-        "…喰われてしまう…"
+        "...By them, by the Dark..."
       ]
     },
     {
       "ID": 57000003,
       "Entries": [
-        "ウッ"
+        "Oogh..."
       ]
     },
     {
       "ID": 57000004,
       "Entries": [
-        "グウッ"
+        "Grrah!"
       ]
     },
     {
       "ID": 57000005,
       "Entries": [
-        "グウウウウオオオオオオオッ"
+        "Hrgg, hrgggrah!"
       ]
     },
     {
       "ID": 57000100,
       "Entries": [
-        "…見事だ、強い人間よ…"
+        "...Thou art strong, human..."
       ]
     },
     {
       "ID": 57000101,
       "Entries": [
-        "…君たちの本質が、ただ、闇のみでないのなら…"
+        "...Surely thine kind are more than pure Dark..."
       ]
     },
     {
       "ID": 57000102,
       "Entries": [
-        "…お願いだ…深淵を食い止めて、くれ…"
+        "...I beg of thee...the spread of the Abyss...\n...it must be stopped..."
       ]
     },
     {
       "ID": 57000103,
       "Entries": [
-        "グゥッ"
+        "Cough!"
       ]
     },
     {
       "ID": 57000104,
       "Entries": [
-        "…ああ、すまんな、お前たち…シフ…"
+        "...Ah, Sif, there you are, all of you...Forgive me..."
       ]
     },
     {
       "ID": 57000105,
       "Entries": [
-        "…結局、何もできなかったよ…"
+        "...For I have availed you nothing..."
       ]
     },
     {
       "ID": 57005000,
       "Entries": [
-        "グオウッ"
+        "Hrgg..."
       ]
     },
     {
       "ID": 57005001,
       "Entries": [
-        "グオッ、グオオッ"
+        "Hrggraaah!"
       ]
     },
     {
       "ID": 57005002,
       "Entries": [
-        "グオオオオオオッ"
+        "Hrggraaah!"
       ]
     },
     {
       "ID": 57005100,
       "Entries": [
-        "グウッ"
+        "Hrgkt!"
       ]
     },
     {
       "ID": 57005101,
       "Entries": [
-        "グエッ"
+        "Ergkt!"
       ]
     },
     {
       "ID": 57005102,
       "Entries": [
-        "グオウッ"
+        "Hrgg!"
       ]
     },
     {
       "ID": 57005200,
       "Entries": [
-        "グオワアアアアッ"
+        "Hrggraaah!"
       ]
     },
     {
       "ID": 57005201,
       "Entries": [
-        "グオエエエエエッ"
+        "Hrggraaah!"
       ]
     },
     {
       "ID": 57005202,
       "Entries": [
-        "グギャアアアアッ"
+        "Hrggraaah!"
       ]
     },
     {
       "ID": 58000000,
       "Entries": [
-        "ほう、訪問者とは、珍しいこともあるものだ"
+        "Hm? A visitor, have we?"
       ]
     },
     {
       "ID": 58000001,
       "Entries": [
-        "もしや、アルトリウスを開放してくれた御人かな"
+        "Thou must be the one who freed Artorias."
       ]
     },
     {
       "ID": 58000002,
       "Entries": [
-        "ならば、古い友の誇りを守ってくれたこと、礼を言わねばなるまい"
+        "An old friend he was, and thanks to thee..."
       ]
     },
     {
       "ID": 58000003,
       "Entries": [
-        "貴公に感謝する"
+        "He left this world with honour intact."
       ]
     },
     {
       "ID": 58000004,
       "Entries": [
-        "…だが、私はもはやモノも見えず、こうして隠居の身"
+        "...And here I am, retired and blind."
       ]
     },
     {
       "ID": 58000005,
       "Entries": [
-        "残念ながら、役たたずであろうが"
+        "Of little help to thee, I am afraid."
       ]
     },
     {
       "ID": 58000100,
       "Entries": [
-        "ほう、また貴公とは。何が珍しいものか…"
+        "Well, thou hast come again. This is a surprise."
       ]
     },
     {
       "ID": 58000200,
       "Entries": [
-        "ほう、また貴公とは。変わった人間もいたものだ"
+        "Well, thou com'st again. Thou art a strange one."
       ]
     },
     {
       "ID": 58000300,
       "Entries": [
-        "ほう、貴公…黒い竜に難儀しているのではないか？"
+        "Good morrow...Is the Black Dragon posing thee duress?"
       ]
     },
     {
       "ID": 58000400,
       "Entries": [
-        "うむ、やはりそうか"
+        "Yes, I thought as much."
       ]
     },
     {
       "ID": 58000401,
       "Entries": [
-        "あれの名はカラミット"
+        "He is called Kalameet."
       ]
     },
     {
       "ID": 58000402,
       "Entries": [
-        "かつてのアノール・ロンドですら見逃した、恐ろしい竜だ"
+        "A ferocious dragon indeed, even mighty Anor Londo dared not provoke his ire."
       ]
     },
     {
       "ID": 58000403,
       "Entries": [
-        "それに人の身で挑むとは…計り知れるものではないが…"
+        "I see little good coming from this, but..."
       ]
     },
     {
       "ID": 58000404,
       "Entries": [
-        "…だが貴公、諦めるつもりもないのだろう？"
+        "...Thy intent is to persevere... to the bitter end, hmm?"
       ]
     },
     {
       "ID": 58000500,
       "Entries": [
-        "…ふははっ"
+        "Hah hah hah!"
       ]
     },
     {
       "ID": 58000501,
       "Entries": [
-        "よい、よい。無謀だが、確かにそれを勇と言うのだろう"
+        "Good, good. What is bravery, without a dash of recklessness!"
       ]
     },
     {
       "ID": 58000502,
       "Entries": [
-        "気に入った"
+        "I have taken a liking to thee."
       ]
     },
     {
       "ID": 58000503,
       "Entries": [
-        "アルトリウスの礼もある。貴公に、ゴーの竜狩りを見せてやろう"
+        "And I owe thee much for thy service to Artorias.\nNow watch, and see how Gough hunts dragons."
       ]
     },
     {
       "ID": 58000510,
       "Entries": [
-        "むうううううん"
+        "Hrrmmm..."
       ]
     },
     {
       "ID": 58000511,
       "Entries": [
-        "おああっ！"
+        "Haah!"
       ]
     },
     {
       "ID": 58000520,
       "Entries": [
-        "ふはっ、見たか、見事命中だ"
+        "Hah hah! Yes, a truer shot was never loosed!"
       ]
     },
     {
       "ID": 58000521,
       "Entries": [
-        "いかにあれとて、暫くは飛べぬだろう"
+        "That bat will be grounded for a good spell!"
       ]
     },
     {
       "ID": 58000522,
       "Entries": [
-        "あとは貴公の武勇次第。よい知らせを待っておるぞ"
+        "The rest is in thine hands. I await good tidings."
       ]
     },
     {
       "ID": 58000523,
       "Entries": [
-        "竜に挑むは、騎士の誉れよな…"
+        "Ahh, dragon slaying. Knighthood's highest calling..."
       ]
     },
     {
       "ID": 58000600,
       "Entries": [
-        "…そうだったか。おかしいな、私の勘も鈍ったものだ…"
+        "...Strange. I am rarely wrong on such matters..."
       ]
     },
     {
       "ID": 58000700,
       "Entries": [
-        "うむ、それがよかろう。貴公は賢い、愚者の何たるかを知るものだ"
+        "A wise choice. Why foist thyself unto the fiery maw?"
       ]
     },
     {
       "ID": 58000800,
       "Entries": [
-        "貴公、やはり、黒い竜に難儀しているのではないか？"
+        "The Black Dragon troubles you yet, I see."
       ]
     },
     {
       "ID": 58000900,
       "Entries": [
-        "…そうだったか。度々すまんな、おかしなことを…"
+        "...Hmm, yes, I see. I was mistaken..."
       ]
     },
     {
       "ID": 58001000,
       "Entries": [
-        "…もしや貴公、やはり、カラミットに挑むつもりか？"
+        "...Art thou prepared to challenge great Kalameet?"
       ]
     },
     {
       "ID": 58001100,
       "Entries": [
-        "そうだな、それがよかろう"
+        "Yes, surely that is best."
       ]
     },
     {
       "ID": 58001200,
       "Entries": [
-        "ほう、また貴公か。どうだ、カラミットは？"
+        "Ah, hello there. What of Kalameet?"
       ]
     },
     {
       "ID": 58001201,
       "Entries": [
-        "あれも古い竜の末だ。落ちたとて、一筋縄ではいかんだろう"
+        "He is an ancient dragon.\nSkyward or no, he will not be put down easily."
       ]
     },
     {
       "ID": 58001300,
       "Entries": [
-        "貴公…カラミットを狩ったのだろう"
+        "Why, thou hast defeated Kalameet!"
       ]
     },
     {
       "ID": 58001301,
       "Entries": [
-        "すばらしい。世であれば、大王グウィンの叙勲に見える偉業だ"
+        "Wondrously played. Lord Gwyn's blessing upon thee."
       ]
     },
     {
       "ID": 58001302,
       "Entries": [
-        "しかし…なあ…あれももう、二度と空を駆けぬのだなあ…"
+        "That beast will never take to the skies again."
       ]
     },
     {
       "ID": 58001400,
       "Entries": [
-        "さらばだ、人間よ"
+        "Farewell, human."
       ]
     },
     {
       "ID": 58001401,
       "Entries": [
-        "貴公らしく生きるがよい"
+        "Lead thy life as thou seest fit."
       ]
     },
     {
       "ID": 58001500,
       "Entries": [
-        "さらばだ、人間よ"
+        "Farewell, human."
       ]
     },
     {
       "ID": 58001501,
       "Entries": [
-        "よい知らせを待っておるぞ"
+        "I await good tidings."
       ]
     },
     {
       "ID": 58001600,
       "Entries": [
-        "さらばだ、人間の英雄よ"
+        "Farewell, proud human."
       ]
     },
     {
       "ID": 58001601,
       "Entries": [
-        "貴公に誉れのあらんことを"
+        "May every honour be bestowed upon thee."
       ]
     },
     {
       "ID": 58001700,
       "Entries": [
-        "このあたりを旅するのであれば、黒い竜に気をつけるがよい"
+        "If thou seeketh to explore this domain, be wary of a black dragon."
       ]
     },
     {
       "ID": 58001701,
       "Entries": [
-        "あれは…おそらくは貴公とて、人の手に負えるものではないぞ"
+        "I fear thee no match for this terrible beast."
       ]
     },
     {
       "ID": 58001800,
       "Entries": [
-        "そういえば、貴公、アルトリウスを倒したとあれば"
+        "I should confer...If thine was the blade to which Artorias fell."
       ]
     },
     {
       "ID": 58001801,
       "Entries": [
-        "キアランの娘っこには、注意した方がよいぞ"
+        "Then thou must be wary of Ciaran."
       ]
     },
     {
       "ID": 58001802,
       "Entries": [
-        "あれは…おそらく、アルトリウスに特別な感情を抱いておった…"
+        "She had strong feelings for the great Artorias."
       ]
     },
     {
       "ID": 58001803,
       "Entries": [
-        "哀れな娘だ"
+        "The poor, poor girl."
       ]
     },
     {
       "ID": 58001900,
       "Entries": [
-        "なんだ、私の話か"
+        "Me?"
       ]
     },
     {
       "ID": 58001901,
       "Entries": [
-        "そんなもの、面白いことは何もない"
+        "There is very little to be said."
       ]
     },
     {
       "ID": 58001902,
       "Entries": [
-        "兎がいなければ、よい猟犬も不要なものだ"
+        "What good is a dog, with no hares to hunt?"
       ]
     },
     {
       "ID": 58001903,
       "Entries": [
-        "…煮られぬだけ幸運というものさね"
+        "...I am lucky to be alive, I suppose."
       ]
     },
     {
       "ID": 58002000,
       "Entries": [
-        "貴公、勘違いするなよ"
+        "Now, do not mistake my words."
       ]
     },
     {
       "ID": 58002001,
       "Entries": [
-        "私は、これはこれで気に入っている。木彫りも、奥深く楽しいもの"
+        "I cherish my work. Wood carving is a nuanced art."
       ]
     },
     {
       "ID": 58002002,
       "Entries": [
-        "今ならば、あの鍛冶小僧と話もあおうというものだ"
+        "I would have much to talk about with that blacksmith."
       ]
     },
     {
       "ID": 58002003,
       "Entries": [
-        "…そういえば、あ奴、どうしているかのう"
+        "In truth, how is the old chap, I wonder?"
       ]
     },
     {
       "ID": 58002004,
       "Entries": [
-        "木槌をずっと、ふるえていればよいが"
+        "Still hammering away, I should hope."
       ]
     },
     {
       "ID": 58002100,
       "Entries": [
-        "…竜どもはなあ"
+        "The dragons shall never be forgotten..."
       ]
     },
     {
       "ID": 58002101,
       "Entries": [
-        "我ら騎士はあれらに挑み、多くを屠り、また多くの友が倒れた"
+        "We knights fought valiantly, but for every one of them,\nwe lost three score of our own."
       ]
     },
     {
       "ID": 58002102,
       "Entries": [
-        "高揚も、名誉も、恨みも、憎しみも、すべてあれらと共にあったのだ"
+        "Exhilaration, pride, hatred, rage...\nThe dragons teased out\nour dearest emotions."
       ]
     },
     {
       "ID": 58002103,
       "Entries": [
-        "…貴公にも、やがて分かるだろう"
+        "...Thou will understand, one day."
       ]
     },
     {
       "ID": 58002104,
       "Entries": [
-        "夕暮れには、手前勝手な感傷を、しかし抑えがたく懐かしむのだと"
+        "At thy twilight, old thoughts return, in great waves of nostalgia."
       ]
     },
     {
       "ID": 58002200,
       "Entries": [
-        "ああ、この大弓か"
+        "Ahh, this Greatbow?"
       ]
     },
     {
       "ID": 58002201,
       "Entries": [
-        "竜なき今、確かに私には不要のものだ"
+        "I shan't need it, with no dragons to hunt."
       ]
     },
     {
       "ID": 58002202,
       "Entries": [
-        "人の身でひけるものかは分からぬが…貴公に委ねるとしよう"
+        "I know not if a human could even operate it, but here..."
       ]
     },
     {
       "ID": 58002203,
       "Entries": [
-        "僅かでも、貴公の誉れの助けとなればな…"
+        "Thy need outweighs mine."
       ]
     },
     {
       "ID": 58002300,
       "Entries": [
-        "ほう、訪問者とは、珍しいこともあるものだ"
+        "Hm? A visitor, have we?"
       ]
     },
     {
       "ID": 58002301,
       "Entries": [
-        "もしや、アルトリウスを開放してくれた御人かな"
+        "Thou must be the one who freed Artorias."
       ]
     },
     {
       "ID": 58002302,
       "Entries": [
-        "ならば、古い友の誇りを守ってくれたこと、礼を言わねばなるまい"
+        "An old friend he was, and thanks to thee..."
       ]
     },
     {
       "ID": 58002303,
       "Entries": [
-        "貴公に感謝する"
+        "He left this world with honour intact."
       ]
     },
     {
       "ID": 58002304,
       "Entries": [
-        "…それに、あの黒い竜、カラミットを狩ったのも貴公のようだな"
+        "And I see that the great black dragon Kalameet is dusted by thine hand."
       ]
     },
     {
       "ID": 58002305,
       "Entries": [
-        "すばらしい。世であれば、大王グウィンの叙勲に見える偉業だ"
+        "Wondrously played. Lord Gwyn's blessing upon thee."
       ]
     },
     {
       "ID": 58002306,
       "Entries": [
-        "私はもはやモノも見えず、こうして隠居の身だが"
+        "I am retired, and blind."
       ]
     },
     {
       "ID": 58002307,
       "Entries": [
-        "それでも、こうして人の英雄に見えることができるとはな…"
+        "To receive a visit by one as lofty as thyself, is a great honour indeed."
       ]
     },
     {
       "ID": 58002400,
       "Entries": [
-        "ほう、貴公…あの黒い竜、カラミットを狩ったようだな"
+        "I see that thou hast dusted the great black dragon Kalameet."
       ]
     },
     {
       "ID": 58002401,
       "Entries": [
-        "すばらしい。世であれば、大王グウィンの叙勲に見える偉業だ"
+        "Wondrously played. Lord Gwyn's blessing upon thee."
       ]
     },
     {
       "ID": 58002402,
       "Entries": [
-        "貴公こそ、まさに人の英雄と呼ぶべきだろう"
+        "I see that there is at least one legend among ye humans."
       ]
     },
     {
       "ID": 58002403,
       "Entries": [
-        "しかし…なあ…あれももう、二度と空を駆けぬのだなあ…"
+        "Dear me... That old bat will never fly again."
       ]
     },
     {
       "ID": 58002500,
       "Entries": [
-        "よくきたな、人の英雄よ"
+        "Thou com'st again, legend of humans."
       ]
     },
     {
       "ID": 58002501,
       "Entries": [
-        "貴公と話せるのは、嬉しいことだ"
+        "It is always an honour to speak with thee."
       ]
     },
     {
       "ID": 58002600,
       "Entries": [
-        "貴公も、おそらくは目にしているだろうが"
+        "I suspect thou hast taken a gander at it,"
       ]
     },
     {
       "ID": 58002601,
       "Entries": [
-        "友アルトリウスを蝕んだ深淵の闇は、いまやこの国、ウーラシールを飲み込もうとしている"
+        "But the Dark of the Abyss, which swallowed poor Artorias,\nthreatens to devour our entire land of Oolacile."
       ]
     },
     {
       "ID": 58002602,
       "Entries": [
-        "…おそらく、滅びは避けられまい"
+        "It seems that this dire fate is unavoidable."
       ]
     },
     {
       "ID": 58002603,
       "Entries": [
-        "だが、たとえ、闇の蛇に唆されたとて"
+        "But, seduced by a Dark serpent or no,"
       ]
     },
     {
       "ID": 58002604,
       "Entries": [
-        "彼らは自ら望み、あれを起こし、狂わせたのだ"
+        "They awoke that thing themselves, and drove it mad."
       ]
     },
     {
       "ID": 58002605,
       "Entries": [
-        "…滅びは自業というものだよ…"
+        "...One's demise is always one's own making."
       ]
     },
     {
       "ID": 58002700,
       "Entries": [
-        "…貴公、もし友と同じように、深淵の闇を留めんとするのであれば"
+        "If thine wish is to succeed poor Artorias, and challenge the spread of the Dark,"
       ]
     },
     {
       "ID": 58002701,
       "Entries": [
-        "深淵の主、マヌスに挑むがよい"
+        "Then thou must face Manus, Father of the Abyss."
       ]
     },
     {
       "ID": 58002702,
       "Entries": [
-        "…深淵の闇はマヌスより生じている"
+        "The Dark emanates from Manus himself."
       ]
     },
     {
       "ID": 58002703,
       "Entries": [
-        "この国は滅びるとて、それ以上の破滅は、あるいは避けられるだろう"
+        "Even if this land shall expire,\nthou may be able to prevent further corrosion."
       ]
     },
     {
       "ID": 58002704,
       "Entries": [
-        "…しかし、いずれ火は消え、暗闇だけが残る"
+        "...But even so, one day the flames will fade, and only Dark will remain."
       ]
     },
     {
       "ID": 58002705,
       "Entries": [
-        "いかな英雄とて、留めることはできん…"
+        "And even a legend such as thineself can do nothing to stop that."
       ]
     },
     {
       "ID": 58005000,
       "Entries": [
-        "やめたまえ"
+        "Cease this."
       ]
     },
     {
       "ID": 58005010,
       "Entries": [
-        "やめたまえと言っているぞ"
+        "Stop it, I say."
       ]
     },
     {
       "ID": 58005020,
       "Entries": [
-        "分からんか。友の恩人を、屠るつもりもないのだ"
+        "Understand this. I wish thee no harm."
       ]
     },
     {
       "ID": 58005030,
       "Entries": [
-        "やめないか！"
+        "Stop that!"
       ]
     },
     {
       "ID": 58005040,
       "Entries": [
-        "分からんか！"
+        "By the Gods!"
       ]
     },
     {
       "ID": 58005100,
       "Entries": [
-        "やはり人間とはそういうものか"
+        "Ahh, so this is true human nature."
       ]
     },
     {
       "ID": 58005101,
       "Entries": [
-        "友の恩人とて、残念だが仕方ない"
+        "Artorias is in your debt, but thou leavest me little choice..."
       ]
     },
     {
       "ID": 58005102,
       "Entries": [
-        "ここで果てるが皆のためだろう！"
+        "May you perish, for the good of all!"
       ]
     },
     {
       "ID": 58005200,
       "Entries": [
-        "どうりゃあっ"
+        "Mmgraah!"
       ]
     },
     {
       "ID": 58005201,
       "Entries": [
-        "うおうりゃあっ"
+        "Mmgraah!"
       ]
     },
     {
       "ID": 58005202,
       "Entries": [
-        "ばはあっ（大きく息を吐くように）"
+        "Hahh..."
       ]
     },
     {
       "ID": 58005300,
       "Entries": [
-        "ぬおっ"
+        "Oog!"
       ]
     },
     {
       "ID": 58005301,
       "Entries": [
-        "ぐぬうっ"
+        "Ooph!"
       ]
     },
     {
       "ID": 58005302,
       "Entries": [
-        "グッ（堪えるように）"
+        "Hrg!"
       ]
     },
     {
       "ID": 58005400,
       "Entries": [
-        "ぐおおおおっ"
+        "Arrgggg!"
       ]
     },
     {
       "ID": 58005401,
       "Entries": [
-        "これが、人間、とは…"
+        "Humans...hmph..."
       ]
     },
     {
       "ID": 58006000,
       "Entries": [
-        "こんにちは"
+        "Hello"
       ]
     },
     {
       "ID": 58006010,
       "Entries": [
-        "ありがとう"
+        "Thank you"
       ]
     },
     {
       "ID": 58006020,
       "Entries": [
-        "いいね！"
+        "Very good!"
       ]
     },
     {
       "ID": 58006030,
       "Entries": [
-        "申し訳ない"
+        "I'm sorry!"
       ]
     },
     {
       "ID": 58006040,
       "Entries": [
-        "助けてくれ！"
+        "Help me!"
       ]
     },
     {
       "ID": 59000000,
       "Entries": [
-        "ん？貴様は…もしや、私と同じか？"
+        "Hm...Oh, let me guess..."
       ]
     },
     {
       "ID": 59000001,
       "Entries": [
-        "黒い腕に引きずり込まれ、過去にいたった…"
+        "Snatched by a shadowy limb,\nand dragged off to the past?"
       ]
     },
     {
       "ID": 59000100,
       "Entries": [
-        "やはりそうか。…お互い、不思議なこともあるものだ"
+        "Yes, of course. Exactly what happened to me."
       ]
     },
     {
       "ID": 59000101,
       "Entries": [
-        "慣れぬ時代だ、不便もあるだろう"
+        "We are both strangers in this strange land."
       ]
     },
     {
       "ID": 59000102,
       "Entries": [
-        "お互い、助け合っていこうじゃあないか"
+        "But, at least now there are two of us."
       ]
     },
     {
       "ID": 59000200,
       "Entries": [
-        "ほう、そうか…"
+        "Oh, well, my mistake..."
       ]
     },
     {
       "ID": 59000201,
       "Entries": [
-        "まあいい、旅人であるのは変わるまい"
+        "But we are both travellers."
       ]
     },
     {
       "ID": 59000202,
       "Entries": [
-        "お互い、助け合っていこうじゃあないか"
+        "We ought to help one another out."
       ]
     },
     {
       "ID": 59000300,
       "Entries": [
-        "おう、貴様、まだ生きていたか"
+        "Oh, still alive, are you?"
       ]
     },
     {
       "ID": 59000301,
       "Entries": [
-        "で、どうした？欲しいものでもできたのかな？"
+        "Think of anything that you might need?"
       ]
     },
     {
       "ID": 59000400,
       "Entries": [
-        "おう、貴様、どうしたんだ？"
+        "Oh, for Juniper's sake."
       ]
     },
     {
       "ID": 59000401,
       "Entries": [
-        "妙にしょぼくれているじゃないか"
+        "Put some spring into your step!"
       ]
     },
     {
       "ID": 59000402,
       "Entries": [
-        "クックックッ"
+        "Mwah hah hah!"
       ]
     },
     {
       "ID": 59000500,
       "Entries": [
-        "…ほう、貴様か…"
+        "Oh, you again..."
       ]
     },
     {
       "ID": 59000501,
       "Entries": [
-        "どうした？妙な顔を妙にして、俺に用があるのだろう？"
+        "What ever's the matter? No, I can tell. \nYou need me more than ever."
       ]
     },
     {
       "ID": 59000502,
       "Entries": [
-        "クックックックックッ"
+        "Mwah hah hah!"
       ]
     },
     {
       "ID": 59000600,
       "Entries": [
-        "じゃあな"
+        "So long."
       ]
     },
     {
       "ID": 59000700,
       "Entries": [
-        "じゃあな"
+        "So long."
       ]
     },
     {
       "ID": 59000701,
       "Entries": [
-        "…また会えるのを、楽しみにしているよ…"
+        "...We'll be seeing each other..."
       ]
     },
     {
       "ID": 59000702,
       "Entries": [
-        "クックックックックッ"
+        "Gee hee hee!"
       ]
     },
     {
       "ID": 59000800,
       "Entries": [
-        "貴様、騎士アルトリウスに会っているか？"
+        "Did you happen across Knight Artorias?"
       ]
     },
     {
       "ID": 59000801,
       "Entries": [
-        "元の時代の伝承にあった、深淵狩りの英雄さ"
+        "The legendary Abysswalker, from the old tales."
       ]
     },
     {
       "ID": 59000802,
       "Entries": [
-        "…まあ、会っていないのなら、それでいい"
+        "...Well, if you haven't, it's just as well..."
       ]
     },
     {
       "ID": 59000803,
       "Entries": [
-        "所詮つまらん話さ…"
+        "He's a colourless sort, if you ask me."
       ]
     },
     {
       "ID": 59000804,
       "Entries": [
-        "クックックッ"
+        "Mwah hah hah!"
       ]
     },
     {
       "ID": 59000900,
       "Entries": [
-        "ほう、貴様、騎士アルトリウスを倒したのか"
+        "Did you really slay Knight Artorias?"
       ]
     },
     {
       "ID": 59000901,
       "Entries": [
-        "深淵に飲まれたとは言え、あの英雄をなあ…"
+        "I'd heard the Abyss found him first,\nbut even still..."
       ]
     },
     {
       "ID": 59000902,
       "Entries": [
-        "いや、それはすばらしいことだ"
+        "That's absolutely treacherous."
       ]
     },
     {
       "ID": 59000903,
       "Entries": [
-        "とてもすばらしいことだよ…"
+        "Yes, magnificently so!"
       ]
     },
     {
       "ID": 59000904,
       "Entries": [
-        "クックックッ"
+        "Mwah hah hah!"
       ]
     },
     {
       "ID": 59001000,
       "Entries": [
-        "ほう、貴様、あのキノコの願いを聞いたのか"
+        "So, what did that giant mushroom make you do?"
       ]
     },
     {
       "ID": 59001001,
       "Entries": [
-        "それはそれは…なんとも物好きなことだ"
+        "Not that I care. It's none of my business."
       ]
     },
     {
       "ID": 59001002,
       "Entries": [
-        "クックックッ"
+        "Heh heh heh..."
       ]
     },
     {
       "ID": 59001100,
       "Entries": [
-        "うん？話など、特にはないなあ"
+        "Hm? I've little to talk about, really."
       ]
     },
     {
       "ID": 59001101,
       "Entries": [
-        "すまんが、何も知らぬものでなあ…"
+        "Oh, you know me. What do I know?"
       ]
     },
     {
       "ID": 59001102,
       "Entries": [
-        "クックックッ"
+        "Heh heh!"
       ]
     },
     {
       "ID": 59001200,
       "Entries": [
-        "なんだ？言いたいことがあれば、言えばよかろう？"
+        "What? If you've something to say, then say it!"
       ]
     },
     {
       "ID": 59001201,
       "Entries": [
-        "それでどうなるのか、十分に考えた上でなあ…"
+        "Just don't say the wrong thing..."
       ]
     },
     {
       "ID": 59001202,
       "Entries": [
-        "クックックックックッ"
+        "Heh heh heh!"
       ]
     },
     {
       "ID": 59001300,
       "Entries": [
-        "…ほう、貴様…"
+        "...Oh, you!"
       ]
     },
     {
       "ID": 59001301,
       "Entries": [
-        "よくもまあ…鈍いのか、それとも厚顔か…"
+        "You have quite some nerve. Or are you just thick?"
       ]
     },
     {
       "ID": 59001302,
       "Entries": [
-        "…まあいい。俺に用があるのだろう？"
+        "Fine, then. What is it that you need?"
       ]
     },
     {
       "ID": 59001400,
       "Entries": [
-        "…じゃあな"
+        "I'll be seeing you."
       ]
     },
     {
       "ID": 59001401,
       "Entries": [
-        "気をつけて旅をするがいいさ…"
+        "If you survive your travels..."
       ]
     },
     {
       "ID": 59001500,
       "Entries": [
-        "…貴様…よくもまあ…"
+        "...Well, you've quite the nerve!"
       ]
     },
     {
       "ID": 59001501,
       "Entries": [
-        "…話など、そんなもの、あるものかよ…"
+        "I've had enough of you!"
       ]
     },
     {
       "ID": 59001600,
       "Entries": [
-        "それにしても、貴様も物好きなことだ"
+        "Believe it or not,"
       ]
     },
     {
       "ID": 59001601,
       "Entries": [
-        "深淵など、まさにウーラシールの自業自得"
+        "Oolacile has brought the Abyss upon itself."
       ]
     },
     {
       "ID": 59001602,
       "Entries": [
-        "出っ歯の大蛇に謀られ、墓を掘り、古人の躯を辱めるなど"
+        "Fooled by that toothy serpent,\nthey upturned the grave of primeval man,\nand incited his ornery wrath."
       ]
     },
     {
       "ID": 59001603,
       "Entries": [
-        "まさに恥知らず、愚者ではないか"
+        "What could they have been thinking?"
       ]
     },
     {
       "ID": 59001604,
       "Entries": [
-        "それに、所詮私たちには昔の話だ"
+        "But to you and I, it's all ancient history."
       ]
     },
     {
       "ID": 59001605,
       "Entries": [
-        "貴様の知ったことでもないだろうに"
+        "You have to ask yourself. Does it really matter?"
       ]
     },
     {
       "ID": 59001606,
       "Entries": [
-        "クックックッ"
+        "Heh heh heh..."
       ]
     },
     {
       "ID": 59005000,
       "Entries": [
-        "ほう、貴様、やるつもりか"
+        "Oh! It's come to blows, has it?"
       ]
     },
     {
       "ID": 59005001,
       "Entries": [
-        "それもよかろう。阿呆は阿呆だからな！"
+        "Fine, then. I've had enough of you, anyway!"
       ]
     },
     {
       "ID": 59005100,
       "Entries": [
-        "なんだ、貴様？逆恨みか？"
+        "What now? You think this my fault?"
       ]
     },
     {
       "ID": 59005101,
       "Entries": [
-        "よくない、よくないなあ！"
+        "How very, very petty of you!"
       ]
     },
     {
       "ID": 59005102,
       "Entries": [
-        "そういうのはよくないぞお！"
+        "Very petty, indeed!"
       ]
     },
     {
       "ID": 59005200,
       "Entries": [
-        "ウッ"
+        "Ooph!"
       ]
     },
     {
       "ID": 59005210,
       "Entries": [
-        "グッ"
+        "Erg!"
       ]
     },
     {
       "ID": 59005220,
       "Entries": [
-        "いてえ！"
+        "Oww!"
       ]
     },
     {
       "ID": 59005230,
       "Entries": [
-        "いてえだろうが！"
+        "That bloody hurts!"
       ]
     },
     {
       "ID": 59005300,
       "Entries": [
-        "そうら"
+        "There!"
       ]
     },
     {
       "ID": 59005301,
       "Entries": [
-        "そうら、そうら"
+        "Ah-hah, there!"
       ]
     },
     {
       "ID": 59005400,
       "Entries": [
-        "どうした？死にそうか？"
+        "What? Now you're feeling the heat?"
       ]
     },
     {
       "ID": 59005401,
       "Entries": [
-        "所詮阿呆などそんなものか！"
+        "You should have thought long and hard..."
       ]
     },
     {
       "ID": 59005402,
       "Entries": [
-        "ウエーハッハッハッハッハッ"
+        "Nyah hah hah hah hah!"
       ]
     },
     {
       "ID": 59005500,
       "Entries": [
-        "フン、阿呆が…"
+        "You damn fool."
       ]
     },
     {
       "ID": 59005501,
       "Entries": [
-        "貴様ごときが、”優れたる”ハギアに敵うと思ったか…"
+        "I am Marvellous Chester! What did you expect?"
       ]
     },
     {
       "ID": 59005600,
       "Entries": [
-        "グウッ…"
+        "Hrrg..."
       ]
     },
     {
       "ID": 59005601,
       "Entries": [
-        "参った、助けて、くれ…"
+        "You win...please..."
       ]
     },
     {
       "ID": 59005602,
       "Entries": [
-        "頼む…神の慈悲を…"
+        "Oh, please...have mercy..."
       ]
     },
     {
       "ID": 60000000,
       "Entries": [
-        "…人間…"
+        "...Human..."
       ]
     },
     {
       "ID": 60000001,
       "Entries": [
-        "…貴様なぜ、アルトリウスの指輪を持っている…"
+        "...Why have you the ring of Artorias?"
       ]
     },
     {
       "ID": 60000002,
       "Entries": [
-        "…私はキアラン。仲間の形見だ、返してもらうぞ…"
+        "...I am Ciaran, and that is a keepsake."
       ]
     },
     {
       "ID": 60000100,
       "Entries": [
-        "…貴公、その指輪…"
+        "...That ring..."
       ]
     },
     {
       "ID": 60000101,
       "Entries": [
-        "その指輪は…コートの男が、盗んでいったもの"
+        "It was purloined by a man in a long coat..."
       ]
     },
     {
       "ID": 60000102,
       "Entries": [
-        "…貴公がなぜそれを持つのか、分からないが"
+        "I know not how you came upon it,"
       ]
     },
     {
       "ID": 60000103,
       "Entries": [
-        "それは、ここで倒れた男の、大切な形見なのだ"
+        "but its owner met his death here."
       ]
     },
     {
       "ID": 60000104,
       "Entries": [
-        "私は、その男の友だった。だから、その形見を、弔いに供えたい"
+        "He was a dear companion,\nand I wish to return the ring to his grave."
       ]
     },
     {
       "ID": 60000105,
       "Entries": [
-        "どうだろう？それを譲ってはくれないだろうか？"
+        "Would you be willing to part with it?"
       ]
     },
     {
       "ID": 60000200,
       "Entries": [
-        "ありがとう。友として、貴公に感謝する"
+        "Thank you. You are very kind."
       ]
     },
     {
       "ID": 60000201,
       "Entries": [
-        "これは、せめてもの礼だ。…もはや私には、不要なものだ"
+        "Please take this. I no longer need it."
       ]
     },
     {
       "ID": 60000210,
       "Entries": [
-        "貴公に王の導きのあらんことを"
+        "May the Lord guide thee."
       ]
     },
     {
       "ID": 60000300,
       "Entries": [
-        "そうか…"
+        "Yes, of course..."
       ]
     },
     {
       "ID": 60000301,
       "Entries": [
-        "…"
+        "..."
       ]
     },
     {
       "ID": 60000302,
       "Entries": [
-        "…いや、すまなかった"
+        "...I must not be presumptuous."
       ]
     },
     {
       "ID": 60000303,
       "Entries": [
-        "無理強いは、アルトリウスも望むまい…"
+        "Artorias would not have approved."
       ]
     },
     {
       "ID": 60000400,
       "Entries": [
-        "どうした？まだ何かあるのか？"
+        "What is it? Something else?"
       ]
     },
     {
       "ID": 60000401,
       "Entries": [
-        "もし譲ってくれる気になったのなら、歓迎だがな"
+        "Have you changed your mind?"
       ]
     },
     {
       "ID": 60000500,
       "Entries": [
-        "…では、特に用もないはずだな…"
+        "...Then you have no business with me..."
       ]
     },
     {
       "ID": 60000600,
       "Entries": [
-        "…貴公、人間か…"
+        "...Are you human?"
       ]
     },
     {
       "ID": 60000601,
       "Entries": [
-        "…まあ、それもよい"
+        "...I forgive you."
       ]
     },
     {
       "ID": 60000602,
       "Entries": [
-        "これは、私の友の弔いなのだ"
+        "I am here to pay respects to a dear friend."
       ]
     },
     {
       "ID": 60000603,
       "Entries": [
-        "すまないが、少し一人にしてくれないか…"
+        "Please, allow me a moment alone."
       ]
     },
     {
       "ID": 60000700,
       "Entries": [
-        "…貴公、それは…"
+        "...You, is that not..."
       ]
     },
     {
       "ID": 60000701,
       "Entries": [
-        "それは、ここで倒れた男の、魂ではないか？"
+        "The soul of the man who fell on this spot?"
       ]
     },
     {
       "ID": 60000702,
       "Entries": [
-        "…私は、その男の友だった。だから、その魂を、しっかりと弔いたい"
+        "He was a dear friend. I wish to pay proper respect, with that soul."
       ]
     },
     {
       "ID": 60000703,
       "Entries": [
-        "どうだろう？それを譲ってはくれないだろうか？"
+        "Would you be willing to part with it?"
       ]
     },
     {
       "ID": 60005000,
       "Entries": [
-        "フン、所詮人間か"
+        "Hmph, you humans..."
       ]
     },
     {
       "ID": 60005001,
       "Entries": [
-        "よかろう、貴公らの流儀で、貰い受けるとしよう"
+        "...always taking what you please.\nThen, I shall do the same."
       ]
     },
     {
       "ID": 60005010,
       "Entries": [
-        "フン、所詮人間か"
+        "Hmph, you humans..."
       ]
     },
     {
       "ID": 60005011,
       "Entries": [
-        "よかろう、貴公らの流儀で、相手するとしよう"
+        "...always resorting to force.\nThen, I shall do the same."
       ]
     },
     {
       "ID": 60005100,
       "Entries": [
-        "クッ"
+        "Hrk!"
       ]
     },
     {
       "ID": 60005110,
       "Entries": [
-        "グッ"
+        "Erg!"
       ]
     },
     {
       "ID": 60005120,
       "Entries": [
-        "ウッ"
+        "Ooh!"
       ]
     },
     {
       "ID": 60005200,
       "Entries": [
-        "フン、思い上がりが…"
+        "Hmph, such conceit..."
       ]
     },
     {
       "ID": 60005201,
       "Entries": [
-        "王の刃、貴公らに届かぬものと思ったか…"
+        "How did you imagine that\nthe Lord's Blade would not reach you?"
       ]
     },
     {
       "ID": 60005300,
       "Entries": [
-        "グウッ、そんな…"
+        "But, how..."
       ]
     },
     {
       "ID": 60005301,
       "Entries": [
-        "人間とは…アルト、リウス…"
+        "You humans..."
       ]
     },
     {
       "ID": 61000000,
       "Entries": [
-        "まあ、珍しい"
+        "Well, look at this one."
       ]
     },
     {
       "ID": 61000001,
       "Entries": [
-        "あなた、とても先の人ね。それに、とっても人臭い"
+        "From what far-away age hast thou come?\nThy scent is very human, indeed."
       ]
     },
     {
       "ID": 61000002,
       "Entries": [
-        "…でも、悪くはないよう…"
+        "...But, not intolerable..."
       ]
     },
     {
       "ID": 61000003,
       "Entries": [
-        "…あなた、宵闇様の救い人ね。見えぬもの、宵闇様の仰る通りだもの"
+        "Ah, Princess Dusk's saviour.\nThine aura is precisely as she described."
       ]
     },
     {
       "ID": 61000004,
       "Entries": [
-        "ありがとう。私からも感謝するわ、宵闇様を救ってくれて"
+        "I thank thee deeply,\nfor rescuing Her Highness."
       ]
     },
     {
       "ID": 61000005,
       "Entries": [
-        "…でも、宵闇様はもういないわ"
+        "But Princess Dusk is here no longer..."
       ]
     },
     {
       "ID": 61000006,
       "Entries": [
-        "古い人の化け物、そのおそろしい腕に連れ去られたの"
+        "...snatched away by that horrifying primeval human."
       ]
     },
     {
       "ID": 61000007,
       "Entries": [
-        "だから、あなた…もう一度、宵闇様を救ってくれませんか"
+        "And so I must ask...\nCouldst thou once more play the saviour?"
       ]
     },
     {
       "ID": 61000020,
       "Entries": [
-        "まあ、珍しい"
+        "Well, look at this one."
       ]
     },
     {
       "ID": 61000021,
       "Entries": [
-        "あなた、とても先の人ね。それに、とっても人臭い"
+        "From what far-away age hast thou come?\nThy scent is very human, indeed."
       ]
     },
     {
       "ID": 61000022,
       "Entries": [
-        "…でも、悪くはないよう…"
+        "...But, not intolerable..."
       ]
     },
     {
       "ID": 61000023,
       "Entries": [
-        "…あなた、宵闇様の想い人ね。見えぬもの、宵闇様の仰る通りだもの"
+        "Princess Dusk has spoken of thee.\nThy aura is precisely as she described."
       ]
     },
     {
       "ID": 61000024,
       "Entries": [
-        "ありがとう。私からも感謝するわ、宵闇様を救ってくれて"
+        "I thank thee deeply,\nfor rescuing Her Highness."
       ]
     },
     {
       "ID": 61000025,
       "Entries": [
-        "…でも、宵闇様はもういないわ"
+        "But Princess Dusk is here no longer..."
       ]
     },
     {
       "ID": 61000026,
       "Entries": [
-        "古い人の化け物、そのおそろしい腕に連れ去られたの"
+        "...snatched away by that horrifying primeval human."
       ]
     },
     {
       "ID": 61000027,
       "Entries": [
-        "だから、あなた…もう一度、宵闇様を救ってくれませんか"
+        "And so I must ask...\nCouldst thou once more play the saviour?"
       ]
     },
     {
       "ID": 61000100,
       "Entries": [
-        "ありがとう"
+        "Thank you."
       ]
     },
     {
       "ID": 61000101,
       "Entries": [
-        "私は霊廟の守人、エリザベス"
+        "I am Elizabeth, guardian of this sanctuary."
       ]
     },
     {
       "ID": 61000102,
       "Entries": [
-        "宵闇様の乳母のようなものかしら"
+        "Something of a godmother to Princess Dusk."
       ]
     },
     {
       "ID": 61000103,
       "Entries": [
-        "私のできるかぎり、あなたに協力しましょう"
+        "I shall assist thee, to my utmost."
       ]
     },
     {
       "ID": 61000104,
       "Entries": [
-        "ウーラシールの魔術は、私と共にありますから"
+        "For I am one with the sorceries of Oolacile."
       ]
     },
     {
       "ID": 61000200,
       "Entries": [
-        "そう…わかりました"
+        "Yes, I understand."
       ]
     },
     {
       "ID": 61000201,
       "Entries": [
-        "いかに宵闇様を思うとて、それはこちらの事情"
+        "We care dearly for Princess Dusk,\nand are apt to blur our boundaries."
       ]
     },
     {
       "ID": 61000202,
       "Entries": [
-        "もう一度など、いかにもあつかましいお願いでしたね"
+        "I am ashamed to have been so imposing."
       ]
     },
     {
       "ID": 61000203,
       "Entries": [
-        "でも…気を変えられたら、またお声がけください"
+        "But should thine heart be changed,\nspeak to me again."
       ]
     },
     {
       "ID": 61000204,
       "Entries": [
-        "私は霊廟の守人。ウーラシールの魔術は、私と共にあります"
+        "This sanctuary, and the sorceries of Oolacile,\nare my domain."
       ]
     },
     {
       "ID": 61000205,
       "Entries": [
-        "あなたの旅に、力添えもできようというものですから"
+        "My strength could surely assist thee in thy travels."
       ]
     },
     {
       "ID": 61000300,
       "Entries": [
-        "あなた…気を変えられたのですか？"
+        "Hast thou reconsidered?"
       ]
     },
     {
       "ID": 61000301,
       "Entries": [
-        "もう一度、宵闇様を救ってくださると？"
+        "Such that thou might rescue dear Dusk?"
       ]
     },
     {
       "ID": 61000400,
       "Entries": [
-        "ああ、やはりそうですか"
+        "Yes, yes, of course."
       ]
     },
     {
       "ID": 61000401,
       "Entries": [
-        "でも…気を変えられたら、またお声がけください"
+        "But shouldst thine heart be changed,\nspeak to me again."
       ]
     },
     {
       "ID": 61000500,
       "Entries": [
-        "あなた、無事で何よりです"
+        "Thank goodness thou art safe."
       ]
     },
     {
       "ID": 61000501,
       "Entries": [
-        "どうしましたか？私のできるかぎり、あなたに協力しましょう"
+        "What is thy wish? I offer thee my all."
       ]
     },
     {
       "ID": 61000600,
       "Entries": [
-        "あなた、苦労されているようですね"
+        "Struggling, are we?"
       ]
     },
     {
       "ID": 61000601,
       "Entries": [
-        "私にできることがあれば、なんなりと仰ってください"
+        "If there is anything I can do,\nnever hesitate to ask."
       ]
     },
     {
       "ID": 61000700,
       "Entries": [
-        "お待ちしておりました。宵闇様をお救い頂いたのでしょう"
+        "I have awaited thee.\nThou hast rescued Princess Dusk,"
       ]
     },
     {
       "ID": 61000701,
       "Entries": [
-        "それに、あの古い人の化け物も退治し、深淵すらを留められた"
+        "...and rid us of that terrible primeval human.\nEven halting the spread of the Abyss!"
       ]
     },
     {
       "ID": 61000702,
       "Entries": [
-        "あなたと、あなたの偉大な運命に感謝します"
+        "I salute the grandeur of thine enterprise."
       ]
     },
     {
       "ID": 61000703,
       "Entries": [
-        "せめてですが、私にお礼をさせてください"
+        "Please, allow me to express my gratitude."
       ]
     },
     {
       "ID": 61000704,
       "Entries": [
-        "ほんとうに…ありがとうございました"
+        "I thank thee... as do we all."
       ]
     },
     {
       "ID": 61000800,
       "Entries": [
-        "あなたに炎の導きのあらんことを"
+        "May the flames guide thee."
       ]
     },
     {
       "ID": 61000900,
       "Entries": [
-        "あなたも、この先にいけば分かるでしょう"
+        "Thou shalt see further on."
       ]
     },
     {
       "ID": 61000901,
       "Entries": [
-        "ウーラシールは今、古い人の化け物が生んだ、深淵に飲まれようとしています"
+        "An abyss was begat of the ancient beast, \nand threatens to swallow the whole of Oolacile."
       ]
     },
     {
       "ID": 61000902,
       "Entries": [
-        "騎士アルトリウスが、これを留めに向かいましたが、英雄とて、所詮は闇を持たぬ身"
+        "Knight Artorias came to stop this,\nbut such a hero has nary a murmur of Dark."
       ]
     },
     {
       "ID": 61000903,
       "Entries": [
-        "いずれは深淵に飲まれ、闇に食われてしまうでしょう"
+        "Without doubt, he will be swallowed by the Abyss,\novercome by its utter blackness."
       ]
     },
     {
       "ID": 61000904,
       "Entries": [
-        "…もう、深淵を留めることは、できないのかもしれません"
+        "...Indeed, the Abyss may be unstoppable..."
       ]
     },
     {
       "ID": 61000905,
       "Entries": [
-        "私は、それでも救いたいのです。せめて宵闇様だけでも…"
+        "Still I have faith, that Princess Dusk \nmay be rescued yet..."
       ]
     },
     {
       "ID": 61001000,
       "Entries": [
-        "あなたは、とても先の人"
+        "Thou art from a time far, far ahead."
       ]
     },
     {
       "ID": 61001001,
       "Entries": [
-        "とても沢山、聞きたいことがあるのだけど"
+        "There are many things I wish to ask."
       ]
     },
     {
       "ID": 61001002,
       "Entries": [
-        "…でも、やはりそうするべきではありませんね"
+        "...But I know that I must not."
       ]
     },
     {
       "ID": 61001003,
       "Entries": [
-        "残念ですが、この時の私は、今この時のことを知るべきです"
+        "The perils of our time are overwhelming enough."
       ]
     },
     {
       "ID": 61001100,
       "Entries": [
-        "ふふ…私が不思議かしら"
+        "Hah hah...Was thine eye, glancing hither?"
       ]
     },
     {
       "ID": 61001101,
       "Entries": [
-        "大丈夫よ、私も不思議だから"
+        "Thou needst not hide thy wonder."
       ]
     },
     {
       "ID": 61001102,
       "Entries": [
-        "キノコですものね"
+        "I am a mushroom, after all."
       ]
     },
     {
       "ID": 61001103,
       "Entries": [
-        "ふふふふ"
+        "Hee hee hee..."
       ]
     },
     {
       "ID": 61001200,
       "Entries": [
-        "そういえば、少し前にも来客がありました"
+        "Not long ago, I had another visitor."
       ]
     },
     {
       "ID": 61001201,
       "Entries": [
-        "あなたと同じ、とっても人臭い、とても先の人"
+        "A human like thineself, from a far-away time."
       ]
     },
     {
       "ID": 61001202,
       "Entries": [
-        "でも…あなたと違い、とても悪い…"
+        "Only, he was dreadfully odious..."
       ]
     },
     {
       "ID": 61001203,
       "Entries": [
-        "おそらく、まだこの時にあるでしょう"
+        "And I am afraid that he is still amongst us."
       ]
     },
     {
       "ID": 61001204,
       "Entries": [
-        "黒いコートと、帽子の男です。注意してくださいね…"
+        "He wore a hat and a long black coat..."
       ]
     },
     {
       "ID": 61001300,
       "Entries": [
-        "あなたのことは、私の記憶にのみ留めておきます"
+        "I will remember thee,\nbut I will keep thy story to myself."
       ]
     },
     {
       "ID": 61001301,
       "Entries": [
-        "あなたは、とても先の人。多分それが、一番よいでしょうから"
+        "This is the best way,\nfor thou art come from a time far ahead."
       ]
     },
     {
       "ID": 61001302,
       "Entries": [
-        "でも…たとえそれで、誰もあなたを歌わずとも、あなたは偉大な英雄です"
+        "No-one will sing thy praises,\nbut yet thy greatness shall live on."
       ]
     },
     {
       "ID": 61001303,
       "Entries": [
-        "それを知り、知り続けるのを、私の使命といたしましょう"
+        "For it shall be my purpose,\nto remember all thou hast done for us."
       ]
     },
     {
       "ID": 61005000,
       "Entries": [
-        "アッ！"
+        "Ah!"
       ]
     },
     {
       "ID": 61005010,
       "Entries": [
-        "ウッ！"
+        "Ooh!"
       ]
     },
     {
       "ID": 61005020,
       "Entries": [
-        "アアッ！"
+        "Aaah!"
       ]
     },
     {
       "ID": 61005030,
       "Entries": [
-        "やめなさい！"
+        "Stop that!"
       ]
     },
     {
       "ID": 61005040,
       "Entries": [
-        "やめてください！"
+        "Please, no!"
       ]
     },
     {
       "ID": 61005050,
       "Entries": [
-        "やめて！"
+        "Stop!"
       ]
     },
     {
       "ID": 61005100,
       "Entries": [
-        "きゃあああああっ！"
+        "Aiieeek!"
       ]
     },
     {
       "ID": 61005101,
       "Entries": [
-        "ぎゃあああああっ！"
+        "Aiieeegh!"
       ]
     },
     {
       "ID": 61005102,
       "Entries": [
-        "う、ううっ…"
+        "Ooh...aah..."
       ]
     },
     {
       "ID": 61005103,
       "Entries": [
-        "なぜ、こんな…宵闇様…"
+        "But, why... Why... Dear Dusk..."
       ]
     }
   ]

--- a/src/Smithbox.Data/Assets/PARAM/DS1R/Community Row Names/ThrowParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/DS1R/Community Row Names/ThrowParam.json
@@ -40,7 +40,7 @@
     {
       "ID": 12280,
       "Entries": [
-        "Backstab - PC -> Mushroom Child"
+        "Backstab - PC -> Mushroom-Man Child"
       ]
     },
     {
@@ -76,13 +76,13 @@
     {
       "ID": 12520,
       "Entries": [
-        "Backstab - PC -> Undead Assassin"
+        "Backstab - PC -> Hollow Thief"
       ]
     },
     {
       "ID": 12530,
       "Entries": [
-        "Backstab - PC -> Blowdart Hollow"
+        "Backstab - PC -> Hollow Blowdart Sniper"
       ]
     },
     {
@@ -112,25 +112,25 @@
     {
       "ID": 12650,
       "Entries": [
-        "Backstab - PC -> Necromancer"
+        "Backstab - PC -> Hollow Necromancer"
       ]
     },
     {
       "ID": 12660,
       "Entries": [
-        "Backstab - PC -> Butcher"
+        "Backstab - PC -> Hollow Maneater Butcher"
       ]
     },
     {
       "ID": 12690,
       "Entries": [
-        "Backstab - PC -> Serpent Soldier"
+        "Backstab - PC -> Man-Serpent Soldier"
       ]
     },
     {
       "ID": 12700,
       "Entries": [
-        "Backstab - PC -> Serpent Mage"
+        "Backstab - PC -> Man-Serpent Sorcerer"
       ]
     },
     {
@@ -142,49 +142,49 @@
     {
       "ID": 12792,
       "Entries": [
-        "Backstab - PC ->"
+        "Backstab - PC -> Black Knight (Sword)"
       ]
     },
     {
       "ID": 12793,
       "Entries": [
-        "Backstab - PC ->"
+        "Backstab - PC -> Black Knight (Greatsword)"
       ]
     },
     {
       "ID": 12794,
       "Entries": [
-        "Backstab - PC ->"
+        "Backstab - PC -> Black Knight (Axe)"
       ]
     },
     {
       "ID": 12795,
       "Entries": [
-        "Backstab - PC ->"
+        "Backstab - PC -> Black Knight (Halberd)"
       ]
     },
     {
       "ID": 12800,
       "Entries": [
-        "Backstab - PC -> Crystal Hollow"
+        "Backstab - PC -> Hollow Crystal Soldier"
       ]
     },
     {
       "ID": 12810,
       "Entries": [
-        "Backstab - PC -> Infested Barbarian (Club)"
+        "Backstab - PC -> Hollow Infested Barbarian (Club)"
       ]
     },
     {
       "ID": 12811,
       "Entries": [
-        "Backstab - PC -> Infested Barbarian (Boulder)"
+        "Backstab - PC -> Hollow Infested Barbarian (Boulder)"
       ]
     },
     {
       "ID": 12820,
       "Entries": [
-        "Backstab - PC ->"
+        "[UNUSED] Backstab - PC -> Hollow (Crag Worshipper)"
       ]
     },
     {
@@ -202,7 +202,7 @@
     {
       "ID": 12920,
       "Entries": [
-        "Backstab - PC -> Vamos"
+        "Backstab - PC -> Vamos the Blacksmith"
       ]
     },
     {
@@ -214,7 +214,7 @@
     {
       "ID": 13460,
       "Entries": [
-        "Backstab - PC -> Armored Tusk"
+        "Backstab - PC -> Fang Boar"
       ]
     },
     {
@@ -226,19 +226,19 @@
     {
       "ID": 14130,
       "Entries": [
-        "Backstab - PC -> Scarecrow"
+        "Backstab - PC -> Scarecrow Gardener"
       ]
     },
     {
       "ID": 14150,
       "Entries": [
-        "Backstab - PC -> Bloathead"
+        "Backstab - PC -> Oolacile Resident (Melee)"
       ]
     },
     {
       "ID": 14160,
       "Entries": [
-        "Backstab - PC -> Bloathead Sorcerer"
+        "Backstab - PC -> Oolacile Resident (Sorceress)"
       ]
     },
     {
@@ -280,13 +280,13 @@
     {
       "ID": 22520,
       "Entries": [
-        "Parry - PC -> Undead Assassin"
+        "Parry - PC -> Hollow Thief"
       ]
     },
     {
       "ID": 22530,
       "Entries": [
-        "Parry - PC -> Blowdart Hollow"
+        "Parry - PC -> Hollow Blowdart Sniper"
       ]
     },
     {
@@ -316,19 +316,19 @@
     {
       "ID": 22660,
       "Entries": [
-        "Parry - PC -> Butcher"
+        "Parry - PC -> Hollow Maneater Butcher"
       ]
     },
     {
       "ID": 22690,
       "Entries": [
-        "Parry - PC -> Serpent Soldier"
+        "Parry - PC -> Man-Serpent Soldier"
       ]
     },
     {
       "ID": 22700,
       "Entries": [
-        "Parry - PC -> Serpent Mage"
+        "Parry - PC -> Man-Serpent Sorcerer"
       ]
     },
     {
@@ -340,43 +340,43 @@
     {
       "ID": 22792,
       "Entries": [
-        "Parry - PC ->"
+        "Parry - PC -> Black Knight (Sword)"
       ]
     },
     {
       "ID": 22793,
       "Entries": [
-        "Parry - PC ->"
+        "Parry - PC -> Black Knight (Greatsword)"
       ]
     },
     {
       "ID": 22794,
       "Entries": [
-        "Parry - PC ->"
+        "Parry - PC -> Black Knight (Axe)"
       ]
     },
     {
       "ID": 22795,
       "Entries": [
-        "Parry - PC ->"
+        "Parry - PC -> Black Knight (Halberd)"
       ]
     },
     {
       "ID": 22800,
       "Entries": [
-        "Parry - PC -> Crystal Hollow"
+        "Parry - PC -> Hollow Crystal Soldier"
       ]
     },
     {
       "ID": 22810,
       "Entries": [
-        "Parry - PC -> Infested Barbarian (Club)"
+        "Parry - PC -> Hollow Infested Barbarian (Club)"
       ]
     },
     {
       "ID": 22820,
       "Entries": [
-        "Parry - PC -> Infested Barbarian (Boulder)"
+        "Parry - PC -> Hollow Infested Barbarian (Boulder)"
       ]
     },
     {
@@ -394,25 +394,25 @@
     {
       "ID": 22920,
       "Entries": [
-        "Parry - PC -> Vamos"
+        "Parry - PC -> Vamos the Blacksmith"
       ]
     },
     {
       "ID": 24130,
       "Entries": [
-        "Parry - PC -> Scarecrow"
+        "Parry - PC -> Scarecrow Gardener"
       ]
     },
     {
       "ID": 24150,
       "Entries": [
-        "Parry - PC -> Bloathead"
+        "Parry - PC -> Oolacile Resident (Melee)"
       ]
     },
     {
       "ID": 24160,
       "Entries": [
-        "Parry - PC -> Bloathead Sorcerer"
+        "Parry - PC -> Oolacile Resident (Sorceress)"
       ]
     },
     {
@@ -424,13 +424,13 @@
     {
       "ID": 31202,
       "Entries": [
-        "Fall - PC -> Giant Rat"
+        "Fall - PC -> Giant Undead Rat"
       ]
     },
     {
       "ID": 32231,
       "Entries": [
-        "Fall - PC -> Firesage Demon"
+        "Fall - PC -> Demon Firesage"
       ]
     },
     {
@@ -448,13 +448,13 @@
     {
       "ID": 33460,
       "Entries": [
-        "Fall - PC -> Armored Tusk"
+        "Fall - PC -> Fang Boar"
       ]
     },
     {
       "ID": 33461,
       "Entries": [
-        "Fall - PC -> Armored Tusk - Reinforced"
+        "Fall - PC -> Fang Boar (Fully-Armored)"
       ]
     },
     {
@@ -484,427 +484,427 @@
     {
       "ID": 112060,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Infested Ghoul [Hornet Ring]"
       ]
     },
     {
       "ID": 112280,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Mushroom-Man Child [Hornet Ring]"
       ]
     },
     {
       "ID": 112390,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Darkwraith [Hornet Ring]"
       ]
     },
     {
       "ID": 112400,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Painting Guardian [Hornet Ring]"
       ]
     },
     {
       "ID": 112410,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Silver Knight [Hornet Ring]"
       ]
     },
     {
       "ID": 112500,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Hollow [Hornet Ring]"
       ]
     },
     {
       "ID": 112510,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Undead Merchant [Hornet Ring]"
       ]
     },
     {
       "ID": 112520,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Hollow Thief [Hornet Ring]"
       ]
     },
     {
       "ID": 112530,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Hollow Blowdart Sniper [Hornet Ring]"
       ]
     },
     {
       "ID": 112540,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Hollow Warrior [Hornet Ring]"
       ]
     },
     {
       "ID": 112550,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Hollow Soldier [Hornet Ring]"
       ]
     },
     {
       "ID": 112560,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Balder Knight [Hornet Ring]"
       ]
     },
     {
       "ID": 112640,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Andre of Astora [Hornet Ring]"
       ]
     },
     {
       "ID": 112650,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Hollow Necromancer [Hornet Ring]"
       ]
     },
     {
       "ID": 112660,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Hollow Maneater Butcher [Hornet Ring]"
       ]
     },
     {
       "ID": 112690,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Man-Serpent Soldier [Hornet Ring]"
       ]
     },
     {
       "ID": 112700,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Man-Serpent Sorcerer [Hornet Ring]"
       ]
     },
     {
       "ID": 112790,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Black Knight [Hornet Ring]"
       ]
     },
     {
       "ID": 112792,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Black Knight (Sword) [Hornet Ring]"
       ]
     },
     {
       "ID": 112793,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Black Knight (Greatsword) [Hornet Ring]"
       ]
     },
     {
       "ID": 112794,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Black Knight (Axe) [Hornet Ring]"
       ]
     },
     {
       "ID": 112795,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Black Knight (Halberd) [Hornet Ring]"
       ]
     },
     {
       "ID": 112800,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Hollow Crystal Soldier [Hornet Ring]"
       ]
     },
     {
       "ID": 112810,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Hollow Infested Barbarian (Club) [Hornet Ring]"
       ]
     },
     {
       "ID": 112811,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Hollow Infested Barbarian (Boulder) [Hornet Ring]"
       ]
     },
     {
       "ID": 112820,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "[UNUSED] Backstab - PC -> Hollow (Crag Worshipper) [Hornet Ring]"
       ]
     },
     {
       "ID": 112840,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Engorged Hollow [Hornet Ring]"
       ]
     },
     {
       "ID": 112900,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Skeleton [Hornet Ring]"
       ]
     },
     {
       "ID": 112920,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Vamos the Blacksmith [Hornet Ring]"
       ]
     },
     {
       "ID": 113300,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Pisaca [Hornet Ring]"
       ]
     },
     {
       "ID": 113460,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Fang Boar [Hornet Ring]"
       ]
     },
     {
       "ID": 114090,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Marvellous Chester [Hornet Ring]"
       ]
     },
     {
       "ID": 114130,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Scarecrow Gardener [Hornet Ring]"
       ]
     },
     {
       "ID": 114150,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Oolacile Resident (Melee) [Hornet Ring]"
       ]
     },
     {
       "ID": 114160,
       "Entries": [
-        "Backstab - PC ->  [Hornet Ring]"
+        "Backstab - PC -> Oolacile Resident (Sorceress) [Hornet Ring]"
       ]
     },
     {
       "ID": 122060,
       "Entries": [
-        "Parry - PC ->  [Hornet Ring]"
+        "Parry - PC -> Infested Ghoul [Hornet Ring]"
       ]
     },
     {
       "ID": 122390,
       "Entries": [
-        "Parry - PC ->  [Hornet Ring]"
+        "Parry - PC -> Darkwraith [Hornet Ring]"
       ]
     },
     {
       "ID": 122400,
       "Entries": [
-        "Parry - PC ->  [Hornet Ring]"
+        "Parry - PC -> Painting Guardian [Hornet Ring]"
       ]
     },
     {
       "ID": 122410,
       "Entries": [
-        "Parry - PC ->  [Hornet Ring]"
+        "Parry - PC -> Silver Knight [Hornet Ring]"
       ]
     },
     {
       "ID": 122500,
       "Entries": [
-        "Parry - PC ->  [Hornet Ring]"
+        "Parry - PC -> Hollow [Hornet Ring]"
       ]
     },
     {
       "ID": 122510,
       "Entries": [
-        "Parry - PC ->  [Hornet Ring]"
+        "Parry - PC -> Undead Merchant [Hornet Ring]"
       ]
     },
     {
       "ID": 122520,
       "Entries": [
-        "Parry - PC ->  [Hornet Ring]"
+        "Parry - PC -> Hollow Thief [Hornet Ring]"
       ]
     },
     {
       "ID": 122530,
       "Entries": [
-        "Parry - PC ->  [Hornet Ring]"
+        "Parry - PC -> Hollow Blowdart Sniper [Hornet Ring]"
       ]
     },
     {
       "ID": 122540,
       "Entries": [
-        "Parry - PC ->  [Hornet Ring]"
+        "Parry - PC -> Hollow Warrior [Hornet Ring]"
       ]
     },
     {
       "ID": 122550,
       "Entries": [
-        "Parry - PC ->  [Hornet Ring]"
+        "Parry - PC -> Hollow Soldier [Hornet Ring]"
       ]
     },
     {
       "ID": 122560,
       "Entries": [
-        "Parry - PC ->  [Hornet Ring]"
+        "Parry - PC -> Balder Knight [Hornet Ring]"
       ]
     },
     {
       "ID": 122640,
       "Entries": [
-        "Parry - PC ->  [Hornet Ring]"
+        "Parry - PC -> Andre of Astora [Hornet Ring]"
       ]
     },
     {
       "ID": 122660,
       "Entries": [
-        "Parry - PC ->  [Hornet Ring]"
+        "Parry - PC -> Hollow Maneater Butcher [Hornet Ring]"
       ]
     },
     {
       "ID": 122690,
       "Entries": [
-        "Parry - PC ->  [Hornet Ring]"
+        "Parry - PC -> Man-Serpent Soldier [Hornet Ring]"
       ]
     },
     {
       "ID": 122700,
       "Entries": [
-        "Parry - PC ->  [Hornet Ring]"
+        "Parry - PC -> Man-Serpent Sorcerer [Hornet Ring]"
       ]
     },
     {
       "ID": 122790,
       "Entries": [
-        "Parry - PC ->  [Hornet Ring]"
+        "Parry - PC -> Black Knight [Hornet Ring]"
       ]
     },
     {
       "ID": 122792,
       "Entries": [
-        "Parry - PC ->  [Hornet Ring]"
+        "Parry - PC -> Black Knight (Sword) [Hornet Ring]"
       ]
     },
     {
       "ID": 122793,
       "Entries": [
-        "Parry - PC ->  [Hornet Ring]"
+        "Parry - PC -> Black Knight (Greatsword) [Hornet Ring]"
       ]
     },
     {
       "ID": 122794,
       "Entries": [
-        "Parry - PC ->  [Hornet Ring]"
+        "Parry - PC -> Black Knight (Axe) [Hornet Ring]"
       ]
     },
     {
       "ID": 122795,
       "Entries": [
-        "Parry - PC ->  [Hornet Ring]"
+        "Parry - PC -> Black Knight (Halberd) [Hornet Ring]"
       ]
     },
     {
       "ID": 122800,
       "Entries": [
-        "Parry - PC ->  [Hornet Ring]"
+        "Parry - PC -> Hollow Crystal Soldier [Hornet Ring]"
       ]
     },
     {
       "ID": 122810,
       "Entries": [
-        "Parry - PC ->  [Hornet Ring]"
+        "Parry - PC -> Hollow Infested Barbarian (Club) [Hornet Ring]"
       ]
     },
     {
       "ID": 122820,
       "Entries": [
-        "Parry - PC ->  [Hornet Ring]"
+        "Parry - PC -> Hollow Infested Barbarian (Boulder) [Hornet Ring]"
       ]
     },
     {
       "ID": 122840,
       "Entries": [
-        "Parry - PC ->  [Hornet Ring]"
+        "Parry - PC -> Engorged Hollow [Hornet Ring]"
       ]
     },
     {
       "ID": 122900,
       "Entries": [
-        "Parry - PC ->  [Hornet Ring]"
+        "Parry - PC -> Skeleton [Hornet Ring]"
       ]
     },
     {
       "ID": 122920,
       "Entries": [
-        "Parry - PC ->  [Hornet Ring]"
+        "Parry - PC -> Vamos the Blacksmith [Hornet Ring]"
       ]
     },
     {
       "ID": 124130,
       "Entries": [
-        "Parry - PC ->  [Hornet Ring]"
+        "Parry - PC -> Scarecrow Gardener [Hornet Ring]"
       ]
     },
     {
       "ID": 124150,
       "Entries": [
-        "Parry - PC ->  [Hornet Ring]"
+        "Parry - PC -> Oolacile Resident (Melee) [Hornet Ring]"
       ]
     },
     {
       "ID": 124160,
       "Entries": [
-        "Parry - PC ->  [Hornet Ring]"
+        "Parry - PC -> Oolacile Resident (Sorceress) [Hornet Ring]"
       ]
     },
     {
       "ID": 125370,
       "Entries": [
-        "Parry - PC ->  [Hornet Ring]"
+        "Parry - PC -> Gwyn, Lord of Cinder [Hornet Ring]"
       ]
     },
     {
       "ID": 131202,
       "Entries": [
-        "Fall - PC ->  [Hornet Ring]"
+        "Fall - PC -> Giant Undead Rat [Hornet Ring]"
       ]
     },
     {
       "ID": 132231,
       "Entries": [
-        "Fall - PC ->  [Hornet Ring]"
+        "Fall - PC -> Demon Firesage [Hornet Ring]"
       ]
     },
     {
       "ID": 132232,
       "Entries": [
-        "Fall - PC ->  [Hornet Ring]"
+        "Fall - PC -> Asylum Demon [Hornet Ring]"
       ]
     },
     {
       "ID": 132250,
       "Entries": [
-        "Fall - PC ->  [Hornet Ring]"
+        "Fall - PC -> Taurus Demon [Hornet Ring]"
       ]
     },
     {
       "ID": 133460,
       "Entries": [
-        "Fall - PC ->  [Hornet Ring]"
+        "Fall - PC -> Fang Boar [Hornet Ring]"
       ]
     },
     {
       "ID": 133461,
       "Entries": [
-        "Fall - PC ->  [Hornet Ring]"
+        "Fall - PC -> Fang Boar (Fully-Armored) [Hornet Ring]"
       ]
     },
     {
@@ -916,13 +916,13 @@
     {
       "ID": 229000,
       "Entries": [
-        "Throw - X -> PC"
+        "Throw - Chained Prisoner (Proto) -> PC"
       ]
     },
     {
       "ID": 230000,
       "Entries": [
-        "Throw - Prowling Demon -> PC"
+        "Throw - Titanite Demon -> PC"
       ]
     },
     {
@@ -982,13 +982,13 @@
     {
       "ID": 252000,
       "Entries": [
-        "Backstab - Undead Assassin -> PC"
+        "Backstab - Hollow Thief -> PC"
       ]
     },
     {
       "ID": 252001,
       "Entries": [
-        "Parry - Undead Assassin -> PC"
+        "Parry - Hollow Thief -> PC"
       ]
     },
     {
@@ -1006,25 +1006,25 @@
     {
       "ID": 266000,
       "Entries": [
-        "Throw - Butcher -> PC"
+        "Throw - Hollow Maneater Butcher -> PC"
       ]
     },
     {
       "ID": 267000,
       "Entries": [
-        "Throw - Ghost (Male)   -> PC"
+        "Throw - Cursed Ghost (Male)   -> PC"
       ]
     },
     {
       "ID": 268000,
       "Entries": [
-        "Throw - Ghost (Female) -> PC"
+        "Throw - Cursed Ghost (Female) -> PC"
       ]
     },
     {
       "ID": 270000,
       "Entries": [
-        "Throw - Serpent Mage -> PC"
+        "Throw - Man-Serpent Sorcerer -> PC"
       ]
     },
     {
@@ -1048,7 +1048,7 @@
     {
       "ID": 320000,
       "Entries": [
-        "Throw - Slime -> PC [1]"
+        "Throw - Slime -> PC"
       ]
     },
     {
@@ -1072,7 +1072,7 @@
     {
       "ID": 325000,
       "Entries": [
-        "Throw - Maneater Clam -> PC"
+        "Throw - Man-Eater Shell -> PC"
       ]
     },
     {
@@ -1090,25 +1090,25 @@
     {
       "ID": 339000,
       "Entries": [
-        "Throw - Burrower -> PC"
+        "Throw - Burrowing Rockworm -> PC"
       ]
     },
     {
       "ID": 339001,
       "Entries": [
-        "Throw - Burrower -> PC"
+        "Throw - Burrowing Rockworm -> PC"
       ]
     },
     {
       "ID": 339002,
       "Entries": [
-        "Throw - Burrower -> PC"
+        "Throw - Burrowing Rockworm -> PC"
       ]
     },
     {
       "ID": 451000,
       "Entries": [
-        "Throw - Kalameet -> PC"
+        "Throw - Black Dragon Kalameet -> PC"
       ]
     },
     {
@@ -1138,13 +1138,13 @@
     {
       "ID": 527000,
       "Entries": [
-        "Throw - Dragonslayer Ornstein -> PC"
+        "Throw - Dragon Slayer Ornstein -> PC"
       ]
     },
     {
       "ID": 527100,
       "Entries": [
-        "Throw - Dragonslayer Ornstein (Giant) -> PC"
+        "Throw - Dragon Slayer Ornstein (Giant) -> PC"
       ]
     },
     {


### PR DESCRIPTION
Supersedes #277, which was started before the format of community row names changed
An overhaul to the General Param community names for DS1/DS1R. 
Not all of the params are done yet, but I figured I'd put up a draft PR to get feedback on formatting and the like.
Aside from minor fix commits, every param is split into its own commit to make looking at changes easier

<details><summary>Param List</summary>
<p>

- [ ] AtkParam_Npc
- [ ] AtkParam_Pc
- [ ] BehaviorParam
- [ ] BehaviorParam_PC
- [ ] Bullet
- [x] CalcCorrectGraph
- [x] CharaInitParam
- [ ] CoolTimeParam
- [x] EquipMtrlSetParam
- [x] EquipParamAccessory - No changes needed
- [x] EquipParamGoods
- [x] EquipParamProtector - No changes needed
- [x] EquipParamWeapon - No changes needed
- [x] FaceGenParam
- [x] GameAreaParam
- [x] HitMtrlParam
- [ ] ItemLotParam
- [ ] KnockBackParam
- [ ] LevelSyncParam
- [x] LockCamParam
- [ ] Magic
- [x] MenuColorTableParam
- [x] MoveParam
- [x] NpcParam
- [x] NpcThinkParam
- [ ] ObjActParam
- [ ] ObjectParam
- [ ] QwcChange
- [ ] QwcJudge
- [x] RagdollParam
- [ ] ReinforceParamProtector
- [ ] ReinforceParamWeapon
- [ ] ShopLineupParam
- [ ] SkeletonParam
- [ ] SpEffectParam
- [ ] SpEffectVfxParam
- [x] TalkParam
- [x] ThrowParam
- [ ] WhiteCoolTimeParam

</p>
</details> 

I do also have some notes on my changes to give reasoning for changes, or to mark a translation I am unsure of.

<details><summary>Character Names</summary>
<p>

Many names have been replaced with what the DS1R FuturePress guidebook calls them, as I would consider it more up to date and accurate than the original DS1 guidebook. Although with that said, in some cases the game itself has more than one name for a character, and sometimes that is slightly different than the guidebook. For example, NPC summons/invasions usually will have a shorter name compared to the NPC's more formal title ("Knight Solaire" in game vs "Solaire of Astora" in the guidebook).

I hope using DS1R guidebook names doesn't cause any confusion, because basically every wiki has at least a few incorrect names (in the case of the Wikidot its mostly that they use the old DS1 guidebook names. For fextralife its because its absolute garbage and has just made up names)

Class name translations:
Many older machine translations have some of the classes incorrect, so I wanted to show how I've changed them based on cross-referencing how the params are used as well as the kanji vs translations which were already correct.
  - "Sorcerer" -> "Pyromancer" (Sometimes params labelled as Sorcerer were already correct, those are unchanged)
  - "Wizard" & "Magician" -> "Sorcerer"
  - "Monk" -> "Cleric"
  - "Voyeur" -> "Thief"
  - "Not possessed" & "What You Don't Have" -> "Deprived" (I just think this one is funny)

I don't think I actually changed any param names for this, but I do want to make note of it. "Marvellous" in Marvellous Chester's name is using the UK English spelling of the word, even though the game I believe mostly uses US English? However the messages for when he invades you _and_ the guidebook call him "Marvelous Chester" with the US English spelling (1 L rather than 2). I've decided to stick with the UK spelling that he is called in his own dialogue.

Unused params named "Witch Mallows" has been changed to "Witch Beatrice". This one is a bit of a stretch since all but one param still named "Witch Mallows" (or "魔女マロース") is unused. Witch Beatrice's params are all called simply "Witch" (or "魔女"), _except_ the FaceGenParam she uses, which was named "魔女マロース", so I'm assuming its the same character. Since this is unused content, I could definitely see leaving it as is.

For NPCs that have multiple variants, I've added little descriptive labels to their name to clarify which one they are, including:
  - if an NPC param is a summon
  - Invader
  - Invaded (black eye orb stuff)
  - Hollow
  - Black phantom (enemies spawned by Gravelord Servant)
  - Weapon (for enemies with multiple weapon variants)
  - Unused (if not immediately clear from name, although I probably missed some unused enemy variants for specific areas)
  - Basically whatever else the devs left notes for

</p>
</details> 

<details><summary>Area Names</summary>
<p>

Mostly just in case someone wants to know what the internal names actually refer to
- Base -> Firelink Shrine
- Castle 1 -> 1st Half is Undead Burg, 2nd Half is Undead Parish
- Castle 2 -> The Depths
- Moriwaba -> 1st Half appears to be the Moonlight Butterfly part of Darkroot Garden/Basin, and 2nd Half appears to be the area after the Crest of Artorias door
- Cemetery 1 -> The Catacombs
- Cemetery 2 -> Tomb of the Giants
- Underground Lake -> Ash Lake
- Kagemachi -> Blighttown
- Closed City -> Demon Ruins/Lost Izalith
- Royal Castle 1/Ojo 1 -> Sen's Fortress
- Royal Castle 2/Ojo 2 -> Anor Londo
  - For some reason this was translated in 2 ways sometimes. Ojo appears to be the pronunciation for the Kanji rather than a translation.
- Abyss -> New Londo Ruins
  - While the Abyss is an actual area, its usage here seems to imply they're just talking about New Londo as a whole
- Crystal Tower -> Duke's Archives/Crystal Cave
- Great Tomb -> Kiln of the First Flame
- Tutorial -> Undead Asylum
- Painting World -> Painted World (I've only seen this listed in GameAreaParam, not sure if it is used anywhere else)

</p>
</details>

<details><summary>Other</summary>
<p>

I've replaced references to "DS2" with "DeS2", to clarify that it is meant to be for "Demon's Souls 2" (aka Dark Souls 1), rather than for Dark Souls 2.
Although tbh it probably would be better to replace it with something like "DS1 Proto".

the Skeleton NpcThinkParams that are labelled with '"Lunging Drill" Attack' are the ones that do that weird emperor palpatine jump and spin attack at you in the Catacombs. A translation of the JP is more like "Screw" attack, but this is another thing where I decided to take the name from the guidebook, since i figured anything I came up with would probably be confusing to someone no matter what and at least the guidebook name is kinda official.

</p>
</details> 

<details><summary>Needs better translations</summary>
<p>

My Japanese skills are very _very_ beginner, and while my translations aren't just dropped into machine translation, I did make heavy use of a dictionary and google translate, the latter of which mostly to just try and understand context a bit better, although even the raw output from that now is a hell of a lot better than whatever was used to machine translate many of these params like over a decade ago.
Because of this I hope someone that has much better knowledge of Japanese can come and double check my work

These are listed by ID, not index.
NpcParam:
- 1: Atarisawari (Unobtrusive?) Data (Recommended Source For Copy \u0026 Paste)
  - formerly "Atarisawari data (copy and paste recommended)-Unobtrusive data (copy and paste recommended)". I'm not entirely sure what "Atarisawari" is, but the rest of the translation seemed relatively correct so I assume that maybe the "Unobtrusive" is at least sort of correct? This seems to be a template param to copy/paste for a simple bipedal NPC
- 510: DeS2 Test - Knight Assumed(?)
  - I only really changed the formatting for this one, but I'm not sure what is meant by "Knight Assumed", maybe an NPC thats supposed to be a knight or that you're supposed to think is a knight?
- 540, 541, 550, 551: "DeS2 Test - For Watanabe(?)", "DeS2 Test - Managed by Watanabe(?)", etc.
  - I assume that Watanabe is the name of a dev who these params are for. The fact that 541 and 551 are seemingly the same but labelled as "spare" is interesting and honestly confuses me more.
- 1003: DeS2 (End of April?) - Gate Closing NPC
  - Labelled sort of similarly to other params which i was pretty sure were named something like "End of April" or "April 2011", but this one uses the characters "4末〆", with that last character being something that even after reading about I still don't understand.
- 225003: [Unused] Lesser Taurus Demon (7 Heroes??)
  - I have no clue what this is referring to. This param is unused, but the same ID is used in NpcThinkParam for the 2 Taurus Demon's to the left of Demon Firesage's arena. That one is simply labelled as "Won't Leave Home". So I assume this is cut content, but I'd like to at least get some confirmation that "7 Heroes" is in fact what the Japanese text says
- 413001, 413011: Scarecrow Gardener (Pitchfork/Shears - Cast Off?)
  - Looking at the model mask, this Scarecrow Gardener is missing its shirt & pants, but does still have tools on its back (the shirtless one doesn't), so I guess maybe this one is more like "nude"? it does still have a little waistcloth on though. looking for suggestions on what to call this barely clothed individual

NpcThinkParam:
Mostly the same unsure translations as NpcParam, but there are a few ones unique to this param
- 702: Beggar For calling Friends Test (Different Room?)
  - Looking at a dictionary I think this could be something like "Wrong room"? Like you walk into the wrong room and then the enemy calls for help.
- 269010: Man-Serpent Soldier (Crystal Performance?)
  - Used for the Man-Serpent Soldiers who run up to the top of the Duke's Archives jail and climb the ladder when the alarm starts blaring. Idk a good way to describe them.
- 278002: Mimic (Again, Can't Leave Home [injoke?])
  - As stated, I'm unsure if this is an injoke or just me poorly translating it. it comes right after "Mimic (Can't Leave Home)", and the only difference is that this one has an even _shorter_ range to fight you before going back home. Probably could leave this as something like "Mimic (Can't Leave Home - Shorter Range)"

MenuColorTableParam:
- 9: Background Plate (Concentration (brightness?) Adjustment)
  - I'm actually relatively sure of the translation here, just not sure of where this is used. My best guess is that its for the brightness adjustment menu but I haven't tested
- 24: Menu Tab (Camp) (Bonfire?)
  - i don't know if I've ever seen them refer to the bonfires as "camps", but this is my best guess as to what this is for.

MoveParam:
Mostly DeS stuff that I'm not as familiar with
- 109: DeS Armor Spider Peeking(??)
  - No clue what this is, the JP text says "Giant Spider" and its among the DeS stuff so I assume its Armor Spider, but idk what the other word is meant to be.
- 113: DeS Storm King (Child) Bichibichi Wait
  - Idk if the Storm King's minions have official names, and I have a hunch that "Bichibichi" (or "ビチビチ") is onomatopoeia but I have no clue what for.
- 118: DeS Shadowlurker (Female)? (For Disappearing)
  - I couldn't figure out what enemy this was talking about.
- 119: DeS For Blood Mites (Giant Tick?)
  - Giant Tick is my best guess as to what enemy this is for but it could be like 3 different enemies in the Valley of Defilement so I have no clue.
- 1003: [Unused] DeS Player - Dying?
  - Looked at the anims and it seems like its a sort of stumbling walk I assume to transition into a death anim? didn't check in game.

GameAreaParam:
- 100: [Unused] DeS Beneath the Nexus (King Allant?)
  - JP text is approximately "Stone Pillar", but it seems to fit the ID of the Nexus in DeS, although the soul amount for clearing the area doesn't seem to match up with anything I could find.

LockCamParam:
- 1: Summoning Magic Range (summon as in player summon or as in cast magic?)
  - Unsure if this is used or not, maybe its there for devs to change to in the debug menu to visualize the range at which summon signs should show up? I have no clue.
- 1300, 1301: [UNUSED] The Catacombs/Tomb of the Giants(?) (Close/Far)
  - Doesn't use the same characters as other references to these maps, and they're not used, but the ID matches up with the map ID (13_00 for catacombs)
- 10005: Camera (A bit Wider(?) - Prototype Map)
  - fields seem to be a bit further than "Medium" but not quite as much as "Far".

</p>
</details> 