### PR TITLE
fix linux build

### DIFF
--- a/src/Smithbox.Program/Application/Developer/Tools/WorldMapLayoutGenerator.cs
+++ b/src/Smithbox.Program/Application/Developer/Tools/WorldMapLayoutGenerator.cs
@@ -2,6 +2,7 @@
 using StudioCore.Utilities;
 using System.Collections.Generic;
 using System.IO;
+using System;
 
 namespace StudioCore.Application;
 


### PR DESCRIPTION
Micro-fix to get the project to build under linux — without it, Environment class is not found.
Tested with dotnet 9.0

Instructions for building on non-windows platforms would be nice, especially since this uses unconventional `dotnet build -C Release-linux` syntax instead of `dotnet build -C Release --os linux` and manual fetching of liboo2corelinux64.so.9 is required (from [privately-accessible](https://gist.github.com/sehnryr/ff4dacaa44b023a7cce1dbecc2648e09) git repo of Unreal Engine)