### PR TITLE
Fix memory mapped file access, BTLs

### DIFF
--- a/src/Andre/Andre.Formats/BinderArchive.cs
+++ b/src/Andre/Andre.Formats/BinderArchive.cs
@@ -154,7 +154,10 @@ namespace Andre.Formats
 
         public BinderArchive(string bhdPath, string bdtPath, Game game)
         {
-            using var file = MemoryMappedFile.CreateFromFile(bhdPath, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+
+            var fs = new FileStream(bhdPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var file = MemoryMappedFile.CreateFromFile(fs, null, 0, MemoryMappedFileAccess.Read,
+                HandleInheritability.None, leaveOpen: false);
             using var accessor = file.CreateMemoryAccessor(0, 0, MemoryMappedFileAccess.Read);
 
             if (IsBhdEncrypted(accessor.Memory))

--- a/src/Andre/SoulsFormats/SoulsFormats/Binder/BND4/BND4Reader.cs
+++ b/src/Andre/SoulsFormats/SoulsFormats/Binder/BND4/BND4Reader.cs
@@ -40,9 +40,20 @@ namespace SoulsFormats
         /// </summary>
         public BND4Reader(string path)
         {
-            _mappedFile = MemoryMappedFile.CreateFromFile(path, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            _mappedFile = MemoryMappedFile.CreateFromFile(fs, null, 0, MemoryMappedFileAccess.Read,
+            HandleInheritability.None, leaveOpen: false);
             _mappedAccessor = _mappedFile.CreateMemoryAccessor(0, 0, MemoryMappedFileAccess.Read);
             var br = new BinaryReaderEx(false, _mappedAccessor.Memory);
+            br = SFUtil.GetDecompressedBR(br, out DCX.Type compression);
+            if (compression != DCX.Type.None)
+            {
+                // We can safely dispose of the memory mapped file accessor,
+                // because decompression produced a new reader to use going forward.
+                // Keeping it open at this point only wastes RAM we'll never access.
+                _mappedAccessor.Dispose();
+                _mappedAccessor = null;
+            }
             Read(br);
         }
 

--- a/src/Smithbox.Program/Editors/MapEditor/Universe.cs
+++ b/src/Smithbox.Program/Editors/MapEditor/Universe.cs
@@ -290,12 +290,10 @@ public class Universe
         }
         else
         {
-            if (File.Exists(curEntry.Path))
-            {
-                var btlFile = (Memory<byte>)Editor.Project.MapData.PrimaryBank.TargetFS.ReadFile(curEntry.Path);
+            Memory<byte>? btlFile = (Memory<byte>)Editor.Project.MapData?.PrimaryBank.TargetFS.ReadFile(curEntry.Path);
 
-                btl = BTL.Read(btlFile);
-            }
+            if (btlFile.HasValue)
+                btl = BTL.Read(btlFile.Value);
         }
 
         return btl;

--- a/src/Smithbox.Program/Resource/HavokCollisionManager.cs
+++ b/src/Smithbox.Program/Resource/HavokCollisionManager.cs
@@ -132,6 +132,7 @@ public class HavokCollisionManager
                         {
                             if (xmlSerializer == null)
                                 xmlSerializer = new HavokXmlSerializer();
+                            memoryStream.Position = 0;
                             fileHkx = (hkRootLevelContainer)xmlSerializer.Read(memoryStream);
                         }
 


### PR DESCRIPTION
BTLs weren't loading at all because they were trying to File.Exists a fake relative path.

Files were blocked due to BNDs being memory-mapped, which would also keep them in memory twice despite being decompressed which creates a separate memory region with a separate reader.