### PR TITLE
Bugfix - Exception for text editor import to prevent crashing

### DIFF
--- a/src/Smithbox.Program/Editors/Text Editor/Tools/FmgImporter.cs
+++ b/src/Smithbox.Program/Editors/Text Editor/Tools/FmgImporter.cs
@@ -251,7 +251,14 @@ public class FmgImporter
                 {
                     using (var stream = File.OpenRead(path))
                     {
-                        wrapper = JsonSerializer.Deserialize(stream, StoredContainerWrapperSerializationContext.Default.StoredFmgContainer);
+                        try
+                        {
+                            wrapper = JsonSerializer.Deserialize(stream, StoredContainerWrapperSerializationContext.Default.StoredFmgContainer);
+                        }
+                        catch
+                        {
+                            continue;
+                        }
                     }
                 }
 


### PR DESCRIPTION
Added an exception for files in the workflow text directory that cannot be deserialized, preventing a crash from happening when an import > file is hovered over.
Relates to issue #455 