### PR TITLE
Remove er auto map offset preference and force it

### DIFF
--- a/src/Smithbox.Program/Configuration/CFG.cs
+++ b/src/Smithbox.Program/Configuration/CFG.cs
@@ -768,7 +768,6 @@ public class CFG
     public bool Viewport_Enable_Texturing = true;
     public bool Viewport_Enable_Culling = true;
 
-    public bool Viewport_Enable_ER_Auto_Map_Offset = true;
     public bool Viewport_Enable_Selection_Outline = true;
     public bool Viewport_Enable_Model_Masks = true;
     public bool Viewport_Enable_LOD_Facesets = false;

--- a/src/Smithbox.Program/Configuration/Settings/EditorSettings.cs
+++ b/src/Smithbox.Program/Configuration/Settings/EditorSettings.cs
@@ -281,9 +281,6 @@ public class MapEditorTab
             {
                 if (BaseEditor.ProjectManager.SelectedProject.ProjectType is ProjectType.ER)
                 {
-                    ImGui.Checkbox("Enable Elden Ring auto map offset", ref CFG.Current.Viewport_Enable_ER_Auto_Map_Offset);
-                    UIHelper.Tooltip("");
-
                     ImGui.Checkbox("Enable Elden Ring collisions", ref CFG.Current.MapEditor_LoadCollisions_ER);
                     UIHelper.Tooltip("Enables the viewing of Elden Ring collisions. Note this will add delay to map loading if enabled.");
                 }

--- a/src/Smithbox.Program/Editors/MapEditor/Universe.cs
+++ b/src/Smithbox.Program/Editors/MapEditor/Universe.cs
@@ -155,7 +155,7 @@ public class Universe
 
                 if (CFG.Current.Viewport_Enable_Rendering)
                 {
-                    if (Editor.Project.ProjectType == ProjectType.ER && CFG.Current.Viewport_Enable_ER_Auto_Map_Offset)
+                    if (Editor.Project.ProjectType == ProjectType.ER)
                     {
                         if (SpecialMapConnections.GetEldenMapTransform(Editor, mapid) is Transform
                             loadTransform)


### PR DESCRIPTION
Artists coming from previous versions of Smithbox have encountered their "Enable Elden Ring auto map offset" preference being set to false. The preference is in fact set to true by default in the source code, however it only seems to truly take affect if it hasn't been changed by the user before at all.

The use cases for this preference being off are minimal, and artists have shared the sentiment that the map offset logic should be hardcoded. This PR removes the preference and forces the map offset logic to always execute for ELDEN RING maps.