### PR TITLE
fixed not being able to save regulation.bin on linux

### DIFF
--- a/src/Andre/Andre.IO/VFS/RealVirtualFileSystem.cs
+++ b/src/Andre/Andre.IO/VFS/RealVirtualFileSystem.cs
@@ -129,13 +129,13 @@ namespace Andre.IO.VFS
             {
                 fileName = fileName.TrimStart('/').TrimStart('\\');
                 string filePath = Path.Combine(path, fileName);
-                if (TryGetFile(filePath, out var file))
+                if (TryGetFile(fileName, out var file))
                 {
                     return file;
                 }
                 if (isReadOnly) throw ThrowWriteNotSupported();
                 File.Create(filePath).Dispose();
-                if (!TryGetFile(filePath, out file))
+                if (!TryGetFile(fileName, out file))
                 {
                     throw new($"Failed to create file \"{filePath}\"... somehow?");
                 }


### PR DESCRIPTION
* fix - not able to save regulation.bin and getting error: [General] Failed to save: regulation.bin - System.Exception: Failed to create file "/path/to/project/directory/regulation.bin.temp"... somehow? at
Andre.IO.VFS.RealVirtualFileSystem.RealVirtualDirectory.GetOrCreateFile(String fileName) in ./src/Andre/Andre.IO/VFS/RealVirtualFileSystem.cs:line 140 at Andre.IO.VFS.VirtualFileSystem.GetOrCreateFile(VFSPath path) in ./src/Andre/Andre.IO/VFS/VirtualFileSystem.cs:line 327 at Andre.IO.VFS.VirtualFileSystem.WriteFile(VFSPath path, Byte[] data) in ./src/Andre/Andre.IO/VFS/VirtualFileSystem.cs:line 321 at Andre.IO.VFS.VirtualFileSystem.WriteFile(String path, Byte[] data) in ./src/Andre/Andre.IO/VFS/VirtualFileSystem.cs:line 312 at StudioCore.Core.ProjectUtils.WriteWithBackup[T](ProjectEntry curProject, VirtualFileSystem vanillaFs, VirtualFileSystem toFs, String assetPath, T item, ProjectType gameType, Object[] writeparms) in ./src/Smithbox.Program/Core/ProjectUtils.cs:line 326

#319 