### PR TITLE
SDT: Row Names

### DIFF
--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/ActionButtonParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/ActionButtonParam.json
@@ -4,223 +4,223 @@
     {
       "ID": 0,
       "Entries": [
-        "Test 0 -- テスト0"
+        ""
       ]
     },
     {
       "ID": 1,
       "Entries": [
-        "Test 1 -- テスト1"
+        ""
       ]
     },
     {
       "ID": 1000,
       "Entries": [
-        "Regain lost life -- 失ったライフを取り戻す"
+        ""
       ]
     },
     {
       "ID": 1010,
       "Entries": [
-        "Take a life -- ライフをとる"
+        ""
       ]
     },
     {
       "ID": 1020,
       "Entries": [
-        "Read the tombstone -- 墓碑を読む"
+        ""
       ]
     },
     {
       "ID": 2000,
       "Entries": [
-        "Read the letter (summon) -- 手紙を読む（召喚）"
+        ""
       ]
     },
     {
       "ID": 2001,
       "Entries": [
-        "Read the letter (summon a red sign) -- 手紙を読む（赤サイン召喚）"
+        ""
       ]
     },
     {
       "ID": 2010,
       "Entries": [
-        "Check your letter (summon) -- 自分の手紙を確認する（召喚）"
+        ""
       ]
     },
     {
       "ID": 3000,
       "Entries": [
-        "Read letter (blood letter) _ Used in NTCSTADIA version -- 手紙を読む（血文字）_NTCSTADIA版で使用"
+        "Touch Remnant"
       ]
     },
     {
       "ID": 3010,
       "Entries": [
-        "Check your letter (blood letters) _ Used in NTCSTADIA version -- 自分の手紙を確認する（血文字）_NTCSTADIA版で使用"
+        "Touch your created Remnant"
       ]
     },
     {
       "ID": 4000,
       "Entries": [
-        "Pick up an item -- アイテムを拾う"
+        "Pick Up Item"
       ]
     },
     {
       "ID": 4050,
       "Entries": [
-        "Pick up items (for water surface) -- アイテムを拾う(水面用)"
+        "Pick Up Item"
       ]
     },
     {
       "ID": 4100,
       "Entries": [
-        "Scour the corpse -- 死体をあさる"
+        "Pick Up Item"
       ]
     },
     {
       "ID": 4200,
       "Entries": [
-        "Purse _360 ° -- 巾着をあさる_360°"
+        "Pick Up Item"
       ]
     },
     {
       "ID": 4201,
       "Entries": [
-        "Purse _180 ° -- 巾着をあさる_180°"
+        "Pick Up Item"
       ]
     },
     {
       "ID": 4202,
       "Entries": [
-        "Purse _100 ° -- 巾着をあさる_100°"
+        "Pick Up Item"
       ]
     },
     {
       "ID": 4210,
       "Entries": [
-        "Underwater purse _360 ° -- 水中巾着をあさる_360°"
+        "Pick Up Item"
       ]
     },
     {
       "ID": 4211,
       "Entries": [
-        "Underwater purse _180 ° -- 水中巾着をあさる_180°"
+        "Pick Up Item"
       ]
     },
     {
       "ID": 4215,
       "Entries": [
-        "Underwater purse _360 ° _for shallow water_used in sick village -- 水中巾着をあさる_360°_浅瀬用_病み村で使用"
+        "Pick Up Item"
       ]
     },
     {
       "ID": 4220,
       "Entries": [
-        "Squeeze a purse in a high place _360 ° -- 高い所の巾着をあさる_360°"
+        "Pick Up Item"
       ]
     },
     {
       "ID": 4300,
       "Entries": [
-        "Take the treasure -- 宝物をとる"
+        "Pick Up Item"
       ]
     },
     {
       "ID": 4400,
       "Entries": [
-        "OK -- OK"
+        "OK"
       ]
     },
     {
       "ID": 5000,
       "Entries": [
-        "Climb the ladder -- はしごをのぼる"
+        ""
       ]
     },
     {
       "ID": 5010,
       "Entries": [
-        "Ladder -- はしごをおりる"
+        ""
       ]
     },
     {
       "ID": 5020,
       "Entries": [
-        "Stick -- 張り付く"
+        ""
       ]
     },
     {
       "ID": 5030,
       "Entries": [
-        "Hanging -- ぶら下がる"
+        ""
       ]
     },
     {
       "ID": 5031,
       "Entries": [
-        "Hanging -- ぶら下がる"
+        ""
       ]
     },
     {
       "ID": 5040,
       "Entries": [
-        "Grab the clouds -- 雲をつかむ"
+        ""
       ]
     },
     {
       "ID": 5100,
       "Entries": [
-        "Ritual: grab -- 儀式：つかむ"
+        ""
       ]
     },
     {
       "ID": 5110,
       "Entries": [
-        "Ritual -- 儀式"
+        ""
       ]
     },
     {
       "ID": 5111,
       "Entries": [
-        "Ritual: Level up -- 儀式：レベルアップ"
+        ""
       ]
     },
     {
       "ID": 5112,
       "Entries": [
-        "Ritual: Reassign status -- 儀式：ステータス振りなおし"
+        ""
       ]
     },
     {
       "ID": 5113,
       "Entries": [
-        "Ritual: Reset the deceased -- 儀式：亡者度リセット"
+        ""
       ]
     },
     {
       "ID": 5114,
       "Entries": [
-        "Ritual: Atonement -- 儀式：贖罪"
+        ""
       ]
     },
     {
       "ID": 5115,
       "Entries": [
-        "Ritual: Summon NPC White Spirit -- 儀式：NPC白霊召喚"
+        ""
       ]
     },
     {
       "ID": 5116,
       "Entries": [
-        "Ritual: Bomb -- 儀式：ボム"
+        ""
       ]
     },
     {
       "ID": 5117,
       "Entries": [
-        "Ritual: No invasion -- 儀式：侵入禁止"
+        ""
       ]
     },
     {
@@ -244,7 +244,7 @@
     {
       "ID": 6100,
       "Entries": [
-        "Light a bonfire -- 篝火を灯す"
+        "Commune with Sculptor's Idol"
       ]
     },
     {

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/ActionGuideParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/ActionGuideParam.json
@@ -4,7 +4,7 @@
     {
       "ID": 0,
       "Entries": [
-        "Do not change"
+        ""
       ]
     },
     {

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/ActionUnlockParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/ActionUnlockParam.json
@@ -4,7 +4,7 @@
     {
       "ID": 0,
       "Entries": [
-        "None"
+        ""
       ]
     },
     {
@@ -154,211 +154,211 @@
     {
       "ID": 910010,
       "Entries": [
-        "Debugging skills lifted: Castle"
+        "\n"
       ]
     },
     {
       "ID": 910020,
       "Entries": [
-        "Debugging skills lifted: Samurai residence"
+        "\n"
       ]
     },
     {
       "ID": 910030,
       "Entries": [
-        "Debugging skills lifted: Honjo"
+        "\n"
       ]
     },
     {
       "ID": 910040,
       "Entries": [
-        "Debugging skills lifted: Hidden prison"
+        "\n"
       ]
     },
     {
       "ID": 910050,
       "Entries": [
-        "Debugging skills lifted: Dungeon"
+        "\n"
       ]
     },
     {
       "ID": 910060,
       "Entries": [
-        "Debugging skills lifted: Temple"
+        "\n"
       ]
     },
     {
       "ID": 910070,
       "Entries": [
-        "Debugging skills lifted: Valley"
+        "\n"
       ]
     },
     {
       "ID": 910080,
       "Entries": [
-        "Debugging skills lifted: Lower valley"
+        "\n"
       ]
     },
     {
       "ID": 910090,
       "Entries": [
-        "Debugging Skills Lifted: Sick Village "
+        "\n"
       ]
     },
     {
       "ID": 910100,
       "Entries": [
-        "Debugging skill lifted: Honjo_Ninja army invasion"
+        "\n"
       ]
     },
     {
       "ID": 910110,
       "Entries": [
-        "Debugging skill lifted: Submerged city"
+        "\n"
       ]
     },
     {
       "ID": 910120,
       "Entries": [
-        "Debugging skills lifted: Honjo Tokugawa invasion "
+        "\n"
       ]
     },
     {
       "ID": 910130,
       "Entries": [
-        "Debugging skill lifted: Hidden prison when Tokugawa attacks "
+        "\n"
       ]
     },
     {
       "ID": 910140,
       "Entries": [
-        "Debugging skills lifted: Castle Tokugawa invasion "
+        "\n"
       ]
     },
     {
       "ID": 910150,
       "Entries": [
-        "Debugging skills lifted: Game clear"
+        "\n"
       ]
     },
     {
       "ID": 920000,
       "Entries": [
-        "Debugging skills lifted: New game for checking enemies "
+        "\n"
       ]
     },
     {
       "ID": 920010,
       "Entries": [
-        "Debugging skill lifted: Castle for checking enemies "
+        "\n"
       ]
     },
     {
       "ID": 920020,
       "Entries": [
-        "Debugging skills lifted: Samurai residence for checking enemies"
+        "\n"
       ]
     },
     {
       "ID": 920030,
       "Entries": [
-        "Debugging skill lifted: Honjo for checking enemies"
+        "\n"
       ]
     },
     {
       "ID": 920040,
       "Entries": [
-        "Debugging skill lifted: Hidden prison for checking enemies"
+        "\n"
       ]
     },
     {
       "ID": 920050,
       "Entries": [
-        "Debugging skills lifted: Enemy check dungeon"
+        "\n"
       ]
     },
     {
       "ID": 920060,
       "Entries": [
-        "Debugging skill lifted: Enemy check temple"
+        "\n"
       ]
     },
     {
       "ID": 920070,
       "Entries": [
-        "Debugging skills lifted: Enemy check valley"
+        "\n"
       ]
     },
     {
       "ID": 920080,
       "Entries": [
-        "Debugging skill lifted: Lower layer of valley for checking enemies"
+        "\n"
       ]
     },
     {
       "ID": 920090,
       "Entries": [
-        "Debugging skill lifted: Enemy check sick village"
+        "\n"
       ]
     },
     {
       "ID": 920100,
       "Entries": [
-        "Debugging skill lifted: Enemy check Honjo Ninja army invasion"
+        "\n"
       ]
     },
     {
       "ID": 920110,
       "Entries": [
-        "Debugging skill lifted: Submerged city for checking enemies"
+        "\n"
       ]
     },
     {
       "ID": 920120,
       "Entries": [
-        "Debugging skill lifted: Enemy check Honjo when Tokugawa attacks"
+        "\n"
       ]
     },
     {
       "ID": 920130,
       "Entries": [
-        "Debugging skill lifted: Hidden prison for checking enemies When Tokugawa attacks"
+        "\n"
       ]
     },
     {
       "ID": 920140,
       "Entries": [
-        "Debugging skill lifted: Enemy check castle Tokugawa invasion"
+        "\n"
       ]
     },
     {
       "ID": 920150,
       "Entries": [
-        "Debugging skill lifted: Clear enemy check game "
+        "\n"
       ]
     },
     {
       "ID": 999996,
       "Entries": [
-        "Lifting of all actions for debugging No derivative attacks"
+        "\n"
       ]
     },
     {
       "ID": 999997,
       "Entries": [
-        "Lifting of the ban on all actions for debugging except for immortal slashing / acquisition of form charges"
+        "\n"
       ]
     },
     {
       "ID": 999998,
       "Entries": [
-        "All actions for debugging have been lifted except for immortal slashing"
+        "\n"
       ]
     },
     {
       "ID": 999999,
       "Entries": [
-        "All actions for debugging have been lifted"
+        "\n"
       ]
     }
   ]

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/AiSoundParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/AiSoundParam.json
@@ -4,7 +4,7 @@
     {
       "ID": 0,
       "Entries": [
-        "Default (do not edit)"
+        ""
       ]
     },
     {

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/AtkParam_Pc.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/AtkParam_Pc.json
@@ -880,13 +880,13 @@
     {
       "ID": 5000156,
       "Entries": [
-        "Prosthetic Hand Ninja _ Iron Fan _ Unleashed Slash _ Orange Wind Enchantment"
+        "Loaded Umbrella - Projected Force - Orange Wind"
       ]
     },
     {
       "ID": 5000157,
       "Entries": [
-        "Prosthetic Hand Ninja _ Iron Fan _ Unleashed Slash _ Gold Wind Enchantment "
+        "Loaded Umbrella - Projected Force - Gold Wind"
       ]
     },
     {
@@ -952,13 +952,13 @@
     {
       "ID": 5000185,
       "Entries": [
-        "Right-handed sword_Orange-style enchantment additional attack -- 右手刀_橙風エンチャント追加攻撃"
+        "Living Force - Divine Abudction Addidtional Attack"
       ]
     },
     {
       "ID": 5000186,
       "Entries": [
-        "Right-handed sword_Kinfu enchantment additional attack -- 右手刀_金風エンチャント追加攻撃"
+        "Living Force - Golden Vortex Addidtional Attack"
       ]
     },
     {

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/AtkParam_Pc.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/AtkParam_Pc.json
@@ -4,307 +4,307 @@
     {
       "ID": 0,
       "Entries": [
-        "Dummy bullet"
+        "Dummy"
       ]
     },
     {
       "ID": 1,
       "Entries": [
-        "Dummy bullets_see per map_normal -- ダミー弾丸_マップあたり参照_通常"
+        "Dummy"
       ]
     },
     {
       "ID": 4,
       "Entries": [
-        "For destroying automatic patrol objects -- 自動巡回オブジェ破壊用"
+        "For destroying automatic patrol objects"
       ]
     },
     {
       "ID": 5,
       "Entries": [
-        "Dummy attack to keep bullets out -- 弾丸出し続ける用ダミー攻撃"
+        "Dummy"
       ]
     },
     {
       "ID": 6,
       "Entries": [
-        "For automatic patrol object destruction_for debug function verification -- 自動巡回オブジェ破壊用_デバッグ機能検証用"
+        "Dummy for debug"
       ]
     },
     {
       "ID": 10,
       "Entries": [
-        "Dummy bullet _ hits nothing -- ダミー弾丸_何にも当たらない"
+        "Dummy - Hits Nothing"
       ]
     },
     {
       "ID": 101,
       "Entries": [
-        "[System] Attack magnification for menu display -- 【システム】メニュー表示用攻撃倍率"
+        "Attack magnification for menu display"
       ]
     },
     {
       "ID": 200,
       "Entries": [
-        "Contact impact_in-game start -- 接触衝撃_インゲーム開始"
+        "Impact\n"
       ]
     },
     {
       "ID": 210,
       "Entries": [
-        "Contact impact_weak_upper and lower wrap -- 接触衝撃_弱_上下包み"
+        "Impact\n"
       ]
     },
     {
       "ID": 211,
       "Entries": [
-        "Contact impact_weak_origin wrap -- 接触衝撃_弱_原点包み"
+        "Impact\n"
       ]
     },
     {
       "ID": 220,
       "Entries": [
-        "Contact impact_middle_upper and lower wrap -- 接触衝撃_中_上下包み"
+        "Impact\n"
       ]
     },
     {
       "ID": 221,
       "Entries": [
-        "Contact impact_medium_origin wrap -- 接触衝撃_中_原点包み"
+        "Impact\n"
       ]
     },
     {
       "ID": 222,
       "Entries": [
-        "Contact impact_middle_below origin -- 接触衝撃_中_原点下方"
+        "Impact\n"
       ]
     },
     {
       "ID": 280,
       "Entries": [
-        "Foot for SFX / right foot -- フットSFX用/右足"
+        "Right foot for SFX"
       ]
     },
     {
       "ID": 281,
       "Entries": [
-        "Foot for SFX / left foot -- フットSFX用/左足"
+        "Left foot for SFX"
       ]
     },
     {
       "ID": 285,
       "Entries": [
-        "Hand for SFX / right hand -- ハンドSFX用/右手"
+        "Right hand for SFX"
       ]
     },
     {
       "ID": 286,
       "Entries": [
-        "Hand for SFX / left hand -- ハンドSFX用/左手"
+        "Left hand for SFX"
       ]
     },
     {
       "ID": 290,
       "Entries": [
-        "Anti-spirit force -- 対霊フォース"
+        "Anti-Apparition Force"
       ]
     },
     {
       "ID": 295,
       "Entries": [
-        "Depression Force_Parent -- 恐慌フォース_親"
+        "Red Eyes Scare Parent"
       ]
     },
     {
       "ID": 296,
       "Entries": [
-        "Depression Force_Child -- 恐慌フォース_子"
+        "Red Eyes Scare Child"
       ]
     },
     {
       "ID": 300,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Common_Enemy Reaction Regeneration -- 忍殺忍術_血煙_共通_敵リアクション再生"
+        "Bloodsmoke Ninjutsu - Enemy Reaction Restoration"
       ]
     },
     {
       "ID": 301,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Common_Blind Special Effects -- 忍殺忍術_血煙_共通_盲目特殊効果"
+        "Bloodsmoke Ninjutsu - Enemy Blinding Effect"
       ]
     },
     {
       "ID": 360,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_Enemy Reaction Regeneration -- 忍殺忍術_血煙_放射_敵リアクション再生"
+        "Poison Bloodsmoke Ninjutsu - Enemy Reaction Restoration"
       ]
     },
     {
       "ID": 361,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_Blind Special Effects -- 忍殺忍術_血煙_放射_盲目特殊効果"
+        "Poison Bloodsmoke Ninjutsu - Enemy Blinding Effect"
       ]
     },
     {
       "ID": 400,
       "Entries": [
-        "Ninjutsu Ninjutsu_Puppet_Normal -- 忍殺忍術_傀儡_通常"
+        "Puppeteer Ninjutsu"
       ]
     },
     {
       "ID": 410,
       "Entries": [
-        "Ninjutsu Ninjutsu_Puppet_Normal_Infinite duration -- 忍殺忍術_傀儡_通常_効果時間無限"
+        "Puppeteer Ninjutsu"
       ]
     },
     {
       "ID": 600,
       "Entries": [
-        "Shinobi killing start_break -- 忍殺始動_崩し"
+        "Deathblow Initiation - Posture Break"
       ]
     },
     {
       "ID": 640,
       "Entries": [
-        "Shinobi killing start_behind -- 忍殺始動_背後"
+        "Deathblow Initiation - Backstab"
       ]
     },
     {
       "ID": 650,
       "Entries": [
-        "Shinobi killing start_ crouching behind -- 忍殺始動_背後しゃがみ"
+        "Deathblow Initiation - Crouching Backstab"
       ]
     },
     {
       "ID": 660,
       "Entries": [
-        "Shinobi killing start_fall -- 忍殺始動_落下"
+        "Deathblow Initiation - Plunging"
       ]
     },
     {
       "ID": 680,
       "Entries": [
-        "Shinobi killing start_breaking wire -- 忍殺始動_崩しワイヤー"
+        "Deathblow Initiation - Grappling Hook"
       ]
     },
     {
       "ID": 690,
       "Entries": [
-        "Shinobi killing start_anti-aircraft -- 忍殺始動_対空"
+        "Deathblow Initiation - Anti-air"
       ]
     },
     {
       "ID": 700,
       "Entries": [
-        "Shinobi killing start_wall left -- 忍殺始動_壁張り付き左"
+        "Deathblow Initiation - Hug Wall Left"
       ]
     },
     {
       "ID": 710,
       "Entries": [
-        "Shinobi killing start_walled right -- 忍殺始動_壁張り付き右"
+        "Deathblow Initiation - Hug Wall Right"
       ]
     },
     {
       "ID": 720,
       "Entries": [
-        "Shinobi killing start_ hanging -- 忍殺始動_ぶら下がり"
+        "Deathblow Initiation - Ledge Hang"
       ]
     },
     {
       "ID": 740,
       "Entries": [
-        "Shinobi killing start_breaking kick jump -- 忍殺始動_崩し蹴りジャンプ"
+        "Deathblow Initiation - Jump Kick Break"
       ]
     },
     {
       "ID": 800,
       "Entries": [
-        "Shinobi slaughter start _ stop _ priest -- 忍殺始動_とどめ_破戒僧"
+        "Deathblow Initiation - Corrupted Monk - Finisher"
       ]
     },
     {
       "ID": 801,
       "Entries": [
-        "Shinobi killing start _ stop _ chief of the ninja army -- 忍殺始動_とどめ_忍軍の長"
+        "Deathblow Initiation - Owl - Finisher"
       ]
     },
     {
       "ID": 803,
       "Entries": [
-        "Shinobi killing start _ stop _ Yasha monkey -- 忍殺始動_とどめ_夜叉猿"
+        "Deathblow Initiation - Guardian Ape - Finisher"
       ]
     },
     {
       "ID": 804,
       "Entries": [
-        "Shinobi killing start _ stop _ rival -- 忍殺始動_とどめ_ライバル"
+        "Deathblow Initiation - Genichiro - Finisher"
       ]
     },
     {
       "ID": 805,
       "Entries": [
-        "Shinobi killing start _ stop _ butterfly -- 忍殺始動_とどめ_お蝶"
+        "Deathblow Initiation - Lady Butterfly - Finisher"
       ]
     },
     {
       "ID": 806,
       "Entries": [
-        "Shinobi killing start _ stop _ sword sacred -- 忍殺始動_とどめ_剣聖"
+        "Deathblow Initiation - Isshin - Finisher"
       ]
     },
     {
       "ID": 807,
       "Entries": [
-        "Shinobi killing start _ stop _ Buddhist demon -- 忍殺始動_とどめ_仏師鬼"
+        "Deathblow Initiation - Demon of Hatred - Finisher"
       ]
     },
     {
       "ID": 840,
       "Entries": [
-        "Shinobi shock _ short distance _ on the spot -- 忍殺衝撃_近距離_その場"
+        "Mikiri Counter - Break"
       ]
     },
     {
       "ID": 841,
       "Entries": [
-        "Shinobi shock _ short distance _ jump away -- 忍殺衝撃_近距離_飛び退き"
+        "Mikiri Counter"
       ]
     },
     {
       "ID": 842,
       "Entries": [
-        "Shinobi shock _ long distance _ on the spot -- 忍殺衝撃_遠距離_その場"
+        "Mikiri Counter - Break"
       ]
     },
     {
       "ID": 843,
       "Entries": [
-        "Shinobi shock _ long distance _ jump away -- 忍殺衝撃_遠距離_飛び退き"
+        "Mikiri Counter"
       ]
     },
     {
       "ID": 844,
       "Entries": [
-        "Resurrection Technique_Boss Sensing Dummy Attack -- 復活の術_ボス感知ダミー攻撃"
+        "Resurrection - Boss Sensing Dummy Attack"
       ]
     },
     {
       "ID": 900,
       "Entries": [
-        "Kick -- 蹴り"
+        "Kick"
       ]
     },
     {
       "ID": 901,
       "Entries": [
-        "Kick_in the air -- 蹴り_空中"
+        "Jump Kick"
       ]
     },
     {
       "ID": 903,
       "Entries": [
-        "Kick_dash -- 蹴り_ダッシュ"
+        "Kick Dash"
       ]
     },
     {
@@ -334,151 +334,151 @@
     {
       "ID": 3531,
       "Entries": [
-        "Release illusion_Short-range surprised bullets -- 幻術解除_近距離びっくり弾丸"
+        "Snap Seed"
       ]
     },
     {
       "ID": 9900,
       "Entries": [
-        "DL confirmation 00_ None -- DL確認00_なし"
+        "Damage Level Confirmation - None"
       ]
     },
     {
       "ID": 9901,
       "Entries": [
-        "DL confirmation 01_small -- DL確認01_小"
+        "Damage Level Confirmation - Weak"
       ]
     },
     {
       "ID": 9902,
       "Entries": [
-        "DL confirmation 02_ Medium -- DL確認02_中"
+        "Damage Level Confirmation - Medium"
       ]
     },
     {
       "ID": 9903,
       "Entries": [
-        "DL confirmation 03_large -- DL確認03_大"
+        "Damage Level Confirmation - Large"
       ]
     },
     {
       "ID": 9904,
       "Entries": [
-        "DL confirmation 04_ Blow-off size -- DL確認04_吹っ飛び大"
+        "Damage Level Confirmation - Blow back"
       ]
     },
     {
       "ID": 9905,
       "Entries": [
-        "DL confirmation 05_ press -- DL確認05_押し"
+        "Damage Level Confirmation - Flatten"
       ]
     },
     {
       "ID": 9906,
       "Entries": [
-        "DL confirmation 06_ slamming -- DL確認06_叩きつけ"
+        "Damage Level Confirmation - Slam"
       ]
     },
     {
       "ID": 9907,
       "Entries": [
-        "DL confirmation 07_Blow-off small (PC kick only) -- DL確認07_吹っ飛び小（PC蹴り専用）"
+        "Damage Level Confirmation - Jump Kick"
       ]
     },
     {
       "ID": 9908,
       "Entries": [
-        "DL confirmation 08_minimal addition -- DL確認08_極小加算"
+        "Damage Level Confirmation - Minimal"
       ]
     },
     {
       "ID": 9909,
       "Entries": [
-        "DL confirmation 09_ lift up -- DL確認09_かち上げ"
+        "Damage Level Confirmation - Launch Up"
       ]
     },
     {
       "ID": 9910,
       "Entries": [
-        "DL confirmation 10_ Blow-off oversized -- DL確認10_吹っ飛び特大"
+        "Damage Level Confirmation - Very Large Blow Back"
       ]
     },
     {
       "ID": 9911,
       "Entries": [
-        "DL confirmation 11_ breath (unused) -- DL確認11_ブレス（未使用）"
+        "Damage Level Confirmation - Unused"
       ]
     },
     {
       "ID": 9915,
       "Entries": [
-        "DL confirmation 15_break -- DL確認15_崩し"
+        "Damage Level Confirmation - Break"
       ]
     },
     {
       "ID": 9920,
       "Entries": [
-        "DL confirmation 20_flame -- DL確認20_炎"
+        "Damage Level Confirmation - Flame"
       ]
     },
     {
       "ID": 9930,
       "Entries": [
-        "AI sound confirmation_normal sound -- AI音確認_通常音"
+        "AI Sound Confirmation - Normal Sound"
       ]
     },
     {
       "ID": 9931,
       "Entries": [
-        "AI sound confirmation_important sound -- AI音確認_重要音"
+        "AI Sound Confirmation - Important Sound"
       ]
     },
     {
       "ID": 10000,
       "Entries": [
-        "Prototype provisional support: Special SFX control bullets when moving / mud dirt decals / walking_right foot -- プロト仮対応：移動時の特殊SFX制御弾丸／泥汚れデカール／歩行_右足"
+        ""
       ]
     },
     {
       "ID": 10001,
       "Entries": [
-        "Prototype provisional support: Special SFX control bullets when moving / mud dirt decals / walking_left foot -- プロト仮対応：移動時の特殊SFX制御弾丸／泥汚れデカール／歩行_左足"
+        ""
       ]
     },
     {
       "ID": 10004,
       "Entries": [
-        "Prototype provisional support: Special SFX control bullets when moving / mud dirt decals / running_right foot -- プロト仮対応：移動時の特殊SFX制御弾丸／泥汚れデカール／走行_右足"
+        ""
       ]
     },
     {
       "ID": 10005,
       "Entries": [
-        "Prototype provisional support: Special SFX control bullets when moving / mud dirt decals / running_left foot -- プロト仮対応：移動時の特殊SFX制御弾丸／泥汚れデカール／走行_左足"
+        ""
       ]
     },
     {
       "ID": 10006,
       "Entries": [
-        "Prototype provisional support: Special SFX control bullets when moving / Mud dirt decals / Rolling _ chest -- プロト仮対応：移動時の特殊SFX制御弾丸／泥汚れデカール／ローリング_胸"
+        ""
       ]
     },
     {
       "ID": 10008,
       "Entries": [
-        "Prototype provisional support: Special SFX control bullet when moving / mud dirt decal / dash_right foot -- プロト仮対応：移動時の特殊SFX制御弾丸／泥汚れデカール／ダッシュ_右足"
+        ""
       ]
     },
     {
       "ID": 10009,
       "Entries": [
-        "Prototype provisional support: Special SFX control bullet when moving / mud dirt decal / dash_left foot -- プロト仮対応：移動時の特殊SFX制御弾丸／泥汚れデカール／ダッシュ_左足"
+        ""
       ]
     },
     {
       "ID": 10010,
       "Entries": [
-        "Bleeding when moving violently when dying -- 瀕死時に激しく動くと出血する"
+        ""
       ]
     },
     {
@@ -736,121 +736,121 @@
     {
       "ID": 5000130,
       "Entries": [
-        "Kodachi_Table 2nd stage_Right hand sword -- 小太刀_表2段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 5000131,
       "Entries": [
-        "Kodachi _ Table 4th _ Right hand sword -- 小太刀_表4段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 5000132,
       "Entries": [
-        "Kodachi _ Table 6th _ Right hand sword -- 小太刀_表6段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 5000133,
       "Entries": [
-        "Kodachi_back 1st stage_right hand sword -- 小太刀_裏1段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 5000134,
       "Entries": [
-        "Kodachi _ back 2nd stage _ right hand sword -- 小太刀_裏2段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 5000135,
       "Entries": [
-        "Kodachi _ back 3rd stage _ right hand sword -- 小太刀_裏3段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 5000136,
       "Entries": [
-        "Kodachi_back 4th stage_right hand sword -- 小太刀_裏4段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 5000137,
       "Entries": [
-        "Kodachi_back 5th stage_right hand sword -- 小太刀_裏5段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 5000138,
       "Entries": [
-        "Kodachi_back 6th stage_right hand sword -- 小太刀_裏6段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 5000140,
       "Entries": [
-        "Kodachi (Ruri) _Table 2nd stage_Right hand sword -- 小太刀（瑠璃）_表2段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 5000141,
       "Entries": [
-        "Kodachi (Ruri) _ Table 4th _ Right hand sword -- 小太刀（瑠璃）_表4段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 5000142,
       "Entries": [
-        "Kodachi (Ruri) _Table 6th row_Right hand sword -- 小太刀（瑠璃）_表6段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 5000143,
       "Entries": [
-        "Kodachi (Ruri) _back 1st stage_right hand sword -- 小太刀（瑠璃）_裏1段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 5000144,
       "Entries": [
-        "Kodachi (Ruri) _2nd back sword_Right hand sword -- 小太刀（瑠璃）_裏2段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 5000145,
       "Entries": [
-        "Kodachi (Ruri) _ 3rd back sword _ Right hand sword -- 小太刀（瑠璃）_裏3段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 5000146,
       "Entries": [
-        "Kodachi (Ruri) _ back 4th stage _ right hand sword -- 小太刀（瑠璃）_裏4段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 5000147,
       "Entries": [
-        "Kodachi (Ruri) _ 5th stage on the back _ Right hand sword -- 小太刀（瑠璃）_裏5段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 5000148,
       "Entries": [
-        "Kodachi (Ruri) _ 6th back sword _ Right hand sword -- 小太刀（瑠璃）_裏6段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 5000150,
       "Entries": [
-        "Kodachi _ front and back switching slash _ front and back left -- 小太刀_表裏切替斬り_前後左"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 5000151,
       "Entries": [
-        "Kodachi _ front and back switching slash _ right -- 小太刀_表裏切替斬り_右"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
@@ -988,1675 +988,1675 @@
     {
       "ID": 5000280,
       "Entries": [
-        "Right hand sword _ thunder return _ weak thunder _ sword blade -- 右手刀_雷返し_弱雷_刀身"
+        "Lightning Reversal"
       ]
     },
     {
       "ID": 5000281,
       "Entries": [
-        "Right hand sword _ thunder return _ weak thunder _ thunder -- 右手刀_雷返し_弱雷_雷"
+        "Lightning Reversal"
       ]
     },
     {
       "ID": 5000600,
       "Entries": [
-        "Right-handed sword_Ninjato body_Crush -- 右手刀_忍殺本体_崩し"
+        "Deathblow Damage"
       ]
     },
     {
       "ID": 5000610,
       "Entries": [
-        "Right hand sword_Ninjato body_Play -- 右手刀_忍殺本体_弾き"
+        "Deathblow Damage"
       ]
     },
     {
       "ID": 5000620,
       "Entries": [
-        "Right hand sword _ Ninjato body _ Closeout -- 右手刀_忍殺本体_見切り"
+        "Deathblow Damage"
       ]
     },
     {
       "ID": 5000640,
       "Entries": [
-        "Right hand sword _ Ninja body _ Behind -- 右手刀_忍殺本体_背後"
+        "Deathblow Damage - Backstab"
       ]
     },
     {
       "ID": 5000650,
       "Entries": [
-        "Right hand sword_Ninjato body_Crouching behind -- 右手刀_忍殺本体_しゃがみ背後"
+        "Deathblow Damage - Crouching Backstab"
       ]
     },
     {
       "ID": 5000660,
       "Entries": [
-        "Right hand sword _ Ninja body _ Fall -- 右手刀_忍殺本体_落下"
+        "Deathblow Damage - Plunging"
       ]
     },
     {
       "ID": 5000661,
       "Entries": [
-        "Right hand sword _ Ninjato body _ Fall _ Fire cow only -- 右手刀_忍殺本体_落下_火牛専用"
+        "Deathblow Damage - Plunging on Bull"
       ]
     },
     {
       "ID": 5000680,
       "Entries": [
-        "Right hand sword _ Ninja body _ Wire -- 右手刀_忍殺本体_ワイヤー"
+        "Deathblow Damage - Grappling Hook"
       ]
     },
     {
       "ID": 5000690,
       "Entries": [
-        "Right hand sword _ Ninja body _ Anti-aircraft -- 右手刀_忍殺本体_対空"
+        "Deathblow Damage - Anti-air"
       ]
     },
     {
       "ID": 5000700,
       "Entries": [
-        "Right hand sword _ Ninja body _ Left and right with wall -- 右手刀_忍殺本体_壁張り付き左右"
+        "Deathblow Damage - Wall Hug"
       ]
     },
     {
       "ID": 5000720,
       "Entries": [
-        "Right hand sword _ Ninja body _ Before and after hanging -- 右手刀_忍殺本体_ぶら下がり前後"
-      ]
-    },
-    {
-      "ID": 5000800,
-      "Entries": [
-        "Right hand sword _ Ninja body _ Stop -- 右手刀_忍殺本体_とどめ"
+        "Deathblow Damage - Ledge Hang"
       ]
     },
     {
       "ID": 5000790,
       "Entries": [
-        "Right-handed sword_Ninjato body_Dummy attack that causes the enemy to send Kanji SFX_Blood smoke -- 右手刀_忍殺本体_漢字SFXを敵に出させるダミー攻撃_血煙"
+        "Ninjutsu Kanji Info for Enemy - Bloodsmoke"
       ]
     },
     {
       "ID": 5000791,
       "Entries": [
-        "Right-handed sword_Ninjato body_Dummy attack that causes the enemy to send Kanji SFX_Puppet -- 右手刀_忍殺本体_漢字SFXを敵に出させるダミー攻撃_傀儡"
+        "Ninjutsu Kanji Info for Enemy - Puppeteer"
       ]
     },
     {
       "ID": 5000792,
       "Entries": [
-        "Right-handed sword_Ninjato body_Dummy attack that causes the enemy to send Kanji SFX_Grant -- 右手刀_忍殺本体_漢字SFXを敵に出させるダミー攻撃_付与"
+        "Ninjutsu Kanji Info for Enemy - Bestowal"
+      ]
+    },
+    {
+      "ID": 5000800,
+      "Entries": [
+        "Deathblow Damage - Finisher"
       ]
     },
     {
       "ID": 5001200,
       "Entries": [
-        "School Technique_Rotating Slash 1-1 -- 流派技_回転斬り1-1"
+        "Whirlwind Slash 1"
       ]
     },
     {
       "ID": 5001201,
       "Entries": [
-        "School Technique_Rotating Slash 1-2 -- 流派技_回転斬り1-2"
+        "Whirlwind Slash 2"
       ]
     },
     {
       "ID": 5002200,
       "Entries": [
-        "School Technique_Dive Slash 1 -- 流派技_飛び込み斬り1"
+        "Nightjar Slash"
       ]
     },
     {
       "ID": 5002201,
       "Entries": [
-        "School Technique_Dive Slash 2 -- 流派技_飛び込み斬り2"
+        "Nightjar Slash Reversal"
       ]
     },
     {
       "ID": 5003200,
       "Entries": [
-        "School technique_face-up 1_reservoir -- 流派技_面打ち1_溜め"
+        "Ichimonji 1 - Charged"
       ]
     },
     {
       "ID": 5003201,
       "Entries": [
-        "School technique_face-up 1 -- 流派技_面打ち1"
+        "Ichimonji 1"
       ]
     },
     {
       "ID": 5003210,
       "Entries": [
-        "School Technique_Face 2 -- 流派技_面打ち2"
+        "Ichimonji 2"
       ]
     },
     {
       "ID": 5004200,
       "Entries": [
-        "School technique _ Kensei Iai _ Reservoir -- 流派技_剣聖居合_溜め"
+        "Dragon Flash - Charged"
       ]
     },
     {
       "ID": 5004201,
       "Entries": [
-        "School technique _ Kensei Iai _ Reservoir _ No form fee -- 流派技_剣聖居合_溜め_形代なし"
+        "Dragon Flash - Charged - No Spirit Emblems"
       ]
     },
     {
       "ID": 5004210,
       "Entries": [
-        "School Technique_Sword Holy Iai_Reserved Bullet 1 -- 流派技_剣聖居合_溜め弾丸1"
+        "Dragon Flash - Charged - Bullet 1"
       ]
     },
     {
       "ID": 5004215,
       "Entries": [
-        "School Technique_Sword Holy Iai_Reserved Bullet 2 -- 流派技_剣聖居合_溜め弾丸2"
+        "Dragon Flash - Charged - Bullet 2"
       ]
     },
     {
       "ID": 5004219,
       "Entries": [
-        "School Technique_Sword Holy Iai_Reserved Bullet 2_Parent Dummy Bullet -- 流派技_剣聖居合_溜め弾丸2_親用ダミー弾丸"
+        "Dragon Flash - Charged - Bullet 2 - Dummy Parent"
       ]
     },
     {
       "ID": 5004220,
       "Entries": [
-        "School technique_Kensei Iai -- 流派技_剣聖居合"
+        "Dragon Flash"
       ]
     },
     {
       "ID": 5004221,
       "Entries": [
-        "School technique_Sword sacred Iai_No form -- 流派技_剣聖居合_形代なし"
+        "Dragon Flash - No Spirit Emblems"
       ]
     },
     {
       "ID": 5004230,
       "Entries": [
-        "School technique_Sword sacred Iai_Bullet -- 流派技_剣聖居合_弾丸"
+        "Dragon Flash - Bullet"
       ]
     },
     {
       "ID": 5005200,
       "Entries": [
-        "School technique_Iai 1 -- 流派技_居合1"
+        "Ashina Cross 1"
       ]
     },
     {
       "ID": 5005201,
       "Entries": [
-        "School technique_Iai 2 -- 流派技_居合2"
+        "Ashina Cross 2"
       ]
     },
     {
       "ID": 5005202,
       "Entries": [
-        "School technique_Iai 1_No form fee -- 流派技_居合1_形代なし"
+        "Ashina Cross 1 - No Spirit Emblems"
       ]
     },
     {
       "ID": 5005203,
       "Entries": [
-        "School technique_Iai 2_No form fee -- 流派技_居合2_形代なし"
+        "Ashina Cross 2 - No Spirit Emblems"
       ]
     },
     {
       "ID": 5005210,
       "Entries": [
-        "School technique_Invisible Iai continuous attack 1 -- 流派技_見えない居合連撃1"
+        "One Mind - Initial Attack"
       ]
     },
     {
       "ID": 5005211,
       "Entries": [
-        "School Technique_Invisible Iai Strike 1_Red Blood Enchantment Additional Attack -- 流派技_見えない居合連撃1_赤血エンチャント追加攻撃"
+        "One Mind - Initial Attack - Bestowal"
       ]
     },
     {
       "ID": 5005212,
       "Entries": [
-        "School Technique_Invisible Iai Strike 1_Poison Blood Enchantment Additional Attack -- 流派技_見えない居合連撃1_毒血エンチャント追加攻撃"
+        "One Mind - Initial Attack - Poison Bestowal"
       ]
     },
     {
       "ID": 5005213,
       "Entries": [
-        "School Technique_Invisible Iai Strike 1_ White Blood Enchantment Additional Attack -- 流派技_見えない居合連撃1_白血エンチャント追加攻撃"
+        "One Mind - Initial Attack - Lifesteal Bestowal"
       ]
     },
     {
       "ID": 5005214,
       "Entries": [
-        "School technique_Invisible Iai continuous attack 1_Orange wind enchantment additional attack -- 流派技_見えない居合連撃1_橙風エンチャント追加攻撃"
+        "One Mind - Initial Attack - Divine Abduction Living Force"
       ]
     },
     {
       "ID": 5005215,
       "Entries": [
-        "School technique_Invisible Iai continuous attack 1_Kinfu enchantment additional attack -- 流派技_見えない居合連撃1_金風エンチャント追加攻撃"
+        "One Mind - Initial Attack - Golden Vortex Living Force"
       ]
     },
     {
       "ID": 5005216,
       "Entries": [
-        "School technique_Invisible Iai continuous attack 1_No form -- 流派技_見えない居合連撃1_形代なし"
+        "One Mind - Initial Attack - No Spirit Emblems"
       ]
     },
     {
       "ID": 5005220,
       "Entries": [
-        "School technique_Invisible Iai continuous attack_Delayed continuous attack 1 -- 流派技_見えない居合連撃_遅延連撃1"
+        "One Mind - Continous Attack 1"
       ]
     },
     {
       "ID": 5005221,
       "Entries": [
-        "School technique_Invisible Iai continuous attack_Delayed continuous attack 2 -- 流派技_見えない居合連撃_遅延連撃2"
+        "One Mind - Continous Attack 2"
       ]
     },
     {
       "ID": 5005222,
       "Entries": [
-        "School technique_Invisible Iai continuous attack_Delayed continuous attack 3 -- 流派技_見えない居合連撃_遅延連撃3"
+        "One Mind - Continous Attack 3"
       ]
     },
     {
       "ID": 5005223,
       "Entries": [
-        "School technique_Invisible Iai continuous attack_Delayed continuous attack 4 -- 流派技_見えない居合連撃_遅延連撃4"
+        "One Mind - Continous Attack 4"
       ]
     },
     {
       "ID": 5005240,
       "Entries": [
-        "School technique_Invisible Iai continuous attack 2 -- 流派技_見えない居合連撃2"
+        "One Mind - Final Attack"
       ]
     },
     {
       "ID": 5005241,
       "Entries": [
-        "School Technique_Invisible Iai Strike 2_Red Blood Enchantment Additional Attack -- 流派技_見えない居合連撃2_赤血エンチャント追加攻撃"
+        "One Mind - Final Attack - Bestowal"
       ]
     },
     {
       "ID": 5005242,
       "Entries": [
-        "School Technique_Invisible Iai Strike 2_Poison Blood Enchantment Additional Attack -- 流派技_見えない居合連撃2_毒血エンチャント追加攻撃"
+        "One Mind - Final Attack - Poison Bestowal"
       ]
     },
     {
       "ID": 5005243,
       "Entries": [
-        "School technique_Invisible Iai continuous attack 2_White blood enchantment additional attack -- 流派技_見えない居合連撃2_白血エンチャント追加攻撃"
+        "One Mind - Final Attack - Lifesteal Bestowal"
       ]
     },
     {
       "ID": 5005244,
       "Entries": [
-        "School technique_Invisible Iai continuous attack 2_Orange wind enchantment additional attack -- 流派技_見えない居合連撃2_橙風エンチャント追加攻撃"
+        "One Mind - Final Attack - Divine Abduction Living Force"
       ]
     },
     {
       "ID": 5005245,
       "Entries": [
-        "School technique_Invisible Iai continuous attack 2_Kinfu enchantment additional attack -- 流派技_見えない居合連撃2_金風エンチャント追加攻撃"
+        "One Mind - Final Attack - Golden Vortex Living Force"
       ]
     },
     {
       "ID": 5005246,
       "Entries": [
-        "School technique_Invisible Iai continuous attack 2_No form -- 流派技_見えない居合連撃2_形代なし"
+        "One Mind - Final Attack - No Spirit Emblems"
       ]
     },
     {
       "ID": 5007200,
       "Entries": [
-        "School Technique_Immortal Slash 1_Reservoir -- 流派技_不死斬り1_溜め"
+        "Mortal Draw 1 - Charged"
       ]
     },
     {
       "ID": 5007201,
       "Entries": [
-        "School Technique_Immortal Slash 1 -- 流派技_不死斬り1"
+        "Mortal Draw 1"
       ]
     },
     {
       "ID": 5007210,
       "Entries": [
-        "School Technique_Immortal Slash 2_Reservoir -- 流派技_不死斬り2_溜め"
+        "Mortal Draw 2 - Charged"
       ]
     },
     {
       "ID": 5007211,
       "Entries": [
-        "School Technique_Immortal Slash 2 -- 流派技_不死斬り2"
+        "Mortal Draw 2"
       ]
     },
     {
       "ID": 5007220,
       "Entries": [
-        "School technique_Immortal slash 1_Reservoir_There is a form fee -- 流派技_不死斬り1_溜め_形代あり"
+        "Mortal Draw 1 - Charged - No Spirit Emblems"
       ]
     },
     {
       "ID": 5007221,
       "Entries": [
-        "School technique_Immortal slash 1_There is a form fee -- 流派技_不死斬り1_形代あり"
+        "Mortal Draw 1 - No Spirit Emblems"
       ]
     },
     {
       "ID": 5007230,
       "Entries": [
-        "School technique_Immortal slash 2_Reservoir_There is a form fee -- 流派技_不死斬り2_溜め_形代あり"
+        "Mortal Draw 2 - Charged - No Spirit Emblems"
       ]
     },
     {
       "ID": 5007231,
       "Entries": [
-        "School technique_Immortal slash 2_There is a form fee -- 流派技_不死斬り2_形代あり"
+        "Mortal Draw 2 - No Spirit Emblems"
       ]
     },
     {
       "ID": 5008200,
       "Entries": [
-        "School Technique_Kick Rush 1-1 -- 流派技_蹴りラッシュ1-1"
+        "Senpou Leaping Kicks / High Monk - Initial Kick Up"
       ]
     },
     {
       "ID": 5008201,
       "Entries": [
-        "School Technique_Kick Rush 1-2 -- 流派技_蹴りラッシュ1-2"
+        "Senpou Leaping Kicks / High Monk - Initial Kick Down"
       ]
     },
     {
       "ID": 5008210,
       "Entries": [
-        "School Technique_Kick Rush 2-1 -- 流派技_蹴りラッシュ2-1"
+        "Senpou Leaping Kicks / High Monk - Follow-up Kick 1"
       ]
     },
     {
       "ID": 5008211,
       "Entries": [
-        "School Technique_Kick Rush 2-2 -- 流派技_蹴りラッシュ2-2"
+        "Senpou Leaping Kicks / High Monk - Follow-up Kick 2"
       ]
     },
     {
       "ID": 5008220,
       "Entries": [
-        "School Technique_Kick Rush 3-1 -- 流派技_蹴りラッシュ3-1"
+        "High Monk - Sword Slash 1"
       ]
     },
     {
       "ID": 5008221,
       "Entries": [
-        "School Technique_Kick Rush 3-2 -- 流派技_蹴りラッシュ3-2"
+        "High Monk - Sword Slash 2"
       ]
     },
     {
       "ID": 5008230,
       "Entries": [
-        "School Technique_Kick Rush 4 -- 流派技_蹴りラッシュ4"
+        "High Monk - Final Kick"
       ]
     },
     {
       "ID": 5009200,
       "Entries": [
-        "School Technique_Fist Attack 1_Accumulation -- 流派技_拳撃1_溜め"
+        "Praying Strikes - Exorcism - Charged"
       ]
     },
     {
       "ID": 5009201,
       "Entries": [
-        "School Technique_Fist Attack 1 -- 流派技_拳撃1"
+        "Praying Stikes - 1"
       ]
     },
     {
       "ID": 5009210,
       "Entries": [
-        "School Technique_Fist Attack 2 -- 流派技_拳撃2"
+        "Praying Stikes - 2"
       ]
     },
     {
       "ID": 5009220,
       "Entries": [
-        "School Technique_Fist Attack 3 -- 流派技_拳撃3"
+        "Praying Stikes - Exorcism - 3"
       ]
     },
     {
       "ID": 5009251,
       "Entries": [
-        "School Technique_Fist Attack 1_Aerial -- 流派技_拳撃1_空中"
+        "Praying Strikes - Aerial"
       ]
     },
     {
       "ID": 5010200,
       "Entries": [
-        "School technique _ sneak stab _ reservoir -- 流派技_忍び刺し_溜め"
+        "Shadowfall / Shadowrush - Stab - Charged"
       ]
     },
     {
       "ID": 5010210,
       "Entries": [
-        "School technique_Sneak stab -- 流派技_忍び刺し"
+        "Shadowfall / Shadowrush - Stab"
       ]
     },
     {
       "ID": 5010215,
       "Entries": [
-        "School technique_Sneak stab_Kick up after hit -- 流派技_忍び刺し_ヒット後蹴上がり"
+        "Shadowfall / Shadowrush - Kick"
       ]
     },
     {
       "ID": 5010220,
       "Entries": [
-        "School technique_Sneak stab_After kicking up, aerial rotation slash 1 -- 流派技_忍び刺し_蹴上がり後空中回転斬り1"
+        "Shadowfall - Aerial Attack 1"
       ]
     },
     {
       "ID": 5010221,
       "Entries": [
-        "School technique_Sneak stab_After kicking up, aerial rotation slash 2 -- 流派技_忍び刺し_蹴上がり後空中回転斬り2"
+        "Shadowfall - Aerial Attack 2"
       ]
     },
     {
       "ID": 5020200,
       "Entries": [
-        "School Technique_Hachiman Flying Rush 1 -- 流派技_八艘飛びラッシュ1"
+        "Floating Passage - 1"
       ]
     },
     {
       "ID": 5020201,
       "Entries": [
-        "School Technique_Hachiman Flying Rush 2 -- 流派技_八艘飛びラッシュ2"
+        "Floating Passage - 2"
       ]
     },
     {
       "ID": 5020202,
       "Entries": [
-        "School Technique_Hachiman Flying Rush 3 -- 流派技_八艘飛びラッシュ3"
+        "Floating Passage - 3"
       ]
     },
     {
       "ID": 5020203,
       "Entries": [
-        "School Technique_Hachiman Flying Rush 4 -- 流派技_八艘飛びラッシュ4"
+        "Floating Passage - 4"
       ]
     },
     {
       "ID": 5020209,
       "Entries": [
-        "School Technique_Hachiman Flying Rush 5F -- 流派技_八艘飛びラッシュ5F"
+        "Floating Passage - 5"
       ]
     },
     {
       "ID": 5021200,
       "Entries": [
-        "School Technique_Hachiman Flying Rush 1 -- 流派技_八艘飛びラッシュ1"
+        "Spiral Cloud Passage - 1"
       ]
     },
     {
       "ID": 5021201,
       "Entries": [
-        "School Technique_Hachiman Flying Rush 2 -- 流派技_八艘飛びラッシュ2"
+        "Spiral Cloud Passage - 2"
       ]
     },
     {
       "ID": 5021202,
       "Entries": [
-        "School Technique_Hachiman Flying Rush 3 -- 流派技_八艘飛びラッシュ3"
+        "Spiral Cloud Passage - 3"
       ]
     },
     {
       "ID": 5021203,
       "Entries": [
-        "School Technique_Hachiman Flying Rush 4 -- 流派技_八艘飛びラッシュ4"
+        "Spiral Cloud Passage - 4"
       ]
     },
     {
       "ID": 5021204,
       "Entries": [
-        "School Technique_Hachiman Flying Rush 5 -- 流派技_八艘飛びラッシュ5"
+        "Spiral Cloud Passage - 5"
       ]
     },
     {
       "ID": 5021205,
       "Entries": [
-        "School Technique_Hachiman Flying Rush 6 -- 流派技_八艘飛びラッシュ6"
+        "Spiral Cloud Passage - 6"
       ]
     },
     {
       "ID": 5021206,
       "Entries": [
-        "School Technique_Hachiman Flying Rush 7 -- 流派技_八艘飛びラッシュ7"
+        "Spiral Cloud Passage - 7"
       ]
     },
     {
       "ID": 5021207,
       "Entries": [
-        "School Technique_Hachiman Flying Rush 8 -- 流派技_八艘飛びラッシュ8"
+        "Spiral Cloud Passage - 8"
       ]
     },
     {
       "ID": 5021208,
       "Entries": [
-        "School Technique_Hachiman Flying Rush 9F -- 流派技_八艘飛びラッシュ9F"
+        "Spiral Cloud Passage - 9"
       ]
     },
     {
       "ID": 5021220,
       "Entries": [
-        "School technique_Hachiman flying rush 1_There is a form fee -- 流派技_八艘飛びラッシュ1_形代あり"
+        "Spiral Cloud Passage - 1 - No Spirit Emblems"
       ]
     },
     {
       "ID": 5021221,
       "Entries": [
-        "School technique_Hachimanbuki Rush 2_There is a form fee -- 流派技_八艘飛びラッシュ2_形代あり"
+        "Spiral Cloud Passage - 2 - No Spirit Emblems"
       ]
     },
     {
       "ID": 5021222,
       "Entries": [
-        "School technique_Hachiman flying rush 3_There is a form fee -- 流派技_八艘飛びラッシュ3_形代あり"
+        "Spiral Cloud Passage - 3 - No Spirit Emblems"
       ]
     },
     {
       "ID": 5021223,
       "Entries": [
-        "School technique_Hachiman flying rush 4_There is a form fee -- 流派技_八艘飛びラッシュ4_形代あり"
+        "Spiral Cloud Passage - 4 - No Spirit Emblems"
       ]
     },
     {
       "ID": 5021224,
       "Entries": [
-        "School technique_Hachiman flying rush 5_There is a form fee -- 流派技_八艘飛びラッシュ5_形代あり"
+        "Spiral Cloud Passage - 5 - No Spirit Emblems"
       ]
     },
     {
       "ID": 5021225,
       "Entries": [
-        "School technique_Hachimanbuki Rush 6_There is a form fee -- 流派技_八艘飛びラッシュ6_形代あり"
+        "Spiral Cloud Passage - 6 - No Spirit Emblems"
       ]
     },
     {
       "ID": 5021226,
       "Entries": [
-        "School technique_Hachiman flying rush 7_There is a form fee -- 流派技_八艘飛びラッシュ7_形代あり"
+        "Spiral Cloud Passage - 7 - No Spirit Emblems"
       ]
     },
     {
       "ID": 5021227,
       "Entries": [
-        "School technique_Hachiman flying rush 8_There is a form fee -- 流派技_八艘飛びラッシュ8_形代あり"
+        "Spiral Cloud Passage - 8 - No Spirit Emblems"
       ]
     },
     {
       "ID": 5021228,
       "Entries": [
-        "School technique_Hachiman Flying Rush 9F_There is a form fee -- 流派技_八艘飛びラッシュ9F_形代あり"
+        "Spiral Cloud Passage - 9 - No Spirit Emblems"
       ]
     },
     {
       "ID": 5030200,
       "Entries": [
-        "School technique_new technique 1 -- 流派技_新技1"
+        "Sakura Dance 1"
       ]
     },
     {
       "ID": 5030201,
       "Entries": [
-        "School technique_new technique 2 -- 流派技_新技2"
+        "Sakura Dance 2"
       ]
     },
     {
       "ID": 5030202,
       "Entries": [
-        "School technique_new technique 3 -- 流派技_新技3"
+        "Sakura Dance 3"
       ]
     },
     {
       "ID": 5030205,
       "Entries": [
-        "School technique_new technique 1_no form fee -- 流派技_新技1_形代なし"
+        "Sakura Dance 1 - No Spirit Emblems"
       ]
     },
     {
       "ID": 5030206,
       "Entries": [
-        "School technique_new technique 2_no form fee -- 流派技_新技2_形代なし"
+        "Sakura Dance 2 - No Spirit Emblems"
       ]
     },
     {
       "ID": 5030207,
       "Entries": [
-        "School technique_new technique 3_no form fee -- 流派技_新技3_形代なし"
+        "Sakura Dance 3 - No Spirit Emblems"
       ]
     },
     {
       "ID": 5030210,
       "Entries": [
-        "School Technique_New Technique 1_Weak Thunder Enchantment Additional Attack -- 流派技_新技1_弱雷エンチャント追加攻撃"
+        "Sakura Dance 1 - Lightning Reversal"
       ]
     },
     {
       "ID": 5030211,
       "Entries": [
-        "School Technique_New Technique 2_Weak Thunder Enchantment Additional Attack -- 流派技_新技2_弱雷エンチャント追加攻撃"
+        "Sakura Dance 2 - Lightning Reversal"
       ]
     },
     {
       "ID": 5030212,
       "Entries": [
-        "School Technique_New Technique 3_Weak Thunder Enchantment Additional Attack (Lightning Return) -- 流派技_新技3_弱雷エンチャント追加攻撃（雷返し）"
+        "Sakura Dance 3 - Lightning Reversal"
       ]
     },
     {
       "ID": 7000100,
       "Entries": [
-        "Shuriken_Reservoir 1/3 Throw_1Hit -- 手裏剣_溜め1/3投目_1Hit"
+        "Shuriken Charge - Throw 1 - Hit 1"
       ]
     },
     {
       "ID": 7000102,
       "Entries": [
-        "Shuriken_Reservoir 1/3 Throw_2Hit -- 手裏剣_溜め1/3投目_2Hit"
+        "Shuriken Charge - Throw 1 - Hit 2"
       ]
     },
     {
       "ID": 7000104,
       "Entries": [
-        "Shuriken _ Reservoir 1/3 Throw _ 3 Hit -- 手裏剣_溜め1/3投目_3Hit"
+        "Shuriken Charge - Throw 1 - Hit 3"
       ]
     },
     {
       "ID": 7000110,
       "Entries": [
-        "Shuriken_2nd throw -- 手裏剣_溜め2投目"
+        "Shuriken Charge - Throw 2 - Hit 1"
       ]
     },
     {
       "ID": 7000112,
       "Entries": [
-        "Shuriken_Reservoir 2nd Throw_2Hit -- 手裏剣_溜め2投目_2Hit"
+        "Shuriken Charge - Throw 2 - Hit 2"
       ]
     },
     {
       "ID": 7000114,
       "Entries": [
-        "Shuriken _ 2nd throw _ 3 Hit -- 手裏剣_溜め2投目_3Hit"
+        "Shuriken Charge - Throw 2 - Hit 3"
       ]
     },
     {
       "ID": 7000150,
       "Entries": [
-        "Shuriken_1 / 3rd throw -- 手裏剣_1/3投目"
+        "Shuriken Throw 1"
       ]
     },
     {
       "ID": 7000160,
       "Entries": [
-        "Shuriken_2 throws -- 手裏剣_2投目"
+        "Shuriken Throw 2"
       ]
     },
     {
       "ID": 7002100,
       "Entries": [
-        "Shuriken LV3-A_ Reservoir 1/3 Throw _1 Hit -- 手裏剣LV3-A_溜め1/3投目_1Hit"
+        "Gouging Top Charge - Throw 1 - Hit 1"
       ]
     },
     {
       "ID": 7002102,
       "Entries": [
-        "Shuriken LV3-A_ Reservoir 1/3 Throw _2 Hit -- 手裏剣LV3-A_溜め1/3投目_2Hit"
+        "Gouging Top Charge - Throw 1 - Hit 2"
       ]
     },
     {
       "ID": 7002104,
       "Entries": [
-        "Shuriken LV3-A_Reservoir 1/3 Throw_3 Hit -- 手裏剣LV3-A_溜め1/3投目_3Hit"
+        "Gouging Top Charge - Throw 1 - Hit 3"
       ]
     },
     {
       "ID": 7002110,
       "Entries": [
-        "Shuriken LV3-A_ 2nd throw -- 手裏剣LV3-A_溜め2投目"
+        "Gouging Top Charge - Throw 2 - Hit 1"
       ]
     },
     {
       "ID": 7002112,
       "Entries": [
-        "Shuriken LV3-A_ Reservoir 2nd Throw_2Hit -- 手裏剣LV3-A_溜め2投目_2Hit"
+        "Gouging Top Charge - Throw 2 - Hit 2"
       ]
     },
     {
       "ID": 7002114,
       "Entries": [
-        "Shuriken LV3-A_Reservoir 2nd throw_3Hit -- 手裏剣LV3-A_溜め2投目_3Hit"
+        "Gouging Top Charge - Throw 2 - Hit 3"
       ]
     },
     {
       "ID": 7002150,
       "Entries": [
-        "Shuriken LV3-A_1 / 3 throw -- 手裏剣LV3-A_1/3投目"
+        "Gouging Top - Throw 1"
       ]
     },
     {
       "ID": 7002160,
       "Entries": [
-        "Shuriken LV3-A_2 throw -- 手裏剣LV3-A_2投目"
+        "Gouging Top - Throw 2"
       ]
     },
     {
       "ID": 7003100,
       "Entries": [
-        "Shuriken LV3-B_1 / 3 throw -- 手裏剣LV3-B_1/3投目"
+        "Phantom Kunai - Throw 1"
       ]
     },
     {
       "ID": 7003110,
       "Entries": [
-        "Shuriken LV3-B_2 throw -- 手裏剣LV3-B_2投目"
+        "Phantom Kunai - Throw 2"
       ]
     },
     {
       "ID": 7003120,
       "Entries": [
-        "Shuriken LV3-B_guided bullet_reservoir -- 手裏剣LV3-B_誘導弾丸_溜め"
+        "Phantom Kunai Charge - Butterfly"
       ]
     },
     {
       "ID": 7003130,
       "Entries": [
-        "Shuriken LV3-B_ Guided Bullet -- 手裏剣LV3-B_誘導弾丸"
+        "Phantom Kunai - Butterfly"
       ]
     },
     {
       "ID": 7004100,
       "Entries": [
-        "Shuriken LV3-C_Reservoir 1/3 Throw_LV1 -- 手裏剣LV3-C_溜め1/3投目_LV1"
+        "Sen Throw Charge - Little Money"
       ]
     },
     {
       "ID": 7004101,
       "Entries": [
-        "Shuriken LV3-C_Reservoir 1/3 Throw_LV2 -- 手裏剣LV3-C_溜め1/3投目_LV2"
+        "Sen Throw Charge - Some Money"
       ]
     },
     {
       "ID": 7004102,
       "Entries": [
-        "Shuriken LV3-C_Reservoir 1/3 Throw_LV3 -- 手裏剣LV3-C_溜め1/3投目_LV3"
+        "Sen Throw Charge - A Lot of Money"
       ]
     },
     {
       "ID": 7004110,
       "Entries": [
-        "Shuriken LV3-C_2nd throw _LV1 -- 手裏剣LV3-C_溜め2投目_LV1"
+        "Sen Throw - Little Money"
       ]
     },
     {
       "ID": 7004111,
       "Entries": [
-        "Shuriken LV3-C_2nd throw _LV2 -- 手裏剣LV3-C_溜め2投目_LV2"
+        "Sen Throw - Some Money"
       ]
     },
     {
       "ID": 7004112,
       "Entries": [
-        "Shuriken LV3-C_2nd throw _LV3 -- 手裏剣LV3-C_溜め2投目_LV3"
+        "Sen Throw - A Lot of Money"
       ]
     },
     {
       "ID": 7004150,
       "Entries": [
-        "Shuriken LV3-C_1 / 3 Throw _LV1 -- 手裏剣LV3-C_1/3投目_LV1"
+        "Sen Throw Charge - Little Money"
       ]
     },
     {
       "ID": 7004151,
       "Entries": [
-        "Shuriken LV3-C_1 / 3 Throw _LV2 -- 手裏剣LV3-C_1/3投目_LV2"
+        "Sen Throw Charge - Some Money"
       ]
     },
     {
       "ID": 7004152,
       "Entries": [
-        "Shuriken LV3-C_1 / 3 Throw _LV3 -- 手裏剣LV3-C_1/3投目_LV3"
+        "Sen Throw Charge - A Lot of Money"
       ]
     },
     {
       "ID": 7004160,
       "Entries": [
-        "Shuriken LV3-C_2 Throw _LV1 -- 手裏剣LV3-C_2投目_LV1"
+        "Sen Throw - Little Money"
       ]
     },
     {
       "ID": 7004161,
       "Entries": [
-        "Shuriken LV3-C_2 Throw _LV2 -- 手裏剣LV3-C_2投目_LV2"
+        "Sen Throw - Some Money"
       ]
     },
     {
       "ID": 7004162,
       "Entries": [
-        "Shuriken LV3-C_2 Throw _LV3 -- 手裏剣LV3-C_2投目_LV3"
+        "Sen Throw - A Lot of Money"
       ]
     },
     {
       "ID": 7005100,
       "Entries": [
-        "Shuriken LV4_ Reservoir 1/3 Throw _1 Hit -- 手裏剣LV4_溜め1/3投目_1Hit"
+        "Lazulite Shuriken Charge - Throw 1 - Hit 1"
       ]
     },
     {
       "ID": 7005102,
       "Entries": [
-        "Shuriken LV4_ Reservoir 1/3 Throw _2 Hit -- 手裏剣LV4_溜め1/3投目_2Hit"
+        "Lazulite Shuriken Charge - Throw 1 - Hit 2"
       ]
     },
     {
       "ID": 7005104,
       "Entries": [
-        "Shuriken LV4_Reservoir 1/3 Throw_3 Hit -- 手裏剣LV4_溜め1/3投目_3Hit"
+        "Lazulite Shuriken Charge - Throw 1 - Hit 3"
       ]
     },
     {
       "ID": 7005110,
       "Entries": [
-        "Shuriken LV4_ 2nd throw -- 手裏剣LV4_溜め2投目"
+        "Lazulite Shuriken Charge - Throw 2 - Hit 1"
       ]
     },
     {
       "ID": 7005112,
       "Entries": [
-        "Shuriken LV4_ Reservoir 2nd Throw_2Hit -- 手裏剣LV4_溜め2投目_2Hit"
+        "Lazulite Shuriken Charge - Throw 2 - Hit 2"
       ]
     },
     {
       "ID": 7005114,
       "Entries": [
-        "Shuriken LV4_Reservoir 2nd throw_3Hit -- 手裏剣LV4_溜め2投目_3Hit"
+        "Lazulite Shuriken Charge - Throw 2 - Hit 3"
       ]
     },
     {
       "ID": 7005150,
       "Entries": [
-        "Shuriken LV4_1 / 3 throw -- 手裏剣LV4_1/3投目"
+        "Lazulite Shuriken - Throw 1"
       ]
     },
     {
       "ID": 7005160,
       "Entries": [
-        "Shuriken LV4_2 -- 手裏剣LV4_2投目"
+        "Lazulite Shuriken - Throw 2"
       ]
     },
     {
       "ID": 7100100,
       "Entries": [
-        "Firecracker_dummy bullet_do not hit the enemy -- 爆竹_ダミー弾丸_敵に当たらない"
+        "Firecracker - Dummy Bullet"
       ]
     },
     {
       "ID": 7100101,
       "Entries": [
-        "Firecracker _ Dummy bullet _ Do not hit the enemy _ See per map _ Normal -- 爆竹_ダミー弾丸_敵に当たらない_マップあたり参照_通常"
+        "Firecracker - Dummy Bullet"
       ]
     },
     {
       "ID": 7100103,
       "Entries": [
-        "Firecracker_Fear other than animals -- 爆竹_動物以外怯み"
+        "Firecracker - Non Animal Stun"
       ]
     },
     {
       "ID": 7100104,
       "Entries": [
-        "Firecracker_animal frightening -- 爆竹_動物怯み"
+        "Firecracker - Animal Stun"
       ]
     },
     {
       "ID": 7200100,
       "Entries": [
-        "Ignition_Pump shot 1 -- 発火_溜め撃ち1"
+        "Flame Vent Charge - Hit 1"
       ]
     },
     {
       "ID": 7200101,
       "Entries": [
-        "Ignition_Pump shot 2 -- 発火_溜め撃ち2"
+        "Flame Vent Charge - Hit 2"
       ]
     },
     {
       "ID": 7200110,
       "Entries": [
-        "Ignition_normal shooting -- 発火_通常撃ち"
+        "Flame Vent - Normal"
       ]
     },
     {
       "ID": 7200120,
       "Entries": [
-        "Ignition_Aerial shooting -- 発火_空中撃ち"
+        "Flame Vent - Aerial"
       ]
     },
     {
       "ID": 7200130,
       "Entries": [
-        "Ignition_flamethrower_start -- 発火_火炎放射_開始"
+        "Flame Vent - Flamethrower Start"
       ]
     },
     {
       "ID": 7200131,
       "Entries": [
-        "Ignition_flamethrower_loop -- 発火_火炎放射_ループ"
+        "Flame Vent - Flamethrower Loop"
       ]
     },
     {
       "ID": 7203100,
       "Entries": [
-        "Ignition LV4_Pump shot 1 -- 発火LV4_溜め撃ち1"
+        "Lazulite Sacred Flame - Charge - Hit 1"
       ]
     },
     {
       "ID": 7203101,
       "Entries": [
-        "Ignition LV4_Pump shot 2 -- 発火LV4_溜め撃ち2"
+        "Lazulite Sacred Flame - Charge - Hit 2"
       ]
     },
     {
       "ID": 7203110,
       "Entries": [
-        "Ignition LV4_normal shooting -- 発火LV4_通常撃ち"
+        "Lazulite Sacred Flame - Normal"
       ]
     },
     {
       "ID": 7203120,
       "Entries": [
-        "Ignition LV4_Aerial shooting -- 発火LV4_空中撃ち"
+        "Lazulite Sacred Flame - Aerial"
       ]
     },
     {
       "ID": 7203130,
       "Entries": [
-        "Ignition LV4_flamethrower_start -- 発火LV4_火炎放射_開始"
+        "Lazulite Sacred Flame - Flamethrower Start"
       ]
     },
     {
       "ID": 7203131,
       "Entries": [
-        "Ignition LV4_flamethrower_loop -- 発火LV4_火炎放射_ループ"
+        "Lazulite Sacred Flame - Flamethrower Loop"
       ]
     },
     {
       "ID": 7300100,
       "Entries": [
-        "Ax_Pump Attack 1 -- 斧_溜め攻撃1"
+        "Axe - Charge - Hit 1"
       ]
     },
     {
       "ID": 7300101,
       "Entries": [
-        "Ax_Pump Attack 2 / Single Attack -- 斧_溜め攻撃2/単発攻撃"
+        "Axe - Charge - Hit 2"
       ]
     },
     {
       "ID": 7300110,
       "Entries": [
-        "Ax _ front slash _ ax -- 斧_前宙斬り_斧"
+        "Axe - Normal"
       ]
     },
     {
       "ID": 7300120,
       "Entries": [
-        "Ax_Aerial attack -- 斧_空中攻撃"
+        "Axe - Aerial"
       ]
     },
     {
       "ID": 7300121,
       "Entries": [
-        "Ax_Aerial Attack_Loop / Landing -- 斧_空中攻撃_ループ/着地"
+        "Axe - Aerial Loop / Landing"
       ]
     },
     {
       "ID": 7302100,
       "Entries": [
-        "Ax LV3_ Reservoir Attack 1 -- 斧LV3_溜め攻撃1"
+        "Sparking Axe - Charge - Hit 1"
       ]
     },
     {
       "ID": 7302101,
       "Entries": [
-        "Ax LV3_ Accumulation Attack 2 / Single Attack -- 斧LV3_溜め攻撃2/単発攻撃"
+        "Sparking Axe - Charge - Hit 2"
       ]
     },
     {
       "ID": 7302110,
       "Entries": [
-        "Ax LV3_Front Slasher_Ax -- 斧LV3_前宙斬り_斧"
+        "Sparking Axe - Normal"
       ]
     },
     {
       "ID": 7302120,
       "Entries": [
-        "Ax LV3_ aerial attack -- 斧LV3_空中攻撃"
+        "Sparking Axe - Aerial"
       ]
     },
     {
       "ID": 7302121,
       "Entries": [
-        "Ax LV3_Aerial Attack_Loop / Landing -- 斧LV3_空中攻撃_ループ/着地"
+        "Sparking Axe - Aerial Loop / Landing"
       ]
     },
     {
       "ID": 7302130,
       "Entries": [
-        "Ax LV3_ shock wave -- 斧LV3_衝撃波"
+        "Sparking Axe - Explosion"
       ]
     },
     {
       "ID": 7303100,
       "Entries": [
-        "Ax LV4_ Reservoir Attack 1 -- 斧LV4_溜め攻撃1"
+        "Lazulite Axe - Charge - Hit 1"
       ]
     },
     {
       "ID": 7303101,
       "Entries": [
-        "Ax LV4_ Accumulation Attack 2 / Single Attack -- 斧LV4_溜め攻撃2/単発攻撃"
+        "Lazulite Axe - Charge - Hit 2"
       ]
     },
     {
       "ID": 7303110,
       "Entries": [
-        "Ax LV4_Front Slasher_Ax -- 斧LV4_前宙斬り_斧"
+        "Lazulite Axe - Normal"
       ]
     },
     {
       "ID": 7303120,
       "Entries": [
-        "Ax LV4_ aerial attack -- 斧LV4_空中攻撃"
+        "Lazulite Axe - Aerial"
       ]
     },
     {
       "ID": 7303121,
       "Entries": [
-        "Ax LV4_Aerial Attack_Loop / Landing -- 斧LV4_空中攻撃_ループ/着地"
+        "Lazulite Axe - Aerial Loop / Landing"
       ]
     },
     {
       "ID": 7303130,
       "Entries": [
-        "Ax LV4_ shock wave -- 斧LV4_衝撃波"
+        "Lazulite Axe - Explosion"
       ]
     },
     {
       "ID": 7303140,
       "Entries": [
-        "Ax LV4_Shockwave_Phantom Eraser -- 斧LV4_衝撃波_幻影消し"
+        "Lazulite Axe - Snap Seed Effect"
       ]
     },
     {
       "ID": 7402100,
       "Entries": [
-        "Transformation LV3_ activation impact -- 変わり身LV3_発動衝撃"
+        "Great Feather Mist Raven - Explosion"
       ]
     },
     {
       "ID": 7500100,
       "Entries": [
-        "Kodachi_Table 1st stage_Left hand sword -- 小太刀_表1段目_左手刀"
+        "Sabimaru - Hit 1"
       ]
     },
     {
       "ID": 7500102,
       "Entries": [
-        "Kodachi _ Table 3rd _ Left hand sword -- 小太刀_表3段目_左手刀"
+        "Sabimaru - Hit 3"
       ]
     },
     {
       "ID": 7500104,
       "Entries": [
-        "Kodachi _ Table 5th _ Left hand sword -- 小太刀_表5段目_左手刀"
+        "Sabimaru - Hit 5"
       ]
     },
     {
       "ID": 7500105,
       "Entries": [
-        "Kodachi _ Table 6th _ Left hand sword -- 小太刀_表6段目_左手刀"
+        "Sabimaru - Hit 6"
       ]
     },
     {
       "ID": 7500110,
       "Entries": [
-        "Kodachi _ back 1st stage _ left hand sword -- 小太刀_裏1段目_左手刀"
+        "Improved Sabimaru Follow-up - Hit 1"
       ]
     },
     {
       "ID": 7500111,
       "Entries": [
-        "Kodachi _ back 2nd stage _ left hand sword -- 小太刀_裏2段目_左手刀"
+        "Improved Sabimaru Follow-up - Hit 2"
       ]
     },
     {
       "ID": 7500112,
       "Entries": [
-        "Kodachi_back 3rd stage_left hand sword -- 小太刀_裏3段目_左手刀"
+        "Improved Sabimaru Follow-up - Hit 3"
       ]
     },
     {
       "ID": 7500113,
       "Entries": [
-        "Kodachi_back 4th stage_left hand sword -- 小太刀_裏4段目_左手刀"
+        "Improved Sabimaru Follow-up - Hit 4"
       ]
     },
     {
       "ID": 7500114,
       "Entries": [
-        "Kodachi_back 5th stage_left hand sword -- 小太刀_裏5段目_左手刀"
+        "Improved Sabimaru Follow-up - Hit 5"
       ]
     },
     {
       "ID": 7500115,
       "Entries": [
-        "Kodachi_back 6th stage_left hand sword -- 小太刀_裏6段目_左手刀"
+        "Improved Sabimaru Follow-up - Hit 6"
       ]
     },
     {
       "ID": 7500140,
       "Entries": [
-        "Kodachi_Aerial 1_Left Hand Sword -- 小太刀_空中1_左手刀"
+        "Sabimaru - Aerial - Hit 1"
       ]
     },
     {
       "ID": 7500141,
       "Entries": [
-        "Kodachi_Aerial 2_Left Hand Sword -- 小太刀_空中2_左手刀"
+        "Sabimaru - Aerial - Hit 2"
       ]
     },
     {
       "ID": 7502100,
       "Entries": [
-        "Kodachi LV3-A_Table 1st stage_Left hand sword -- 小太刀LV3-A_表1段目_左手刀"
+        "Piercing Sabimaru - Hit 1"
       ]
     },
     {
       "ID": 7502102,
       "Entries": [
-        "Kodachi LV3-A_Table 3rd stage_Left hand sword -- 小太刀LV3-A_表3段目_左手刀"
+        "Piercing Sabimaru - Hit 3"
       ]
     },
     {
       "ID": 7502104,
       "Entries": [
-        "Kodachi LV3-A_Table 5th stage_Left hand sword -- 小太刀LV3-A_表5段目_左手刀"
+        "Piercing Sabimaru - Hit 5"
       ]
     },
     {
       "ID": 7502105,
       "Entries": [
-        "Kodachi LV3-A_Table 6th row_Left hand sword -- 小太刀LV3-A_表6段目_左手刀"
+        "Piercing Sabimaru - Hit 6"
       ]
     },
     {
       "ID": 7502110,
       "Entries": [
-        "Kodachi LV3-A_back 1st stage_left hand sword -- 小太刀LV3-A_裏1段目_左手刀"
+        "Piercing Sabimaru Follow-up - Hit 1"
       ]
     },
     {
       "ID": 7502111,
       "Entries": [
-        "Kodachi LV3-A_back 2nd stage_left hand sword -- 小太刀LV3-A_裏2段目_左手刀"
+        "Piercing Sabimaru Follow-up - Hit 3"
       ]
     },
     {
       "ID": 7502112,
       "Entries": [
-        "Kodachi LV3-A_back 3rd stage_left hand sword -- 小太刀LV3-A_裏3段目_左手刀"
+        "Piercing Sabimaru Follow-up - Hit 3"
       ]
     },
     {
       "ID": 7502113,
       "Entries": [
-        "Kodachi LV3-A_back 4th stage_left hand sword -- 小太刀LV3-A_裏4段目_左手刀"
+        "Piercing Sabimaru Follow-up - Hit 4"
       ]
     },
     {
       "ID": 7502114,
       "Entries": [
-        "Kodachi LV3-A_back 5th stage_left hand sword -- 小太刀LV3-A_裏5段目_左手刀"
+        "Piercing Sabimaru Follow-up - Hit 5"
       ]
     },
     {
       "ID": 7502115,
       "Entries": [
-        "Kodachi LV3-A_Back 6th stage_Left hand sword -- 小太刀LV3-A_裏6段目_左手刀"
+        "Piercing Sabimaru Follow-up - Hit 6"
       ]
     },
     {
       "ID": 7502140,
       "Entries": [
-        "Kodachi LV3-A_Aerial 1_Left Hand Sword -- 小太刀LV3-A_空中1_左手刀"
+        "Piercing Sabimaru - Aerial - Hit 1"
       ]
     },
     {
       "ID": 7502141,
       "Entries": [
-        "Kodachi LV3-A_Aerial 2_Left Hand Sword -- 小太刀LV3-A_空中2_左手刀"
+        "Piercing Sabimaru - Aerial - Hit 2"
       ]
     },
     {
       "ID": 7503100,
       "Entries": [
-        "Kodachi LV3-B_Table 1st stage_Left hand sword -- 小太刀LV3-B_表1段目_左手刀"
+        "Lazulite Sabimaru - Hit 1"
       ]
     },
     {
       "ID": 7503102,
       "Entries": [
-        "Kodachi LV3-B_Table 3rd stage_Left hand sword -- 小太刀LV3-B_表3段目_左手刀"
+        "Lazulite Sabimaru - Hit 3"
       ]
     },
     {
       "ID": 7503104,
       "Entries": [
-        "Kodachi LV3-B_Table 5th stage_Left hand sword -- 小太刀LV3-B_表5段目_左手刀"
+        "Lazulite Sabimaru - Hit 5"
       ]
     },
     {
       "ID": 7503105,
       "Entries": [
-        "Kodachi LV3-B_Table 6th row_Left hand sword -- 小太刀LV3-B_表6段目_左手刀"
+        "Lazulite Sabimaru - Hit 6"
       ]
     },
     {
       "ID": 7503110,
       "Entries": [
-        "Kodachi LV3-B_Back 1st stage_Left hand sword -- 小太刀LV3-B_裏1段目_左手刀"
+        "Lazulite Sabimaru Follow-up - Hit 1"
       ]
     },
     {
       "ID": 7503111,
       "Entries": [
-        "Kodachi LV3-B_Back 2nd stage_Left hand sword -- 小太刀LV3-B_裏2段目_左手刀"
+        "Lazulite Sabimaru Follow-up - Hit 2"
       ]
     },
     {
       "ID": 7503112,
       "Entries": [
-        "Kodachi LV3-B_back 3rd stage_left hand sword -- 小太刀LV3-B_裏3段目_左手刀"
+        "Lazulite Sabimaru Follow-up - Hit 3"
       ]
     },
     {
       "ID": 7503113,
       "Entries": [
-        "Kodachi LV3-B_back 4th stage_left hand sword -- 小太刀LV3-B_裏4段目_左手刀"
+        "Lazulite Sabimaru Follow-up - Hit 4"
       ]
     },
     {
       "ID": 7503114,
       "Entries": [
-        "Kodachi LV3-B_back 5th stage_left hand sword -- 小太刀LV3-B_裏5段目_左手刀"
+        "Lazulite Sabimaru Follow-up - Hit 5"
       ]
     },
     {
       "ID": 7503115,
       "Entries": [
-        "Kodachi LV3-B_Back 6th stage_Left hand sword -- 小太刀LV3-B_裏6段目_左手刀"
+        "Lazulite Sabimaru Follow-up - Hit 6"
       ]
     },
     {
       "ID": 7503140,
       "Entries": [
-        "Kodachi LV3-B_Aerial 1_Left Hand Sword -- 小太刀LV3-B_空中1_左手刀"
+        "Lazulite Sabimaru - Aerial - Hit 1"
       ]
     },
     {
       "ID": 7503141,
       "Entries": [
-        "Kodachi LV3-B_Aerial 2_Left Hand Sword -- 小太刀LV3-B_空中2_左手刀"
+        "Lazulite Sabimaru - Aerial - Hit 2"
       ]
     },
     {
       "ID": 7503150,
       "Entries": [
-        "Kodachi LV3-B_ poison fog -- 小太刀LV3-B_毒霧"
+        "Lazulite Sabimaru - Poison Mist"
       ]
     },
     {
       "ID": 7600100,
       "Entries": [
-        "Iron fan_guard -- 鉄扇_ガード"
+        "Loaded Umbrella Guard"
       ]
     },
     {
       "ID": 7600200,
       "Entries": [
-        "Projected Force - Loaded Umbrella - Projectile Level 1"
+        "Projected Force - Loaded Umbrella - Level 1"
       ]
     },
     {
       "ID": 7600210,
       "Entries": [
-        "Projected Force - Loaded Umbrella - Projectile Level 2"
+        "Projected Force - Loaded Umbrella - Level 2"
       ]
     },
     {
       "ID": 7600220,
       "Entries": [
-        "Projected Force - Loaded Umbrella - Projectile Level 3"
+        "Projected Force - Loaded Umbrella - Level 3"
       ]
     },
     {
       "ID": 7700100,
       "Entries": [
-        "Enemy turning _ wind release -- 敵回し_風放ち"
+        "Divine Abduction"
       ]
     },
     {
       "ID": 7701100,
       "Entries": [
-        "Enemy turning LV2_ wind release -- 敵回しLV2_風放ち"
+        "Double Divine Abduction"
       ]
     },
     {
       "ID": 7702100,
       "Entries": [
-        "Enemy turning LV3_ wind release -- 敵回しLV3_風放ち"
+        "Golden Vortex"
       ]
     },
     {
       "ID": 7800100,
       "Entries": [
-        "Spear_Pump Charge 1 -- 槍_溜め突撃1"
+        "Spear Thrust Type - Charge - Hit 1"
       ]
     },
     {
       "ID": 7800101,
       "Entries": [
-        "Spear_Pump Charge 2 -- 槍_溜め突撃2"
+        "Spear Thrust Type - Charge - Hit 2"
       ]
     },
     {
       "ID": 7800105,
       "Entries": [
-        "Spear _ Accumulation Assault 3 / Single Thrust _ Tip -- 槍_溜め突撃3/単発突き_先端"
+        "Spear Thrust Type - Single Thrust / Charge Final - Tip"
       ]
     },
     {
       "ID": 7800106,
       "Entries": [
-        "Spear_Pump Charge 3 / Single-shot Charge_Intermediate -- 槍_溜め突撃3/単発突き_中間"
+        "Spear Thrust Type / Normal - Single Thrust / Charge Final - Middle"
       ]
     },
     {
       "ID": 7800107,
       "Entries": [
-        "Spear _ Reservoir Assault 3 / Single Thrust _ Root -- 槍_溜め突撃3/単発突き_根元"
+        "Spear Thrust Type / Normal - Single Thrust / Charge Final - Root"
       ]
     },
     {
       "ID": 7800110,
       "Entries": [
-        "Spear_Attract 1 -- 槍_引き寄せ1"
+        "Spear Thrust Type / Normal - Pull - Beginning"
       ]
     },
     {
       "ID": 7800115,
       "Entries": [
-        "Spear_pull 2_tip -- 槍_引き寄せ2_先端"
+        "Spear Thrust Type / Normal - Pull - Tip"
       ]
     },
     {
       "ID": 7800116,
       "Entries": [
-        "Spear_Attract 2_Intermediate -- 槍_引き寄せ2_中間"
+        "Spear Thrust Type / Normal - Middle"
       ]
     },
     {
       "ID": 7800117,
       "Entries": [
-        "Spear_Attract 2_Root -- 槍_引き寄せ2_根元"
+        "Spear Thrust Type / Normal - Root"
       ]
     },
     {
       "ID": 7802100,
       "Entries": [
-        "Spear LV2-B_ Reservoir _ Tip -- 槍LV2-B_溜めなぎ払い_先端"
+        "Spear Cleave Type - Charge - Tip"
       ]
     },
     {
       "ID": 7802101,
       "Entries": [
-        "Spear LV2-B_Reservoir _Intermediate -- 槍LV2-B_溜めなぎ払い_中間"
+        "Spear Cleave Type - Charge - Middle"
       ]
     },
     {
       "ID": 7802102,
       "Entries": [
-        "Spear LV2-B_ Reservoir _ Root -- 槍LV2-B_溜めなぎ払い_根元"
+        "Spear Cleave Type - Charge Final - Root"
       ]
     },
     {
       "ID": 7802105,
       "Entries": [
-        "Spear LV2-B_single thrust_tip -- 槍LV2-B_単発突き_先端"
+        "Spear Cleave Type - Single Thrust - Tip"
       ]
     },
     {
       "ID": 7802106,
       "Entries": [
-        "Spear LV2-B_single thrust_intermediate -- 槍LV2-B_単発突き_中間"
+        "Spear Cleave Type - Single Thrust - Middle"
       ]
     },
     {
       "ID": 7802107,
       "Entries": [
-        "Spear LV2-B_single thrust_root -- 槍LV2-B_単発突き_根元"
+        "Spear Cleave Type - Single Thrust - Root"
       ]
     },
     {
       "ID": 7802110,
       "Entries": [
-        "Spear LV2-B_Attract 1 -- 槍LV2-B_引き寄せ1"
+        "Spear Cleave Type - Pull - Beginning"
       ]
     },
     {
       "ID": 7802115,
       "Entries": [
-        "Spear LV2-B_Pulling 2_Tip -- 槍LV2-B_引き寄せ2_先端"
+        "Spear Cleave Type - Pull - Tip"
       ]
     },
     {
       "ID": 7802116,
       "Entries": [
-        "Spear LV2-B_Attract 2_Intermediate -- 槍LV2-B_引き寄せ2_中間"
+        "Spear Cleave Type - Pull - Middle"
       ]
     },
     {
       "ID": 7802117,
       "Entries": [
-        "Spear LV2-B_Attract 2_Root -- 槍LV2-B_引き寄せ2_根元"
+        "Spear Cleave Type - Pull - Root"
       ]
     },
     {
       "ID": 7803100,
       "Entries": [
-        "Spear LV3-A_ Reservoir Charge 1 -- 槍LV3-A_溜め突撃1"
+        "Spiral Spear - Charge - Hit 1"
       ]
     },
     {
       "ID": 7803101,
       "Entries": [
-        "Spear LV3-A_ Reservoir Assault 2 -- 槍LV3-A_溜め突撃2"
+        "Spiral Spear - Charge - Hit 2"
       ]
     },
     {
       "ID": 7803105,
       "Entries": [
-        "Spear LV3-A_Reservoir Assault 3 / Single Thrust_Tips -- 槍LV3-A_溜め突撃3/単発突き_先端"
+        "Spiral Spear - Single Thrust / Charge Final - Tip"
       ]
     },
     {
       "ID": 7803106,
       "Entries": [
-        "Spear LV3-A_Reservoir Assault 3 / Single-shot Assault_Intermediate -- 槍LV3-A_溜め突撃3/単発突き_中間"
+        "Spiral Spear - Single Thrust / Charge Final - Middle"
       ]
     },
     {
       "ID": 7803107,
       "Entries": [
-        "Spear LV3-A_Reservoir Assault 3 / Single Thrust_Root -- 槍LV3-A_溜め突撃3/単発突き_根元"
+        "Spiral Spear - Single Thrust / Charge Final - Root"
       ]
     },
     {
       "ID": 7803110,
       "Entries": [
-        "Spear LV3-A_Attract 1 -- 槍LV3-A_引き寄せ1"
+        "Spiral Spear - Pull - Beginning"
       ]
     },
     {
       "ID": 7803115,
       "Entries": [
-        "Spear LV3-A_Attract 2_ Tip -- 槍LV3-A_引き寄せ2_先端"
+        "Spiral Spear - Pull - Tip"
       ]
     },
     {
       "ID": 7803116,
       "Entries": [
-        "Spear LV3-A_Attract 2_Intermediate -- 槍LV3-A_引き寄せ2_中間"
+        "Spiral Spear - Pull - Middle"
       ]
     },
     {
       "ID": 7803117,
       "Entries": [
-        "Spear LV3-A_Attract 2_Root -- 槍LV3-A_引き寄せ2_根元"
+        "Spiral Spear - Pull - Root"
       ]
     },
     {
       "ID": 7804100,
       "Entries": [
-        "Spear LV3-B-B_ Reservoir _ Tip -- 槍LV3-B-B_溜めなぎ払い_先端"
+        "Leaping Flame - Charge - Tip"
       ]
     },
     {
       "ID": 7804101,
       "Entries": [
-        "Spear LV3-B-B_Pump-up _Intermediate -- 槍LV3-B-B_溜めなぎ払い_中間"
+        "Leaping Flame - Charge - Middle"
       ]
     },
     {
       "ID": 7804102,
       "Entries": [
-        "Spear LV3-B-B_ Reservoir _ Root -- 槍LV3-B-B_溜めなぎ払い_根元"
+        "Leaping Flame - Charge - Root"
       ]
     },
     {
       "ID": 7804105,
       "Entries": [
-        "Spear LV3-B-B_single thrust_tip -- 槍LV3-B-B_単発突き_先端"
+        "Leaping Flame - Single Thrust - Tip"
       ]
     },
     {
       "ID": 7804106,
       "Entries": [
-        "Spear LV3-B-B_single thrust_intermediate -- 槍LV3-B-B_単発突き_中間"
+        "Leaping Flame - Single Thrust - Middle"
       ]
     },
     {
       "ID": 7804107,
       "Entries": [
-        "Spear LV3-B-B_single thrust_root -- 槍LV3-B-B_単発突き_根元"
+        "Leaping Flame - Single Thrust - Root"
       ]
     },
     {
       "ID": 7804110,
       "Entries": [
-        "Spear LV3-B-B_Attract 1 -- 槍LV3-B-B_引き寄せ1"
+        "Leaping Flame - Pull - Beginning"
       ]
     },
     {
       "ID": 7804115,
       "Entries": [
-        "Spear LV3-B-B_Pulling 2_Tip -- 槍LV3-B-B_引き寄せ2_先端"
+        "Leaping Flame - Pull - Tip"
       ]
     },
     {
       "ID": 7804116,
       "Entries": [
-        "Spear LV3-B-B_Attract 2_Intermediate -- 槍LV3-B-B_引き寄せ2_中間"
+        "Leaping Flame - Pull - Middle"
       ]
     },
     {
       "ID": 7804117,
       "Entries": [
-        "Spear LV3-B-B_Attract 2_Root -- 槍LV3-B-B_引き寄せ2_根元"
+        "Leaping Flame - Pull - Root"
       ]
     },
     {
       "ID": 7900100,
       "Entries": [
-        "Finger whistle_no lock_AI sound -- 指笛_ノーロック_AI音"
+        "Finger Whistle Sound - No Lock On"
       ]
     },
     {
       "ID": 9500000,
       "Entries": [
-        "When the wire is stabbed -- ワイヤー_刺さったとき"
+        "Grappling Hook Stab"
       ]
     },
     {
       "ID": 9500001,
       "Entries": [
-        "When the wire_pulls -- ワイヤー_引っ張ったとき"
+        "Grappling Hook Pull"
       ]
     },
     {
       "ID": 50100000,
       "Entries": [
-        "Test Shinobi 1 Grab -- テスト忍殺1掴み"
+        ""
       ]
     },
     {
       "ID": 50100010,
       "Entries": [
-        "Test Shinobi 2 Grab -- テスト忍殺2掴み"
+        ""
       ]
     },
     {
       "ID": 50200000,
       "Entries": [
-        "Test Shinobi 1 Grab -- テスト忍殺1掴み"
+        ""
       ]
     },
     {
       "ID": 50200010,
       "Entries": [
-        "Test Shinobi 2 Grab -- テスト忍殺2掴み"
+        ""
       ]
     },
     {
       "ID": 50300000,
       "Entries": [
-        "Test Shinobi 1 Grab -- テスト忍殺1掴み"
+        ""
       ]
     },
     {
       "ID": 50300010,
       "Entries": [
-        "Test Shinobi 2 Grab -- テスト忍殺2掴み"
+        ""
       ]
     },
     {
       "ID": 50400000,
       "Entries": [
-        "Test Shinobi 1 Grab -- テスト忍殺1掴み"
+        ""
       ]
     },
     {
       "ID": 50400010,
       "Entries": [
-        "Test Shinobi 2 Grab -- テスト忍殺2掴み"
+        ""
       ]
     }
   ]

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/AttackElementCorrectParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/AttackElementCorrectParam.json
@@ -4,337 +4,337 @@
     {
       "ID": 0,
       "Entries": [
-        "Default (for testing) -- デフォルト(テスト用)"
+        "Default\n"
       ]
     },
     {
       "ID": 10,
       "Entries": [
-        "Test: Use weapons to thunder strength and skill -- テスト：武器で、筋力と技量を雷にする"
+        "\n"
       ]
     },
     {
       "ID": 1000,
       "Entries": [
-        "Molotov cocktail -- 火炎瓶"
+        "\n"
       ]
     },
     {
       "ID": 1001,
       "Entries": [
-        "Thunder bottle -- 雷瓶"
+        "\n"
       ]
     },
     {
       "ID": 1002,
       "Entries": [
-        "Holy water bottle -- 聖水瓶"
+        "\n"
       ]
     },
     {
       "ID": 1010,
       "Entries": [
-        "Throw knife -- 投げナイフ"
+        "\n"
       ]
     },
     {
       "ID": 1020,
       "Entries": [
-        "Crown stone -- 竜頭石"
+        "\n"
       ]
     },
     {
       "ID": 1030,
       "Entries": [
-        "Dragon body stone Lvl2 -- 竜体石Lvl2"
+        "\n"
       ]
     },
     {
       "ID": 10000,
       "Entries": [
-        "Weapon: Normal -- 武器：通常"
+        "\n"
       ]
     },
     {
       "ID": 10014,
       "Entries": [
-        "Weapon: Holy Regen -- 武器：神聖リジェネ"
+        "\n"
       ]
     },
     {
       "ID": 10015,
       "Entries": [
-        "Weapon: Luck correction -- 武器：運補正"
+        "\n"
       ]
     },
     {
       "ID": 12000,
       "Entries": [
-        "Weapon: Cardinal Spear -- 武器：枢機卿団の槍"
+        "\n"
       ]
     },
     {
       "ID": 13000,
       "Entries": [
-        "Weapon: Sullivan&#39;s Longbow -- 武器：サリヴァーンのロングボウ"
+        "\n"
       ]
     },
     {
       "ID": 15000,
       "Entries": [
-        "Weapon: Blue Astra Straight Sword -- 武器：青いアストラ直剣"
+        "\n"
       ]
     },
     {
       "ID": 20000,
       "Entries": [
-        "Magic-1x -- 魔術-等倍"
+        "\n"
       ]
     },
     {
       "ID": 20100,
       "Entries": [
-        "Magic-Low Magnification (0.8) -- 魔術-低倍率（0.8）"
+        "\n"
       ]
     },
     {
       "ID": 20110,
       "Entries": [
-        "Magic-Low Magnification (0.87) -- 魔術-低倍率（0.87）"
+        "\n"
       ]
     },
     {
       "ID": 20120,
       "Entries": [
-        "Magic-Low Magnification (0.95) -- 魔術-低倍率（0.95）"
+        "\n"
       ]
     },
     {
       "ID": 20200,
       "Entries": [
-        "Magic-High Magnification (1.1) -- 魔術-高倍率（1.1）"
+        "\n"
       ]
     },
     {
       "ID": 20210,
       "Entries": [
-        "Magic-High Magnification (1.2) -- 魔術-高倍率（1.2）"
+        "\n"
       ]
     },
     {
       "ID": 30000,
       "Entries": [
-        "Spell-Low Magnification (0.8) -- 呪術-低倍率(0.8)"
+        "\n"
       ]
     },
     {
       "ID": 32010,
       "Entries": [
-        "Magic-Rock spitting -- 呪術-岩吐き"
+        "\n"
       ]
     },
     {
       "ID": 42060,
       "Entries": [
-        "Miracle-Sacred Storm -- 奇跡-神聖の嵐"
+        "\n"
       ]
     },
     {
       "ID": 42070,
       "Entries": [
-        "Miracle-God&#39;s Wrath -- 奇跡-神の怒り"
+        "\n"
       ]
     },
     {
       "ID": 42080,
       "Entries": [
-        "Miracle-Unleashing Force -- 奇跡-放つフォース"
+        "\n"
       ]
     },
     {
       "ID": 10010000,
       "Entries": [
-        "Dark wand -- 闇の杖"
+        "\n"
       ]
     },
     {
       "ID": 10010010,
       "Entries": [
-        "Dark Talisman -- 闇のタリスマン"
+        "\n"
       ]
     },
     {
       "ID": 10010020,
       "Entries": [
-        "Dark tin -- 闇のすず"
+        "\n"
       ]
     },
     {
       "ID": 10010030,
       "Entries": [
-        "Magic miracle tin -- 魔術奇跡のすず"
+        "\n"
       ]
     },
     {
       "ID": 10041000,
       "Entries": [
-        "Dragon&#39;s messenger&#39;s sword (Moonlight of the missing moon) _Arts one shot (magical power) -- 竜の御使の曲剣（欠け月のムーンライト）_アーツワンショット（魔力）"
+        "\n"
       ]
     },
     {
       "ID": 10061700,
       "Entries": [
-        "The Great Sword of the Old King of Eating (Blue) -- 蝕の老王の大剣（青）_アーツ構え派生R2（魔力）"
+        "\n"
       ]
     },
     {
       "ID": 10062700,
       "Entries": [
-        "Twin Prince Combined Sword_Arts Position Derived R2 (Flame) -- 双皇子合体剣_アーツ構え派生R2（炎）"
+        "\n"
       ]
     },
     {
       "ID": 10063200,
       "Entries": [
-        "Moonlight Great Sword_Normal Reservoir (Magic Power) -- 月光大剣_通常溜め（魔力）"
+        "\n"
       ]
     },
     {
       "ID": 10063210,
       "Entries": [
-        "Moonlight Great Sword_Arts One Shot (Magic Power) -- 月光大剣_アーツワンショット（魔力）"
+        "\n"
       ]
     },
     {
       "ID": 10063400,
       "Entries": [
-        "Las Boss Sword_Arts One Shot (Flame) -- ラスボス剣_アーツワンショット（炎）"
+        "\n"
       ]
     },
     {
       "ID": 10062600,
       "Entries": [
-        "Two Princes (elder brother) oversized sword_arts stepping on (flame) -- 双皇子（兄）の特大剣_アーツ踏み込み（炎）"
+        "\n"
       ]
     },
     {
       "ID": 10071200,
       "Entries": [
-        "Firewood Demon_Arts One Shot (Flame) -- 薪デーモン_アーツワンショット（炎）"
+        "\n"
       ]
     },
     {
       "ID": 10071100,
       "Entries": [
-        "Dragon Guardian Knight&#39;s Ax_Arts One Shot (Lightning) -- 竜の守護騎士の斧_アーツワンショット（雷）"
+        "\n"
       ]
     },
     {
       "ID": 10081700,
       "Entries": [
-        "Gargoyle Torch_Arts Patience Derived R2 (Flame) -- ガーゴイルのトーチ_アーツ我慢派生R2（炎）"
+        "\n"
       ]
     },
     {
       "ID": 10081900,
       "Entries": [
-        "Ash Demon Otsuchi_Arts Patience Derived R2 (Flame) -- 灰のデーモン大槌_アーツ我慢派生R2（炎）"
+        "\n"
       ]
     },
     {
       "ID": 10091800,
       "Entries": [
-        "Cardinal Spear (Physical Faith) -- 枢機卿団の槍（信仰を物理）"
+        "\n"
       ]
     },
     {
       "ID": 10091814,
       "Entries": [
-        "Cardinal Spear (Physical Faith): Sacred Derivation -- 枢機卿団の槍（信仰を物理）：神聖派生"
+        "\n"
       ]
     },
     {
       "ID": 10091815,
       "Entries": [
-        "Cardinal Spear (Physical Faith): Derived from the Dead -- 枢機卿団の槍（信仰を物理）：亡者派生"
+        "\n"
       ]
     },
     {
       "ID": 10092200,
       "Entries": [
-        "Dragon Hunting Spear_Arts Assault (Lightning) -- 竜狩りの槍_アーツ突撃（雷）"
+        "\n"
       ]
     },
     {
       "ID": 10091100,
       "Entries": [
-        "Gargoyle Spear_Arts Assault R2 Derived (Flame) -- ガーゴイルの槍_アーツ突撃R2派生（炎）"
+        "\n"
       ]
     },
     {
       "ID": 10091600,
       "Entries": [
-        "Storm King&#39;s Sword Spear_Arts One Shot (Lightning) -- 嵐の王の剣槍_アーツワンショット（雷）"
+        "\n"
       ]
     },
     {
       "ID": 10101600,
       "Entries": [
-        "Moonlight Witch&#39;s Spear_Arts One Shot (Flame) -- 月光魔女の槍_アーツワンショット（炎）"
+        "\n"
       ]
     },
     {
       "ID": 10110300,
       "Entries": [
-        "Firewood Demon Knuckle_Arts Rotation (Flame) -- 薪のデーモンのナックル_アーツ回転（炎）"
+        "\n"
       ]
     },
     {
       "ID": 10110310,
       "Entries": [
-        "Firewood Demon Knuckle_Arts Rotation Derived R2 (Flame) -- 薪のデーモンのナックル_アーツ回転派生R2（炎）"
+        "\n"
       ]
     },
     {
       "ID": 10131000,
       "Entries": [
-        "Maggot&#39;s Wand (Luck as Magic) -- 蛆人の杖（運を魔力に）"
+        "\n"
       ]
     },
     {
       "ID": 10131100,
       "Entries": [
-        "Cardinal&#39;s Wand (Faith as Magic) -- 枢機卿団の大杖（信仰を魔力に）"
+        "\n"
       ]
     },
     {
       "ID": 10131200,
       "Entries": [
-        "Sullivan&#39;s Spear (Faith to Magic) -- サリヴァーンの槍（信仰を魔力に）"
+        "\n"
       ]
     },
     {
       "ID": 10141300,
       "Entries": [
-        "Sullivan&#39;s Longbow_Arts One Shot (Magic) -- サリヴァーンのロングボウ_アーツワンショット（魔力）"
+        "\n"
       ]
     },
     {
       "ID": 10160400,
       "Entries": [
-        "Tracker&#39;s dual wield sword_right hand (magical power) -- 追跡者の二刀曲剣_右手（魔力）"
+        "\n"
       ]
     },
     {
       "ID": 10160410,
       "Entries": [
-        "Tracker&#39;s dual wield sword_left hand (flame) -- 追跡者の二刀曲剣_左手（炎）"
+        "\n"
       ]
     },
     {
       "ID": 10160420,
       "Entries": [
-        "Tracker&#39;s dual wield sword_left hand (for weapon side display) -- 追跡者の二刀曲剣_左手（武器側表示用）"
+        "\n"
       ]
     }
   ]

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/BehaviorParam_PC.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/BehaviorParam_PC.json
@@ -4,55 +4,55 @@
     {
       "ID": 4,
       "Entries": [
-        "Object destruction attack for automatic patrol -- 自動巡回用オブジェ破壊攻撃"
+        "For destroying automatic patrol objects"
       ]
     },
     {
       "ID": 6,
       "Entries": [
-        "Object destruction attack for automatic patrol_for debugging function verification -- 自動巡回用オブジェ破壊攻撃_デバッグ機能検証用"
+        "Dummy for debug"
       ]
     },
     {
       "ID": 10,
       "Entries": [
-        ""
+        "Dummy - Hits Nothing"
       ]
     },
     {
       "ID": 200,
       "Entries": [
-        "Impact"
+        "Impact\n"
       ]
     },
     {
       "ID": 210,
       "Entries": [
-        "Impact"
+        "Impact\n"
       ]
     },
     {
       "ID": 211,
       "Entries": [
-        "Impact"
+        "Impact\n"
       ]
     },
     {
       "ID": 220,
       "Entries": [
-        "Impact"
+        "Impact\n"
       ]
     },
     {
       "ID": 221,
       "Entries": [
-        "Impact"
+        "Impact\n"
       ]
     },
     {
       "ID": 222,
       "Entries": [
-        "Impact"
+        "Impact\n"
       ]
     },
     {
@@ -82,883 +82,883 @@
     {
       "ID": 600,
       "Entries": [
-        "Shinobi killing start_break -- 忍殺始動_崩し"
+        "Deathblow Initiation - Posture Break"
       ]
     },
     {
       "ID": 640,
       "Entries": [
-        "Shinobi killing start_behind -- 忍殺始動_背後"
+        "Deathblow Initiation - Backstab"
       ]
     },
     {
       "ID": 650,
       "Entries": [
-        "Shinobi killing start_ crouching behind -- 忍殺始動_背後しゃがみ"
+        "Deathblow Initiation - Crouching Backstab"
       ]
     },
     {
       "ID": 660,
       "Entries": [
-        "Shinobi killing start_fall -- 忍殺始動_落下"
+        "Deathblow Initiation - Plunging"
       ]
     },
     {
       "ID": 680,
       "Entries": [
-        "Shinobi killing start_breaking wire -- 忍殺始動_崩しワイヤー"
+        "Deathblow Initiation - Grappling Hook"
       ]
     },
     {
       "ID": 690,
       "Entries": [
-        "Shinobi killing start_anti-aircraft -- 忍殺始動_対空"
+        "Deathblow Initiation - Anti-air"
       ]
     },
     {
       "ID": 700,
       "Entries": [
-        "Shinobi killing start_wall left -- 忍殺始動_壁張り付き左"
+        "Deathblow Initiation - Hug Wall Left"
       ]
     },
     {
       "ID": 710,
       "Entries": [
-        "Shinobi killing start_walled right -- 忍殺始動_壁張り付き右"
+        "Deathblow Initiation - Hug Wall Right"
       ]
     },
     {
       "ID": 720,
       "Entries": [
-        "Shinobi killing start_ hanging -- 忍殺始動_ぶら下がり"
+        "Deathblow Initiation - Ledge Hang"
       ]
     },
     {
       "ID": 740,
       "Entries": [
-        "Shinobi killing start_breaking kick jump -- 忍殺始動_崩し蹴りジャンプ"
+        "Deathblow Initiation - Jump Kick Break"
       ]
     },
     {
       "ID": 800,
       "Entries": [
-        "Shinobi slaughter start _ stop _ priest -- 忍殺始動_とどめ_破戒僧"
+        "Deathblow Initiation - Corrupted Monk - Finisher"
       ]
     },
     {
       "ID": 801,
       "Entries": [
-        "Shinobi killing start _ stop _ chief of the ninja army -- 忍殺始動_とどめ_忍軍の長"
+        "Deathblow Initiation - Owl - Finisher"
       ]
     },
     {
       "ID": 803,
       "Entries": [
-        "Shinobi killing start _ stop _ Yasha monkey -- 忍殺始動_とどめ_夜叉猿"
+        "Deathblow Initiation - Guardian Ape - Finisher"
       ]
     },
     {
       "ID": 804,
       "Entries": [
-        "Shinobi killing start _ stop _ rival -- 忍殺始動_とどめ_ライバル"
+        "Deathblow Initiation - Genichiro - Finisher"
       ]
     },
     {
       "ID": 805,
       "Entries": [
-        "Shinobi killing start _ stop _ butterfly -- 忍殺始動_とどめ_お蝶"
+        "Deathblow Initiation - Lady Butterfly - Finisher"
       ]
     },
     {
       "ID": 806,
       "Entries": [
-        "Shinobi killing start _ stop _ sword sacred -- 忍殺始動_とどめ_剣聖"
+        "Deathblow Initiation - Isshin - Finisher"
       ]
     },
     {
       "ID": 807,
       "Entries": [
-        "Shinobi killing start _ stop _ Buddhist demon -- 忍殺始動_とどめ_仏師鬼"
+        "Deathblow Initiation - Demon of Hatred - Finisher"
       ]
     },
     {
       "ID": 840,
       "Entries": [
-        "Shinobi shock _ short distance _ on the spot -- 忍殺衝撃_近距離_その場"
+        "Mikiri Counter - Break"
       ]
     },
     {
       "ID": 841,
       "Entries": [
-        "Shinobi shock _ short distance _ jump away -- 忍殺衝撃_近距離_飛び退き"
+        "Mikiri Counter"
       ]
     },
     {
       "ID": 842,
       "Entries": [
-        "Shinobi shock _ long distance _ on the spot -- 忍殺衝撃_遠距離_その場"
+        "Mikiri Counter - Break"
       ]
     },
     {
       "ID": 843,
       "Entries": [
-        "Shinobi shock _ long distance _ jump away -- 忍殺衝撃_遠距離_飛び退き"
+        "Mikiri Counter"
       ]
     },
     {
       "ID": 900,
       "Entries": [
-        "Kick -- 蹴り"
+        "Kick"
       ]
     },
     {
       "ID": 901,
       "Entries": [
-        "Kick_in the air -- 蹴り_空中"
+        "Jump Kick"
       ]
     },
     {
       "ID": 902,
       "Entries": [
-        "Kick _ closeout success production -- 蹴り_見切り成功演出"
+        ""
       ]
     },
     {
       "ID": 903,
       "Entries": [
-        "Kick_dash -- 蹴り_ダッシュ"
+        "Kick Dash"
       ]
     },
     {
       "ID": 950,
       "Entries": [
-        "Action ID direct designation attack for wire -- ワイヤー用行動ID直指定攻撃"
+        "Grappling Hook Pull"
       ]
     },
     {
       "ID": 105000000,
       "Entries": [
-        "Right-handed sword_reservoir 1 -- 右手刀_溜め突き1"
+        "Kusabimaru Thrust 1"
       ]
     },
     {
       "ID": 105000001,
       "Entries": [
-        "Right-handed sword_reservoir 2 -- 右手刀_溜め突き2"
+        "Kusabimaru Thrust 2"
       ]
     },
     {
       "ID": 105000006,
       "Entries": [
-        "Right hand sword_reservoir 2_reverse foot -- 右手刀_溜め突き2_逆足"
+        "Kusabimaru Thrust"
       ]
     },
     {
       "ID": 105000010,
       "Entries": [
-        "Right hand sword_normal attack 1 -- 右手刀_通常攻撃1"
+        "Kusabimaru Light Attack 1"
       ]
     },
     {
       "ID": 105000011,
       "Entries": [
-        "Right hand sword_normal attack 2 -- 右手刀_通常攻撃2"
+        "Kusabimaru Light Attack 2"
       ]
     },
     {
       "ID": 105000012,
       "Entries": [
-        "Right hand sword_normal attack 3 -- 右手刀_通常攻撃3"
+        "Kusabimaru Light Attack 3"
       ]
     },
     {
       "ID": 105000013,
       "Entries": [
-        "Right hand sword_normal attack 4 -- 右手刀_通常攻撃4"
+        "Kusabimaru Light Attack 4"
       ]
     },
     {
       "ID": 105000014,
       "Entries": [
-        "Right hand sword_normal attack 5 -- 右手刀_通常攻撃5"
+        "Kusabimaru Light Attack 5"
       ]
     },
     {
       "ID": 105000016,
       "Entries": [
-        "Right hand sword_normal attack 2_reverse foot -- 右手刀_通常攻撃2_逆足"
+        "Kusabimaru Light Attack"
       ]
     },
     {
       "ID": 105000020,
       "Entries": [
-        "Right hand sword _ Small jasuga received and then accumulated stab _ Left -- 右手刀_小ジャスガ受け後溜め突き_左"
+        "Kusabimaru Guard Attack"
       ]
     },
     {
       "ID": 105000021,
       "Entries": [
-        "Right hand sword_Small jasuga received and then accumulated thrust_Right -- 右手刀_小ジャスガ受け後溜め突き_右"
+        "Kusabimaru Guard Attack"
       ]
     },
     {
       "ID": 105000025,
       "Entries": [
-        "Right hand sword _ Middle jasuga receiver / After step stab _ Left -- 右手刀_中ジャスガ受け/ステップ後溜め突き_左"
+        "Kusabimaru Guard Attack"
       ]
     },
     {
       "ID": 105000026,
       "Entries": [
-        "Right hand sword _ Middle jasuga receiving / After step stab _ Right -- 右手刀_中ジャスガ受け/ステップ後溜め突き_右"
+        "Kusabimaru Guard Attack"
       ]
     },
     {
       "ID": 105000030,
       "Entries": [
-        "Right hand sword _ Attack after receiving small jasuga _ Left -- 右手刀_小ジャスガ受け後攻撃_左"
+        "Kusabimaru Guard Attack"
       ]
     },
     {
       "ID": 105000031,
       "Entries": [
-        "Right hand sword _ Attack after receiving small jasuga _ Right -- 右手刀_小ジャスガ受け後攻撃_右"
+        "Kusabimaru Guard Attack"
       ]
     },
     {
       "ID": 105000035,
       "Entries": [
-        "Right hand sword_Middle Jasuga receiving / Attack after step_Left -- 右手刀_中ジャスガ受け/ステップ後攻撃_左"
+        "Kusabimaru Guard Attack"
       ]
     },
     {
       "ID": 105000036,
       "Entries": [
-        "Right hand sword_Medium Jasuga receiving / Attack after step_Right -- 右手刀_中ジャスガ受け/ステップ後攻撃_右"
+        "Kusabimaru Guard Attack"
       ]
     },
     {
       "ID": 105000040,
       "Entries": [
-        "Right-handed sword_guard / Jasuga is flipped and then accumulated -- 右手刀_ガード/ジャスガ弾かれ後溜め突き_右"
+        "Kusabimaru Guard Attack"
       ]
     },
     {
       "ID": 105000041,
       "Entries": [
-        "Right hand sword _ guard / jasuga is flipped and then accumulated _ left -- 右手刀_ガード/ジャスガ弾かれ後溜め突き_左"
+        "Kusabimaru Guard Attack"
       ]
     },
     {
       "ID": 105000050,
       "Entries": [
-        "Right hand sword_guard / Jasuga attack after being hit_right -- 右手刀_ガード/ジャスガ弾かれ後攻撃_右"
+        "Kusabimaru Guard Attack"
       ]
     },
     {
       "ID": 105000051,
       "Entries": [
-        "Right hand sword_guard / Jasuga attack after being hit_left -- 右手刀_ガード/ジャスガ弾かれ後攻撃_左"
+        "Kusabimaru Guard Attack"
       ]
     },
     {
       "ID": 105000060,
       "Entries": [
-        "Right hand sword_Aerial attack 1 -- 右手刀_空中攻撃1"
+        "Jump Attack 1"
       ]
     },
     {
       "ID": 105000061,
       "Entries": [
-        "Right hand sword_Aerial attack 2 -- 右手刀_空中攻撃2"
+        "Jump Attack 2"
       ]
     },
     {
       "ID": 105000062,
       "Entries": [
-        "Right hand sword_Aerial attack 3 -- 右手刀_空中攻撃3"
+        "Jump Attack 3"
       ]
     },
     {
       "ID": 105000065,
       "Entries": [
-        "Right hand sword_wire attack 1 -- 右手刀_ワイヤー攻撃1"
+        "Grappling Hook Attack 1"
       ]
     },
     {
       "ID": 105000066,
       "Entries": [
-        "Right hand sword_wire attack 2 -- 右手刀_ワイヤー攻撃2"
+        "Grappling Hook Attack 2"
       ]
     },
     {
       "ID": 105000070,
       "Entries": [
-        "Right hand sword_dash attack -- 右手刀_ダッシュ攻撃"
+        "Kusabimaru Dash Attack"
       ]
     },
     {
       "ID": 105000075,
       "Entries": [
-        "Right hand sword_ crouching attack -- 右手刀_しゃがみ攻撃"
+        "Kusabimaru Crouch Attack"
       ]
     },
     {
       "ID": 105000076,
       "Entries": [
-        "Right hand sword_Crouching attack_Underfloor -- 右手刀_しゃがみ攻撃_床下"
+        "Kusabimaru Crouch Attack Under Floor"
       ]
     },
     {
       "ID": 105000080,
       "Entries": [
-        "Right hand sword _ hanging attack -- 右手刀_ぶら下がり攻撃"
+        "Kusabimaru Hanging Attack"
       ]
     },
     {
       "ID": 105000085,
       "Entries": [
-        "Right hand sword_aging attack -- 右手刀_老化攻撃"
+        "Kusabimaru Enfeebled Attack"
       ]
     },
     {
       "ID": 105000086,
       "Entries": [
-        "Right hand sword_water / underwater thrust 1 -- 右手刀_水上/水中突き1"
+        "Kusabimaru Underwater Thrust 1"
       ]
     },
     {
       "ID": 105000087,
       "Entries": [
-        "Right hand sword_water / underwater thrust 2 -- 右手刀_水上/水中突き2"
+        "Kusabimaru Underwater Thrust 2"
       ]
     },
     {
       "ID": 105000088,
       "Entries": [
-        "Right hand sword_water / underwater attack 1 -- 右手刀_水上/水中攻撃撃1"
+        "Kusabimaru Underwater Attack 1"
       ]
     },
     {
       "ID": 105000089,
       "Entries": [
-        "Right hand sword_water / underwater attack 2 -- 右手刀_水上/水中攻撃撃2"
+        "Kusabimaru Underwater Attack 2"
       ]
     },
     {
       "ID": 105000090,
       "Entries": [
-        "Right hand sword_guard -- 右手刀_ガード"
+        "Kusabimaru Guard"
       ]
     },
     {
       "ID": 105000100,
       "Entries": [
-        "Shuriken_Chasing Slash -- 手裏剣_追いかけ斬り"
+        "Chasing Slice - Shuriken"
       ]
     },
     {
       "ID": 105000105,
       "Entries": [
-        "Firecracker _ slip-through slash -- 爆竹_すり抜け斬り"
+        "Chasing Slice - Firecracker"
       ]
     },
     {
       "ID": 105000110,
       "Entries": [
-        "Ignition_Flame Slash -- 発火_炎まとい斬り"
+        "Living Force - Flame Vent"
       ]
     },
     {
       "ID": 105000115,
       "Entries": [
-        "Ax _ front slash _ sword -- 斧_前宙斬り_刀"
+        "Fang and Blade - Loaded Axe - Kusabimaru Part"
       ]
     },
     {
       "ID": 105000120,
       "Entries": [
-        "Transformation_ground appearance attack -- 変わり身_地上出現攻撃"
+        "Fang and Blade - Mist Raven - Ground attack"
       ]
     },
     {
       "ID": 105000121,
       "Entries": [
-        "Transformation_Aerial Appearance Attack -- 変わり身_空中出現攻撃"
+        "Fang and Blade - Mist Raven - Aerial attack"
       ]
     },
     {
       "ID": 105000130,
       "Entries": [
-        "Kodachi_Table 2nd stage_Right hand sword -- 小太刀_表2段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 105000131,
       "Entries": [
-        "Kodachi _ Table 4th _ Right hand sword -- 小太刀_表4段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 105000132,
       "Entries": [
-        "Kodachi _ Table 6th _ Right hand sword -- 小太刀_表6段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 105000133,
       "Entries": [
-        "Kodachi_back 1st stage_right hand sword -- 小太刀_裏1段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 105000134,
       "Entries": [
-        "Kodachi _ back 2nd stage _ right hand sword -- 小太刀_裏2段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 105000135,
       "Entries": [
-        "Kodachi _ back 3rd stage _ right hand sword -- 小太刀_裏3段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 105000136,
       "Entries": [
-        "Kodachi_back 4th stage_right hand sword -- 小太刀_裏4段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 105000137,
       "Entries": [
-        "Kodachi_back 5th stage_right hand sword -- 小太刀_裏5段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 105000138,
       "Entries": [
-        "Kodachi_back 6th stage_right hand sword -- 小太刀_裏6段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 105000140,
       "Entries": [
-        "Kodachi (Ruri) _Table 2nd stage_Right hand sword -- 小太刀（瑠璃）_表2段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 105000141,
       "Entries": [
-        "Kodachi (Ruri) _ Table 4th _ Right hand sword -- 小太刀（瑠璃）_表4段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 105000142,
       "Entries": [
-        "Kodachi (Ruri) _Table 6th row_Right hand sword -- 小太刀（瑠璃）_表6段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 105000143,
       "Entries": [
-        "Kodachi (Ruri) _back 1st stage_right hand sword -- 小太刀（瑠璃）_裏1段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 105000144,
       "Entries": [
-        "Kodachi (Ruri) _2nd back sword_Right hand sword -- 小太刀（瑠璃）_裏2段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 105000145,
       "Entries": [
-        "Kodachi (Ruri) _ 3rd back sword _ Right hand sword -- 小太刀（瑠璃）_裏3段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 105000146,
       "Entries": [
-        "Kodachi (Ruri) _ back 4th stage _ right hand sword -- 小太刀（瑠璃）_裏4段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 105000147,
       "Entries": [
-        "Kodachi (Ruri) _ 5th stage on the back _ Right hand sword -- 小太刀（瑠璃）_裏5段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 105000148,
       "Entries": [
-        "Kodachi (Ruri) _ 6th back sword _ Right hand sword -- 小太刀（瑠璃）_裏6段目_右手刀"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 105000150,
       "Entries": [
-        "Kodachi _ front and back switching slash _ front and back left -- 小太刀_表裏切替斬り_前後左"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 105000151,
       "Entries": [
-        "Kodachi _ front and back switching slash _ right -- 小太刀_表裏切替斬り_右"
+        "Sabimaru - Kusabimaru Attack"
       ]
     },
     {
       "ID": 105000160,
       "Entries": [
-        "Enemy turning _ Wind sword -- 敵回し_風まとい斬り"
+        "Living Force - Divine Abduction"
       ]
     },
     {
       "ID": 105000165,
       "Entries": [
-        "Spear_Chasing Slash -- 槍_追いかけ斬り"
+        "Chasing Slice - Loaded Spear"
       ]
     },
     {
       "ID": 105000166,
       "Entries": [
-        "Spear_Pulling Slash -- 槍_引き寄せ斬り"
+        "Fang and Blade - Loaded Spear"
       ]
     },
     {
       "ID": 105000170,
       "Entries": [
-        "Finger whistle_sound feed slash -- 指笛_音送り斬り"
+        "Projected Force - Finger Whistle"
       ]
     },
     {
       "ID": 105000180,
       "Entries": [
-        "Right Hand Sword_Red Blood Enchantment Additional Attack -- 右手刀_赤血エンチャント追加攻撃"
+        "Bestowal Ninjutsu Blood"
       ]
     },
     {
       "ID": 105000181,
       "Entries": [
-        "Right-handed sword_poison blood enchantment additional attack -- 右手刀_毒血エンチャント追加攻撃"
+        "Bestowal Ninjutsu Poison"
       ]
     },
     {
       "ID": 105000182,
       "Entries": [
-        "Right-handed sword_white blood enchantment additional attack -- 右手刀_白血エンチャント追加攻撃"
+        "Bestowal Ninjutsu Lifesteal"
       ]
     },
     {
       "ID": 105000183,
       "Entries": [
-        "Right-handed sword_Weak thunder enchantment additional attack -- 右手刀_弱雷エンチャント追加攻撃"
+        "Non Divine Dragon Lightning Reversal"
       ]
     },
     {
       "ID": 105000184,
       "Entries": [
-        "Right-handed sword_strong thunder enchantment additional bullet -- 右手刀_強雷エンチャント追加弾丸"
+        "Divine Dragon Lightning Reversal"
       ]
     },
     {
       "ID": 105000185,
       "Entries": [
-        "Right-handed sword_Orange-style enchantment additional attack -- 右手刀_橙風エンチャント追加攻撃"
+        "Living Force - Divine Abudction Addidtional Attack"
       ]
     },
     {
       "ID": 105000186,
       "Entries": [
-        "Right-handed sword_Kinfu enchantment additional attack -- 右手刀_金風エンチャント追加攻撃"
+        "Living Force - Golden Vortex Addidtional Attack"
       ]
     },
     {
       "ID": 105000190,
       "Entries": [
-        "Right hand sword_red blood enchantment additional bullet (thrust) -- 右手刀_赤血エンチャント追加弾丸（突き）"
+        "Bestowal Ninjutsu Thrust Attack"
       ]
     },
     {
       "ID": 105000191,
       "Entries": [
-        "Right hand sword_poison blood enchantment additional bullet (thrust) -- 右手刀_毒血エンチャント追加弾丸（突き）"
+        "Bestowal Ninjutsu Poison Thrust Attack"
       ]
     },
     {
       "ID": 105000192,
       "Entries": [
-        "Right hand sword_white blood enchantment additional bullet (thrust) -- 右手刀_白血エンチャント追加弾丸（突き）"
+        "Bestowal Ninjutsu Lifesteal Thrust Attack"
       ]
     },
     {
       "ID": 105000193,
       "Entries": [
-        "Right-handed sword_Weak thunder enchantment additional bullet (thrust) -- 右手刀_弱雷エンチャント追加弾丸（突き）"
+        "Non Divine Dragon Lightning Reversal"
       ]
     },
     {
       "ID": 105000280,
       "Entries": [
-        "Right hand sword _ thunder return _ weak thunder _ sword blade -- 右手刀_雷返し_弱雷_刀身"
+        "Lightning Reversal"
       ]
     },
     {
       "ID": 105000281,
       "Entries": [
-        "Right hand sword _ thunder return _ weak thunder _ thunder -- 右手刀_雷返し_弱雷_雷"
+        "Lightning Reversal"
       ]
     },
     {
       "ID": 105000290,
       "Entries": [
-        "Right-handed sword_anti-spirit force -- 右手刀_対霊フォース"
+        "Anti-Apparition Force"
       ]
     },
     {
       "ID": 105000295,
       "Entries": [
-        "Right Hand Sword_Crisis Force -- 右手刀_恐慌フォース"
+        "Red Eyes Scare Parent"
       ]
     },
     {
       "ID": 105000300,
       "Entries": [
-        "Right-handed sword_Ninjato body_Ninjutsu Ninjutsu_Blood smoke_Normal_Red blood_Dazzle -- 右手刀_忍殺本体_忍殺忍術_血煙_通常_赤血_目くらまし"
+        "Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 105000301,
       "Entries": [
-        "Right hand sword _ Ninja body _ Ninjutsu ninjutsu _ Blood smoke _ Normal _ Red blood _ Hidden -- 右手刀_忍殺本体_忍殺忍術_血煙_通常_赤血_姿隠し"
+        "Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 105000360,
       "Entries": [
-        "Right hand sword _ Ninja body _ Ninjutsu ninjutsu _ Blood smoke _ Radiation _ Red blood _ Dazzle -- 右手刀_忍殺本体_忍殺忍術_血煙_放射_赤血_目くらまし"
+        "Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 105000361,
       "Entries": [
-        "Right-handed sword_Ninjato body_Ninjutsu Ninjutsu_Blood smoke_Radiation_Red blood_Hidden -- 右手刀_忍殺本体_忍殺忍術_血煙_放射_赤血_姿隠し"
+        "Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 105000370,
       "Entries": [
-        "Right hand sword _ Ninja body _ Ninjutsu ninjutsu _ Blood smoke _ Radiation _ Poison blood _ Dazzle -- 右手刀_忍殺本体_忍殺忍術_血煙_放射_毒血_目くらまし"
+        "Poison Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 105000371,
       "Entries": [
-        "Right hand sword _ Ninja body _ Ninjutsu ninjutsu _ Blood smoke _ Radiation _ Poison blood _ Hidden -- 右手刀_忍殺本体_忍殺忍術_血煙_放射_毒血_姿隠し"
+        "Poison Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 105000380,
       "Entries": [
-        "Right-handed sword_Ninjato body_Ninjutsu Ninjutsu_Blood smoke_Radiation_White blood_Dazzle -- 右手刀_忍殺本体_忍殺忍術_血煙_放射_白血_目くらまし"
+        "Lifesteal Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 105000381,
       "Entries": [
-        "Right-handed sword_Ninjato body_Ninjutsu Ninjutsu_Blood smoke_Radiation_White blood_Hidden -- 右手刀_忍殺本体_忍殺忍術_血煙_放射_白血_姿隠し"
+        "Lifesteal Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 105000400,
       "Entries": [
-        "Right-handed sword_Ninjato body_Ninjato Ninjutsu_Puppet_Default -- 右手刀_忍殺本体_忍殺忍術_傀儡_デフォルト"
+        "Puppeteer Ninjutsu"
       ]
     },
     {
       "ID": 105000410,
       "Entries": [
-        "Right-handed sword_Ninjato body_Ninjato Ninjutsu_Puppet_Infinite duration -- 右手刀_忍殺本体_忍殺忍術_傀儡_効果時間無限"
+        "Puppeteer Ninjutsu"
       ]
     },
     {
       "ID": 105000500,
       "Entries": [
-        "Right hand sword _ Ninja body _ Ninjutsu ninjutsu _ Grant _ Normal _ Red blood -- 右手刀_忍殺本体_忍殺忍術_付与_通常_赤血"
+        "Bestowal Ninjutsu"
       ]
     },
     {
       "ID": 105000510,
       "Entries": [
-        "Right hand sword _ Ninja body _ Ninjutsu ninjutsu _ Grant _ Normal _ Poison blood -- 右手刀_忍殺本体_忍殺忍術_付与_通常_毒血"
+        "Poison Bestowal Ninjutsu"
       ]
     },
     {
       "ID": 105000520,
       "Entries": [
-        "Right hand sword _ Ninja body _ Ninjutsu ninjutsu _ Grant _ Normal _ White blood -- 右手刀_忍殺本体_忍殺忍術_付与_通常_白血"
+        "Lifesteal Bestowal Ninjutsu"
       ]
     },
     {
       "ID": 105000600,
       "Entries": [
-        "Right-handed sword_Ninjato body_Crush -- 右手刀_忍殺本体_崩し"
+        "Deathblow Damage"
       ]
     },
     {
       "ID": 105000610,
       "Entries": [
-        "Right hand sword_Ninjato body_Play -- 右手刀_忍殺本体_弾き"
+        "Deathblow Damage"
       ]
     },
     {
       "ID": 105000620,
       "Entries": [
-        "Right hand sword _ Ninjato body _ Closeout -- 右手刀_忍殺本体_見切り"
+        "Deathblow Damage"
       ]
     },
     {
       "ID": 105000640,
       "Entries": [
-        "Right hand sword _ Ninja body _ Behind -- 右手刀_忍殺本体_背後"
+        "Deathblow Damage - Backstab"
       ]
     },
     {
       "ID": 105000650,
       "Entries": [
-        "Right hand sword_Ninjato body_Crouching behind -- 右手刀_忍殺本体_しゃがみ背後"
+        "Deathblow Damage - Crouching Backstab"
       ]
     },
     {
       "ID": 105000660,
       "Entries": [
-        "Right hand sword _ Ninja body _ Fall -- 右手刀_忍殺本体_落下"
+        "Deathblow Damage - Plunging"
       ]
     },
     {
       "ID": 105000661,
       "Entries": [
-        "Right hand sword _ Ninjato body _ Fall _ Fire cow only -- 右手刀_忍殺本体_落下_火牛専用"
+        "Deathblow Damage - Plunging on Bull"
       ]
     },
     {
       "ID": 105000680,
       "Entries": [
-        "Right hand sword _ Ninja body _ Wire -- 右手刀_忍殺本体_ワイヤー"
+        "Deathblow Damage - Grappling Hook"
       ]
     },
     {
       "ID": 105000690,
       "Entries": [
-        "Right hand sword _ Ninja body _ Anti-aircraft -- 右手刀_忍殺本体_対空"
+        "Deathblow Damage - Anti-air"
       ]
     },
     {
       "ID": 105000700,
       "Entries": [
-        "Right hand sword _ Ninja body _ Left and right with wall -- 右手刀_忍殺本体_壁張り付き左右"
+        "Deathblow Damage - Wall Hug"
       ]
     },
     {
       "ID": 105000720,
       "Entries": [
-        "Right hand sword _ Ninja body _ Before and after hanging -- 右手刀_忍殺本体_ぶら下がり前後"
+        "Deathblow Damage - Ledge Hang"
       ]
     },
     {
       "ID": 105000790,
       "Entries": [
-        "Right-handed sword_Ninjato body_Dummy attack that causes the enemy to send Kanji SFX_Blood smoke -- 右手刀_忍殺本体_漢字SFXを敵に出させるダミー攻撃_血煙"
+        "Ninjutsu Kanji Info for Enemy - Bloodsmoke"
       ]
     },
     {
       "ID": 105000791,
       "Entries": [
-        "Right-handed sword_Ninjato body_Dummy attack that causes the enemy to send Kanji SFX_Puppet -- 右手刀_忍殺本体_漢字SFXを敵に出させるダミー攻撃_傀儡"
+        "Ninjutsu Kanji Info for Enemy - Puppeteer"
       ]
     },
     {
       "ID": 105000792,
       "Entries": [
-        "Right-handed sword_Ninjato body_Dummy attack that causes the enemy to send Kanji SFX_Grant -- 右手刀_忍殺本体_漢字SFXを敵に出させるダミー攻撃_付与"
+        "Ninjutsu Kanji Info for Enemy - Bestowal"
       ]
     },
     {
       "ID": 105000800,
       "Entries": [
-        "Right hand sword _ Ninja body _ Stop -- 右手刀_忍殺本体_とどめ"
+        "Deathblow Damage - Finisher"
       ]
     },
     {
       "ID": 105000899,
       "Entries": [
-        "Right-handed sword_Ninjato body_Aging Ninjato_Abnormal condition recovery bullet -- 右手刀_忍殺本体_老化忍殺_状態異常回復弾丸"
+        "Enfeeble Buildup Removal"
       ]
     },
     {
       "ID": 105000990,
       "Entries": [
-        "Shinobi shock _ short distance _ on the spot -- 忍殺衝撃_近距離_その場"
+        "Mikiri Counter - Break"
       ]
     },
     {
       "ID": 105000991,
       "Entries": [
-        "Shinobi shock _ short distance _ jump away -- 忍殺衝撃_近距離_飛び退き"
+        "Mikiri Counter"
       ]
     },
     {
       "ID": 105000992,
       "Entries": [
-        "Shinobi shock _ long distance _ on the spot -- 忍殺衝撃_遠距離_その場"
+        "Mikiri Counter - Break"
       ]
     },
     {
       "ID": 105000993,
       "Entries": [
-        "Shinobi shock _ long distance _ jump away -- 忍殺衝撃_遠距離_飛び退き"
+        "Mikiri Counter"
       ]
     },
     {
       "ID": 105000994,
       "Entries": [
-        "Resurrection Technique_Boss Sensing Dummy Attack -- 復活の術_ボス感知ダミー攻撃"
+        "Resurrection - Boss Sensing Dummy Attack"
       ]
     },
     {
       "ID": 105000910,
       "Entries": [
-        "Piece of porcelain -- 陶片"
+        "Ceramic Shard"
       ]
     },
     {
       "ID": 105000911,
       "Entries": [
-        "Pottery piece _ hanging -- 陶片_ぶら下がり"
+        "Ceramic Shard - Ledge Hang"
       ]
     },
     {
       "ID": 105000912,
       "Entries": [
-        "Pottery piece _ peek left -- 陶片_覗き込み左"
+        "Ceramic Shard - Peeping Left"
       ]
     },
     {
       "ID": 105000913,
       "Entries": [
-        "Pottery piece _ peep right -- 陶片_覗き込み右"
+        "Ceramic Shard - Peeping Right"
       ]
     },
     {
       "ID": 105001200,
       "Entries": [
-        "School Technique_Rotating Slash 1-1 -- 流派技_回転斬り1-1"
+        "Whirlwind Slash 1"
       ]
     },
     {
       "ID": 105001201,
       "Entries": [
-        "School Technique_Rotating Slash 1-2 -- 流派技_回転斬り1-2"
+        "Whirlwind Slash 2"
       ]
     },
     {
@@ -976,2647 +976,2647 @@
     {
       "ID": 105003200,
       "Entries": [
-        "School technique_face-up 1_reservoir -- 流派技_面打ち1_溜め"
+        "Ichimonji 1 - Charged"
       ]
     },
     {
       "ID": 105003201,
       "Entries": [
-        "School technique_face-up 1 -- 流派技_面打ち1"
+        "Ichimonji 1"
       ]
     },
     {
       "ID": 105003210,
       "Entries": [
-        "School Technique_Face 2 -- 流派技_面打ち2"
+        "Ichimonji 2"
       ]
     },
     {
       "ID": 105004200,
       "Entries": [
-        "School technique _ Kensei Iai _ Reservoir -- 流派技_剣聖居合_溜め"
+        "Dragon Flash - Charged"
       ]
     },
     {
       "ID": 105004201,
       "Entries": [
-        "School technique _ Kensei Iai _ Reservoir _ No form fee -- 流派技_剣聖居合_溜め_形代なし"
+        "Dragon Flash - Charged - No Spirit Emblems"
       ]
     },
     {
       "ID": 105004210,
       "Entries": [
-        "School Technique_Sword Holy Iai_Reserved Bullet 1 -- 流派技_剣聖居合_溜め弾丸1"
+        "Dragon Flash - Charged - Bullet 1"
       ]
     },
     {
       "ID": 105004215,
       "Entries": [
-        "School Technique_Sword Holy Iai_Reserved Bullet 2 -- 流派技_剣聖居合_溜め弾丸2"
+        "Dragon Flash - Charged - Bullet 2 - Dummy Parent"
       ]
     },
     {
       "ID": 105004220,
       "Entries": [
-        "School technique_Kensei Iai -- 流派技_剣聖居合"
+        "Dragon Flash"
       ]
     },
     {
       "ID": 105004221,
       "Entries": [
-        "School technique_Sword sacred Iai_No form -- 流派技_剣聖居合_形代なし"
+        "Dragon Flash - No Spirit Emblems"
       ]
     },
     {
       "ID": 105004230,
       "Entries": [
-        "School technique_Sword sacred Iai_Bullet -- 流派技_剣聖居合_弾丸"
+        "Dragon Flash - Bullet"
       ]
     },
     {
       "ID": 105005200,
       "Entries": [
-        "School technique_Iai 1 -- 流派技_居合1"
+        "Ashina Cross 1"
       ]
     },
     {
       "ID": 105005201,
       "Entries": [
-        "School technique_Iai 2 -- 流派技_居合2"
+        "Ashina Cross 2"
       ]
     },
     {
       "ID": 105005202,
       "Entries": [
-        "School technique_Iai 1_No form fee -- 流派技_居合1_形代なし"
+        "Ashina Cross 1 - No Spirit Emblems"
       ]
     },
     {
       "ID": 105005203,
       "Entries": [
-        "School technique_Iai 2_No form fee -- 流派技_居合2_形代なし"
+        "Ashina Cross 2 - No Spirit Emblems"
       ]
     },
     {
       "ID": 105005210,
       "Entries": [
-        "School technique_Invisible Iai continuous attack 1 -- 流派技_見えない居合連撃1"
+        "One Mind - Initial Attack"
       ]
     },
     {
       "ID": 105005211,
       "Entries": [
-        "School Technique_Invisible Iai Strike 1_Red Blood Enchantment Additional Attack -- 流派技_見えない居合連撃1_赤血エンチャント追加攻撃"
+        "One Mind - Initial Attack - Bestowal"
       ]
     },
     {
       "ID": 105005212,
       "Entries": [
-        "School Technique_Invisible Iai Strike 1_Poison Blood Enchantment Additional Attack -- 流派技_見えない居合連撃1_毒血エンチャント追加攻撃"
+        "One Mind - Initial Attack - Poison Bestowal"
       ]
     },
     {
       "ID": 105005213,
       "Entries": [
-        "School Technique_Invisible Iai Strike 1_ White Blood Enchantment Additional Attack -- 流派技_見えない居合連撃1_白血エンチャント追加攻撃"
+        "One Mind - Initial Attack - Lifesteal Bestowal"
       ]
     },
     {
       "ID": 105005214,
       "Entries": [
-        "School technique_Invisible Iai continuous attack 1_Orange wind enchantment additional attack -- 流派技_見えない居合連撃1_橙風エンチャント追加攻撃"
+        "One Mind - Initial Attack - Divine Abduction Living Force"
       ]
     },
     {
       "ID": 105005215,
       "Entries": [
-        "School technique_Invisible Iai continuous attack 1_Kinfu enchantment additional attack -- 流派技_見えない居合連撃1_金風エンチャント追加攻撃"
+        "One Mind - Initial Attack - Golden Vortex Living Force"
       ]
     },
     {
       "ID": 105005216,
       "Entries": [
-        "School technique_Invisible Iai continuous attack 1_No form -- 流派技_見えない居合連撃1_形代なし"
+        "One Mind - Initial Attack - No Spirit Emblems"
       ]
     },
     {
       "ID": 105005220,
       "Entries": [
-        "School technique_Invisible Iai continuous attack_Delayed continuous attack 1 -- 流派技_見えない居合連撃_遅延連撃1"
+        "One Mind - Continuous Attack Parent"
       ]
     },
     {
       "ID": 105005221,
       "Entries": [
-        "School technique_Invisible Iai continuous attack_Delayed continuous attack 2 -- 流派技_見えない居合連撃_遅延連撃2"
+        "One Mind - Continuous Attack 1"
       ]
     },
     {
       "ID": 105005222,
       "Entries": [
-        "School technique_Invisible Iai continuous attack_Delayed continuous attack 3 -- 流派技_見えない居合連撃_遅延連撃3"
+        "One Mind - Continuous Attack 2"
       ]
     },
     {
       "ID": 105005223,
       "Entries": [
-        "School technique_Invisible Iai continuous attack_Delayed continuous attack 4 -- 流派技_見えない居合連撃_遅延連撃4"
+        "One Mind - Continuous Attack 3"
       ]
     },
     {
       "ID": 105005230,
       "Entries": [
-        "School technique_Invisible Iai continuous attack_Delayed continuous attack SFX -- 流派技_見えない居合連撃_遅延連撃SFX"
+        "One Mind - Continuous Attack SFX"
       ]
     },
     {
       "ID": 105005240,
       "Entries": [
-        "School technique_Invisible Iai continuous attack 2 -- 流派技_見えない居合連撃2"
+        "One Mind - Final Attack"
       ]
     },
     {
       "ID": 105005241,
       "Entries": [
-        "School Technique_Invisible Iai Strike 2_Red Blood Enchantment Additional Attack -- 流派技_見えない居合連撃2_赤血エンチャント追加攻撃"
+        "One Mind - Final Attack - Bestowal"
       ]
     },
     {
       "ID": 105005242,
       "Entries": [
-        "School Technique_Invisible Iai Strike 2_Poison Blood Enchantment Additional Attack -- 流派技_見えない居合連撃2_毒血エンチャント追加攻撃"
+        "One Mind - Final Attack - Poison Bestowal"
       ]
     },
     {
       "ID": 105005243,
       "Entries": [
-        "School technique_Invisible Iai continuous attack 2_White blood enchantment additional attack -- 流派技_見えない居合連撃2_白血エンチャント追加攻撃"
+        "One Mind - Final Attack - Lifesteal Bestowal"
       ]
     },
     {
       "ID": 105005244,
       "Entries": [
-        "School technique_Invisible Iai continuous attack 2_Orange wind enchantment additional attack -- 流派技_見えない居合連撃2_橙風エンチャント追加攻撃"
+        "One Mind - Final Attack - Divine Abduction Living Force"
       ]
     },
     {
       "ID": 105005245,
       "Entries": [
-        "School technique_Invisible Iai continuous attack 2_Kinfu enchantment additional attack -- 流派技_見えない居合連撃2_金風エンチャント追加攻撃"
+        "One Mind - Final Attack - Golden Vortex Living Force"
       ]
     },
     {
       "ID": 105005246,
       "Entries": [
-        "School technique_Invisible Iai continuous attack 2_No form -- 流派技_見えない居合連撃2_形代なし"
+        "One Mind - Final Attack - No Spirit Emblems"
       ]
     },
     {
       "ID": 105007200,
       "Entries": [
-        "School Technique_Immortal Slash 1_Reservoir -- 流派技_不死斬り1_溜め"
+        "Mortal Draw 1 - Charged"
       ]
     },
     {
       "ID": 105007201,
       "Entries": [
-        "School Technique_Immortal Slash 1 -- 流派技_不死斬り1"
+        "Mortal Draw 1"
       ]
     },
     {
       "ID": 105007210,
       "Entries": [
-        "School Technique_Immortal Slash 2_Reservoir -- 流派技_不死斬り2_溜め"
+        "Mortal Draw 2 - Charged"
       ]
     },
     {
       "ID": 105007211,
       "Entries": [
-        "School Technique_Immortal Slash 2 -- 流派技_不死斬り2"
+        "Mortal Draw 2"
       ]
     },
     {
       "ID": 105007220,
       "Entries": [
-        "School technique_Immortal slash 1_Reservoir_There is a form fee -- 流派技_不死斬り1_溜め_形代あり"
+        "Mortal Draw 1 - Charged - No Spirit Emblems"
       ]
     },
     {
       "ID": 105007221,
       "Entries": [
-        "School technique_Immortal slash 1_There is a form fee -- 流派技_不死斬り1_形代あり"
+        "Mortal Draw 1 - No Spirit Emblems"
       ]
     },
     {
       "ID": 105007230,
       "Entries": [
-        "School technique_Immortal slash 2_Reservoir_There is a form fee -- 流派技_不死斬り2_溜め_形代あり"
+        "Mortal Draw 2 - Charged - No Spirit Emblems"
       ]
     },
     {
       "ID": 105007231,
       "Entries": [
-        "School technique_Immortal slash 2_There is a form fee -- 流派技_不死斬り2_形代あり"
+        "Mortal Draw 2 - No Spirit Emblems"
       ]
     },
     {
       "ID": 105007999,
       "Entries": [
-        "School technique_immortal slashing_form consumption dummy -- 流派技_不死斬り_形代消費ダミー"
+        "Prosthetic Tool - Spirit Emblem Consumption Dummy"
       ]
     },
     {
       "ID": 105008200,
       "Entries": [
-        "School Technique_Kick Rush 1-1 -- 流派技_蹴りラッシュ1-1"
+        "Senpou Leaping Kicks / High Monk - Initial Kick Up"
       ]
     },
     {
       "ID": 105008201,
       "Entries": [
-        "School Technique_Kick Rush 1-2 -- 流派技_蹴りラッシュ1-2"
+        "Senpou Leaping Kicks / High Monk - Initial Kick Down"
       ]
     },
     {
       "ID": 105008210,
       "Entries": [
-        "School Technique_Kick Rush 2-1 -- 流派技_蹴りラッシュ2-1"
+        "Senpou Leaping Kicks / High Monk - Follow-up Kick 1"
       ]
     },
     {
       "ID": 105008211,
       "Entries": [
-        "School Technique_Kick Rush 2-2 -- 流派技_蹴りラッシュ2-2"
+        "Senpou Leaping Kicks / High Monk - Follow-up Kick 2"
       ]
     },
     {
       "ID": 105008220,
       "Entries": [
-        "School Technique_Kick Rush 3-1 -- 流派技_蹴りラッシュ3-1"
+        "High Monk - Sword Slash 1"
       ]
     },
     {
       "ID": 105008221,
       "Entries": [
-        "School Technique_Kick Rush 3-2 -- 流派技_蹴りラッシュ3-2"
+        "High Monk - Sword Slash 2"
       ]
     },
     {
       "ID": 105008230,
       "Entries": [
-        "School Technique_Kick Rush 4 -- 流派技_蹴りラッシュ4"
+        "High Monk - Final Kick"
       ]
     },
     {
       "ID": 105009200,
       "Entries": [
-        "School Technique_Fist Attack 1_Accumulation -- 流派技_拳撃1_溜め"
+        "Praying Strikes - Exorcism - Charged"
       ]
     },
     {
       "ID": 105009201,
       "Entries": [
-        "School Technique_Fist Attack 1 -- 流派技_拳撃1"
+        "Praying Stikes - 1"
       ]
     },
     {
       "ID": 105009210,
       "Entries": [
-        "School Technique_Fist Attack 2 -- 流派技_拳撃2"
+        "Praying Stikes - 2"
       ]
     },
     {
       "ID": 105009220,
       "Entries": [
-        "School Technique_Fist Attack 3 -- 流派技_拳撃3"
+        "Praying Stikes - Exorcism - 3"
       ]
     },
     {
       "ID": 105009251,
       "Entries": [
-        "School Technique_Fist Attack 1_Aerial -- 流派技_拳撃1_空中"
+        "Praying Strikes - Aerial"
       ]
     },
     {
       "ID": 105010200,
       "Entries": [
-        "School technique _ sneak stab _ reservoir -- 流派技_忍び刺し_溜め"
+        "Shadowfall / Shadowrush - Stab - Charged"
       ]
     },
     {
       "ID": 105010210,
       "Entries": [
-        "School technique_Sneak stab -- 流派技_忍び刺し"
+        "Shadowfall / Shadowrush - Stab"
       ]
     },
     {
       "ID": 105010215,
       "Entries": [
-        "School technique_Sneak stab_Kick up after hit -- 流派技_忍び刺し_ヒット後蹴上がり"
+        "Shadowfall / Shadowrush - Kick"
       ]
     },
     {
       "ID": 105010220,
       "Entries": [
-        "School technique_Sneak stab_After kicking up, aerial rotation slash 1 -- 流派技_忍び刺し_蹴上がり後空中回転斬り1"
+        "Shadowfall - Aerial Attack 1"
       ]
     },
     {
       "ID": 105010221,
       "Entries": [
-        "School technique_Sneak stab_After kicking up, aerial rotation slash 2 -- 流派技_忍び刺し_蹴上がり後空中回転斬り2"
+        "Shadowfall - Aerial Attack 2"
       ]
     },
     {
       "ID": 105020200,
       "Entries": [
-        "School Technique_Hachiman Flying Rush 1 -- 流派技_八艘飛びラッシュ1"
+        "Floating Passage - 1"
       ]
     },
     {
       "ID": 105020201,
       "Entries": [
-        "School Technique_Hachiman Flying Rush 2 -- 流派技_八艘飛びラッシュ2"
+        "Floating Passage - 2"
       ]
     },
     {
       "ID": 105020202,
       "Entries": [
-        "School Technique_Hachiman Flying Rush 3 -- 流派技_八艘飛びラッシュ3"
+        "Floating Passage - 3"
       ]
     },
     {
       "ID": 105020203,
       "Entries": [
-        "School Technique_Hachiman Flying Rush 4 -- 流派技_八艘飛びラッシュ4"
+        "Floating Passage - 4"
       ]
     },
     {
       "ID": 105020209,
       "Entries": [
-        "School Technique_Hachiman Flying Rush 5F -- 流派技_八艘飛びラッシュ5F"
+        "Floating Passage - 5"
       ]
     },
     {
       "ID": 105021200,
       "Entries": [
-        "School Technique_Hachiman Flying Rush 1 -- 流派技_八艘飛びラッシュ1"
+        "Spiral Cloud Passage - 1"
       ]
     },
     {
       "ID": 105021201,
       "Entries": [
-        "School Technique_Hachiman Flying Rush 2 -- 流派技_八艘飛びラッシュ2"
+        "Spiral Cloud Passage - 2"
       ]
     },
     {
       "ID": 105021202,
       "Entries": [
-        "School Technique_Hachiman Flying Rush 3 -- 流派技_八艘飛びラッシュ3"
+        "Spiral Cloud Passage - 3"
       ]
     },
     {
       "ID": 105021203,
       "Entries": [
-        "School Technique_Hachiman Flying Rush 4 -- 流派技_八艘飛びラッシュ4"
+        "Spiral Cloud Passage - 4"
       ]
     },
     {
       "ID": 105021204,
       "Entries": [
-        "School Technique_Hachiman Flying Rush 5 -- 流派技_八艘飛びラッシュ5"
+        "Spiral Cloud Passage - 5"
       ]
     },
     {
       "ID": 105021205,
       "Entries": [
-        "School Technique_Hachiman Flying Rush 6 -- 流派技_八艘飛びラッシュ6"
+        "Spiral Cloud Passage - 6"
       ]
     },
     {
       "ID": 105021206,
       "Entries": [
-        "School Technique_Hachiman Flying Rush 7 -- 流派技_八艘飛びラッシュ7"
+        "Spiral Cloud Passage - 7"
       ]
     },
     {
       "ID": 105021207,
       "Entries": [
-        "School Technique_Hachiman Flying Rush 8 -- 流派技_八艘飛びラッシュ8"
+        "Spiral Cloud Passage - 8"
       ]
     },
     {
       "ID": 105021208,
       "Entries": [
-        "School Technique_Hachiman Flying Rush 9F -- 流派技_八艘飛びラッシュ9F"
+        "Spiral Cloud Passage - 9"
       ]
     },
     {
       "ID": 105021220,
       "Entries": [
-        "School technique_Hachiman flying rush 1_There is a form fee -- 流派技_八艘飛びラッシュ1_形代あり"
+        "Spiral Cloud Passage - 1 - No Spirit Emblems"
       ]
     },
     {
       "ID": 105021221,
       "Entries": [
-        "School technique_Hachimanbuki Rush 2_There is a form fee -- 流派技_八艘飛びラッシュ2_形代あり"
+        "Spiral Cloud Passage - 2 - No Spirit Emblems"
       ]
     },
     {
       "ID": 105021222,
       "Entries": [
-        "School technique_Hachiman flying rush 3_There is a form fee -- 流派技_八艘飛びラッシュ3_形代あり"
+        "Spiral Cloud Passage - 3 - No Spirit Emblems"
       ]
     },
     {
       "ID": 105021223,
       "Entries": [
-        "School technique_Hachiman flying rush 4_There is a form fee -- 流派技_八艘飛びラッシュ4_形代あり"
+        "Spiral Cloud Passage - 4 - No Spirit Emblems"
       ]
     },
     {
       "ID": 105021224,
       "Entries": [
-        "School technique_Hachiman flying rush 5_There is a form fee -- 流派技_八艘飛びラッシュ5_形代あり"
+        "Spiral Cloud Passage - 5 - No Spirit Emblems"
       ]
     },
     {
       "ID": 105021225,
       "Entries": [
-        "School technique_Hachimanbuki Rush 6_There is a form fee -- 流派技_八艘飛びラッシュ6_形代あり"
+        "Spiral Cloud Passage - 6 - No Spirit Emblems"
       ]
     },
     {
       "ID": 105021226,
       "Entries": [
-        "School technique_Hachiman flying rush 7_There is a form fee -- 流派技_八艘飛びラッシュ7_形代あり"
+        "Spiral Cloud Passage - 7 - No Spirit Emblems"
       ]
     },
     {
       "ID": 105021227,
       "Entries": [
-        "School technique_Hachiman flying rush 8_There is a form fee -- 流派技_八艘飛びラッシュ8_形代あり"
+        "Spiral Cloud Passage - 8 - No Spirit Emblems"
       ]
     },
     {
       "ID": 105021228,
       "Entries": [
-        "School technique_Hachiman Flying Rush 9F_There is a form fee -- 流派技_八艘飛びラッシュ9F_形代あり"
+        "Spiral Cloud Passage - 9 - No Spirit Emblems"
       ]
     },
     {
       "ID": 105021229,
       "Entries": [
-        "School technique_Hachiman Flying Rush 3F_There is a form fee -- 流派技_八艘飛びラッシュ3F_形代あり"
+        ""
       ]
     },
     {
       "ID": 105021999,
       "Entries": [
-        "School Technique_Hachiman Flying Rush_Shape Consumption Dummy -- 流派技_八艘飛びラッシュ_形代消費ダミー"
+        "Prosthetic Tool - Spirit Emblem Consumption Dummy"
       ]
     },
     {
       "ID": 105030200,
       "Entries": [
-        "School technique_new technique 1 -- 流派技_新技1"
+        "Sakura Dance 1"
       ]
     },
     {
       "ID": 105030201,
       "Entries": [
-        "School technique_new technique 2 -- 流派技_新技2"
+        "Sakura Dance 2"
       ]
     },
     {
       "ID": 105030202,
       "Entries": [
-        "School technique_new technique 3 -- 流派技_新技3"
+        "Sakura Dance 3"
       ]
     },
     {
       "ID": 105030205,
       "Entries": [
-        "School technique_new technique 1_no form fee -- 流派技_新技1_形代なし"
+        "Sakura Dance 1 - No Spirit Emblems"
       ]
     },
     {
       "ID": 105030206,
       "Entries": [
-        "School technique_new technique 2_no form fee -- 流派技_新技2_形代なし"
+        "Sakura Dance 2 - No Spirit Emblems"
       ]
     },
     {
       "ID": 105030207,
       "Entries": [
-        "School technique_new technique 3_no form fee -- 流派技_新技3_形代なし"
+        "Sakura Dance 3 - No Spirit Emblems"
       ]
     },
     {
       "ID": 105030210,
       "Entries": [
-        "School technique_new technique 1_SFX -- 流派技_新技1_SFX"
+        "Sakura Dance"
       ]
     },
     {
       "ID": 105030211,
       "Entries": [
-        "School technique_new technique 2_SFX -- 流派技_新技2_SFX"
+        "Sakura Dance"
       ]
     },
     {
       "ID": 105030212,
       "Entries": [
-        "School technique_new technique 3_SFX -- 流派技_新技3_SFX"
+        "Sakura Dance"
       ]
     },
     {
       "ID": 105030215,
       "Entries": [
-        "School technique_new technique 1_SFX_no form fee -- 流派技_新技1_SFX_形代なし"
+        "Sakura Dance - No Spirit Emblems"
       ]
     },
     {
       "ID": 105030216,
       "Entries": [
-        "School technique_new technique 2_SFX_no form fee -- 流派技_新技2_SFX_形代なし"
+        "Sakura Dance - No Spirit Emblems"
       ]
     },
     {
       "ID": 105030217,
       "Entries": [
-        "School technique_new technique 3_SFX_no form fee -- 流派技_新技3_SFX_形代なし"
+        "Sakura Dance - No Spirit Emblems"
       ]
     },
     {
       "ID": 105030220,
       "Entries": [
-        "School Technique_New Technique 1_SFX_Flame Encha -- 流派技_新技1_SFX_炎エンチャ"
+        "Sakura Dance - Flame"
       ]
     },
     {
       "ID": 105030221,
       "Entries": [
-        "School Technique_New Technique 2_SFX_Flame Encha -- 流派技_新技2_SFX_炎エンチャ"
+        "Sakura Dance - Flame"
       ]
     },
     {
       "ID": 105030222,
       "Entries": [
-        "School Technique_New Technique 3_SFX_Flame Encha -- 流派技_新技3_SFX_炎エンチャ"
+        "Sakura Dance - Flame"
       ]
     },
     {
       "ID": 105030225,
       "Entries": [
-        "School Technique_New Technique 1_SFX_Rei Encha -- 流派技_新技1_SFX_霊エンチャ"
+        "Sakura Dance - Anti-apparition"
       ]
     },
     {
       "ID": 105030226,
       "Entries": [
-        "School Technique_New Technique 2_SFX_Rei Encha -- 流派技_新技2_SFX_霊エンチャ"
+        "Sakura Dance - Anti-apparition"
       ]
     },
     {
       "ID": 105030227,
       "Entries": [
-        "School technique_new technique 3_SFX_spirit enchantment -- 流派技_新技3_SFX_霊エンチャ"
+        "Sakura Dance - Anti-apparition"
       ]
     },
     {
       "ID": 105030230,
       "Entries": [
-        "School Technique_New Technique 1_SFX_Orange Wind Encha -- 流派技_新技1_SFX_橙風エンチャ"
+        "Sakura Dance - Divine Abduction Living Force"
       ]
     },
     {
       "ID": 105030231,
       "Entries": [
-        "School Technique_New Technique 2_SFX_Orange Wind Encha -- 流派技_新技2_SFX_橙風エンチャ"
+        "Sakura Dance - Divine Abduction Living Force"
       ]
     },
     {
       "ID": 105030232,
       "Entries": [
-        "School Technique_New Technique 3_SFX_Orange Wind Encha -- 流派技_新技3_SFX_橙風エンチャ"
+        "Sakura Dance - Divine Abduction Living Force"
       ]
     },
     {
       "ID": 105030235,
       "Entries": [
-        "School Technique_New Technique 1_SFX_Kinfu Encha -- 流派技_新技1_SFX_金風エンチャ"
+        "Sakura Dance - Golden Vortex Living Force"
       ]
     },
     {
       "ID": 105030236,
       "Entries": [
-        "School Technique_New Technique 2_SFX_Kinfu Encha -- 流派技_新技2_SFX_金風エンチャ"
+        "Sakura Dance - Golden Vortex Living Force"
       ]
     },
     {
       "ID": 105030237,
       "Entries": [
-        "School Technique_New Technique 3_SFX_Kinfu Encha -- 流派技_新技3_SFX_金風エンチャ"
+        "Sakura Dance - Golden Vortex Living Force"
       ]
     },
     {
       "ID": 105030240,
       "Entries": [
-        "School Technique_New Technique 1_SFX_Red Blood Encha -- 流派技_新技1_SFX_赤血エンチャ"
+        "Sakura Dance - Bestowal"
       ]
     },
     {
       "ID": 105030241,
       "Entries": [
-        "School Technique_New Technique 2_SFX_Red Blood Encha -- 流派技_新技2_SFX_赤血エンチャ"
+        "Sakura Dance - Bestowal"
       ]
     },
     {
       "ID": 105030242,
       "Entries": [
-        "School Technique_New Technique 3_SFX_Red Blood Encha -- 流派技_新技3_SFX_赤血エンチャ"
+        "Sakura Dance - Bestowal"
       ]
     },
     {
       "ID": 105030245,
       "Entries": [
-        "School Technique_New Technique 1_SFX_Poisonous Blood Encha -- 流派技_新技1_SFX_毒血エンチャ"
+        "Sakura Dance - Poison Bestowal"
       ]
     },
     {
       "ID": 105030246,
       "Entries": [
-        "School Technique_New Technique 2_SFX_Poisonous Blood Encha -- 流派技_新技2_SFX_毒血エンチャ"
+        "Sakura Dance - Poison Bestowal"
       ]
     },
     {
       "ID": 105030247,
       "Entries": [
-        "School Technique_New Technique 3_SFX_Poisonous Blood Encha -- 流派技_新技3_SFX_毒血エンチャ"
+        "Sakura Dance - Poison Bestowal"
       ]
     },
     {
       "ID": 105030250,
       "Entries": [
-        "School Technique_New Technique 1_SFX_White Blood Encha -- 流派技_新技1_SFX_白血エンチャ"
+        "Sakura Dance - Lifesteal Bestowal"
       ]
     },
     {
       "ID": 105030251,
       "Entries": [
-        "School Technique_New Technique 2_SFX_White Blood Encha -- 流派技_新技2_SFX_白血エンチャ"
+        "Sakura Dance - Lifesteal Bestowal"
       ]
     },
     {
       "ID": 105030252,
       "Entries": [
-        "School Technique_New Technique 3_SFX_White Blood Encha -- 流派技_新技3_SFX_白血エンチャ"
+        "Sakura Dance - Lifesteal Bestowal"
       ]
     },
     {
       "ID": 105030255,
       "Entries": [
-        "School Technique_New Technique 1_SFX_Thunder Encha -- 流派技_新技1_SFX_雷エンチャ"
+        "Sakura Dance - Lightning"
       ]
     },
     {
       "ID": 105030256,
       "Entries": [
-        "School Technique_New Technique 2_SFX_Thunder Encha -- 流派技_新技2_SFX_雷エンチャ"
+        "Sakura Dance - Lightning"
       ]
     },
     {
       "ID": 105030257,
       "Entries": [
-        "School Technique_New Technique 3_SFX_Thunder Encha -- 流派技_新技3_SFX_雷エンチャ"
+        "Sakura Dance - Lightning"
       ]
     },
     {
       "ID": 105030260,
       "Entries": [
-        "School technique_new technique 1_SFX_ petals -- 流派技_新技1_SFX_花弁"
+        "Sakura Dance - Petals"
       ]
     },
     {
       "ID": 105030261,
       "Entries": [
-        "School technique_new technique 2_SFX_petals -- 流派技_新技2_SFX_花弁"
+        "Sakura Dance - Petals"
       ]
     },
     {
       "ID": 105030262,
       "Entries": [
-        "School technique_new technique 3_SFX_petals -- 流派技_新技3_SFX_花弁"
+        "Sakura Dance - Petals"
       ]
     },
     {
       "ID": 105030265,
       "Entries": [
-        "School Technique_New Technique 1_Thunder Enchantment Additional Attack -- 流派技_新技1_雷エンチャント追加攻撃"
+        "Sakura Dance 1 - Lightning Reversal"
       ]
     },
     {
       "ID": 105030266,
       "Entries": [
-        "School Technique_New Technique 2_Thunder Enchantment Additional Attack -- 流派技_新技2_雷エンチャント追加攻撃"
+        "Sakura Dance 2 - Lightning Reversal"
       ]
     },
     {
       "ID": 105030267,
       "Entries": [
-        "School Technique_New Technique 3_Thunder Enchantment Additional Attack -- 流派技_新技3_雷エンチャント追加攻撃"
+        "Sakura Dance 3 - Lightning Reversal"
       ]
     },
     {
       "ID": 107000100,
       "Entries": [
-        "Shuriken_Reservoir 1/3 throw -- 手裏剣_溜め1/3投目"
+        "Shuriken Charge - Throw 1 - Hit 1"
       ]
     },
     {
       "ID": 107000110,
       "Entries": [
-        "Shuriken_2nd throw -- 手裏剣_溜め2投目"
+        "Shuriken Charge - Throw 2 - Hit 1"
       ]
     },
     {
       "ID": 107000150,
       "Entries": [
-        "Shuriken_1 / 3rd throw -- 手裏剣_1/3投目"
+        "Shuriken Throw 1"
       ]
     },
     {
       "ID": 107000160,
       "Entries": [
-        "Shuriken_2 throws -- 手裏剣_2投目"
+        "Shuriken Throw 2"
       ]
     },
     {
       "ID": 107000184,
       "Entries": [
-        "Right-handed sword_strong thunder enchantment additional bullet -- 右手刀_強雷エンチャント追加弾丸"
+        "Divine Dragon Lightning Reversal"
       ]
     },
     {
       "ID": 107000190,
       "Entries": [
-        "Right hand sword_red blood enchantment additional bullet (thrust) -- 右手刀_赤血エンチャント追加弾丸（突き）"
+        "Bestowal Ninjutsu Thrust Attack"
       ]
     },
     {
       "ID": 107000191,
       "Entries": [
-        "Right hand sword_poison blood enchantment additional bullet (thrust) -- 右手刀_毒血エンチャント追加弾丸（突き）"
+        "Bestowal Ninjutsu Poison Thrust Attack"
       ]
     },
     {
       "ID": 107000192,
       "Entries": [
-        "Right hand sword_white blood enchantment additional bullet (thrust) -- 右手刀_白血エンチャント追加弾丸（突き）"
+        "Bestowal Ninjutsu Lifesteal Thrust Attack"
       ]
     },
     {
       "ID": 107000193,
       "Entries": [
-        "Right-handed sword_Weak thunder enchantment additional bullet (thrust) -- 右手刀_弱雷エンチャント追加弾丸（突き）"
+        "Non Divine Dragon Lightning Reversal"
       ]
     },
     {
       "ID": 107000195,
       "Entries": [
-        "Right-handed sword_Orange-style enchantment additional bullet (thrust) -- 右手刀_橙風エンチャント追加弾丸（突き）"
+        ""
       ]
     },
     {
       "ID": 107000196,
       "Entries": [
-        "Right hand sword_Kinfu enchantment additional bullet (thrust) -- 右手刀_金風エンチャント追加弾丸（突き）"
+        ""
       ]
     },
     {
       "ID": 107000290,
       "Entries": [
-        "Shuriken_Anti-spirit force -- 手裏剣_対霊フォース"
+        "Anti-Apparition Force"
       ]
     },
     {
       "ID": 107000295,
       "Entries": [
-        "Shuriken_Crisis Force -- 手裏剣_恐慌フォース"
+        "Red Eyes Scare Parent"
       ]
     },
     {
       "ID": 107002100,
       "Entries": [
-        "Shuriken LV3-A_ Reservoir 1/3 throw -- 手裏剣LV3-A_溜め1/3投目"
+        "Gouging Top Charge - Throw 1 - Hit 1"
       ]
     },
     {
       "ID": 107002110,
       "Entries": [
-        "Shuriken LV3-A_ 2nd throw -- 手裏剣LV3-A_溜め2投目"
+        "Gouging Top Charge - Throw 2 - Hit 1"
       ]
     },
     {
       "ID": 107002150,
       "Entries": [
-        "Shuriken LV3-A_1 / 3 throw -- 手裏剣LV3-A_1/3投目"
+        "Gouging Top - Throw 1"
       ]
     },
     {
       "ID": 107002160,
       "Entries": [
-        "Shuriken LV3-A_2 throw -- 手裏剣LV3-A_2投目"
+        "Gouging Top - Throw 2"
       ]
     },
     {
       "ID": 107003100,
       "Entries": [
-        "Shuriken LV3-B_ Reservoir 1/3 throw -- 手裏剣LV3-B_溜め1/3投目"
+        "Phantom Kunai Charge - Throw 1"
       ]
     },
     {
       "ID": 107003110,
       "Entries": [
-        "Shuriken LV3-B_ 2nd throw -- 手裏剣LV3-B_溜め2投目"
+        "Phantom Kunai Charge - Throw 2"
       ]
     },
     {
       "ID": 107003120,
       "Entries": [
-        "Shuriken LV3-B_ Reservoir Guided Bullet -- 手裏剣LV3-B_溜め誘導弾丸"
+        "Phantom Kunai Charge - Butterfly - Parent"
       ]
     },
     {
       "ID": 107003150,
       "Entries": [
-        "Shuriken LV3-B_1 / 3 throw -- 手裏剣LV3-B_1/3投目"
+        "Phantom Kunai - Throw 1"
       ]
     },
     {
       "ID": 107003160,
       "Entries": [
-        "Shuriken LV3-B_2 throw -- 手裏剣LV3-B_2投目"
+        "Phantom Kunai - Throw 2"
       ]
     },
     {
       "ID": 107003170,
       "Entries": [
-        "Shuriken LV3-B_ Guided Bullet -- 手裏剣LV3-B_誘導弾丸"
+        "Phantom Kunai - Butterfly Parent"
       ]
     },
     {
       "ID": 107004100,
       "Entries": [
-        "Shuriken LV3-C_ Reservoir 1/3 throw -- 手裏剣LV3-C_溜め1/3投目"
+        "Dummy"
       ]
     },
     {
       "ID": 107004101,
       "Entries": [
-        "Shuriken LV3-C_Reservoir 1/3 Throw_LV0 -- 手裏剣LV3-C_溜め1/3投目_LV0"
+        "Dummy"
       ]
     },
     {
       "ID": 107004102,
       "Entries": [
-        "Shuriken LV3-C_Reservoir 1/3 Throw_LV1 -- 手裏剣LV3-C_溜め1/3投目_LV1"
+        "Sen Throw Charge - Little Money"
       ]
     },
     {
       "ID": 107004103,
       "Entries": [
-        "Shuriken LV3-C_Reservoir 1/3 Throw_LV2 -- 手裏剣LV3-C_溜め1/3投目_LV2"
+        "Sen Throw Charge - Some Money"
       ]
     },
     {
       "ID": 107004104,
       "Entries": [
-        "Shuriken LV3-C_Reservoir 1/3 Throw_LV3 -- 手裏剣LV3-C_溜め1/3投目_LV3"
+        "Sen Throw Charge - A Lot of Money"
       ]
     },
     {
       "ID": 107004110,
       "Entries": [
-        "Shuriken LV3-C_ 2nd throw -- 手裏剣LV3-C_溜め2投目"
+        "Dummy"
       ]
     },
     {
       "ID": 107004111,
       "Entries": [
-        "Shuriken LV3-C_Reservoir 2nd throw_LV0 -- 手裏剣LV3-C_溜め2投目_LV0"
+        "Dummy"
       ]
     },
     {
       "ID": 107004112,
       "Entries": [
-        "Shuriken LV3-C_2nd throw _LV1 -- 手裏剣LV3-C_溜め2投目_LV1"
+        "Sen Throw - Little Money"
       ]
     },
     {
       "ID": 107004113,
       "Entries": [
-        "Shuriken LV3-C_2nd throw _LV2 -- 手裏剣LV3-C_溜め2投目_LV2"
+        "Sen Throw - Some Money"
       ]
     },
     {
       "ID": 107004114,
       "Entries": [
-        "Shuriken LV3-C_2nd throw _LV3 -- 手裏剣LV3-C_溜め2投目_LV3"
+        "Sen Throw - A Lot of Money"
       ]
     },
     {
       "ID": 107004150,
       "Entries": [
-        "Shuriken LV3-C_1 / 3 -- 手裏剣LV3-C_1/3投目"
+        "Dummy"
       ]
     },
     {
       "ID": 107004151,
       "Entries": [
-        "Shuriken LV3-C_1 / 3 Throw _LV0 -- 手裏剣LV3-C_1/3投目_LV0"
+        "Dummy"
       ]
     },
     {
       "ID": 107004152,
       "Entries": [
-        "Shuriken LV3-C_1 / 3 Throw _LV1 -- 手裏剣LV3-C_1/3投目_LV1"
+        "Sen Throw Charge - Little Money"
       ]
     },
     {
       "ID": 107004153,
       "Entries": [
-        "Shuriken LV3-C_1 / 3 Throw _LV2 -- 手裏剣LV3-C_1/3投目_LV2"
+        "Sen Throw Charge - Some Money"
       ]
     },
     {
       "ID": 107004154,
       "Entries": [
-        "Shuriken LV3-C_1 / 3 Throw _LV3 -- 手裏剣LV3-C_1/3投目_LV3"
+        "Sen Throw Charge - A Lot of Money"
       ]
     },
     {
       "ID": 107004160,
       "Entries": [
-        "Shuriken LV3-C_2 throw -- 手裏剣LV3-C_2投目"
+        "Dummy"
       ]
     },
     {
       "ID": 107004161,
       "Entries": [
-        "Shuriken LV3-C_2 Throw _LV0 -- 手裏剣LV3-C_2投目_LV0"
+        "Dummy"
       ]
     },
     {
       "ID": 107004162,
       "Entries": [
-        "Shuriken LV3-C_2 Throw _LV1 -- 手裏剣LV3-C_2投目_LV1"
+        "Sen Throw - Little Money"
       ]
     },
     {
       "ID": 107004163,
       "Entries": [
-        "Shuriken LV3-C_2 Throw _LV2 -- 手裏剣LV3-C_2投目_LV2"
+        "Sen Throw - Some Money"
       ]
     },
     {
       "ID": 107004164,
       "Entries": [
-        "Shuriken LV3-C_2 Throw _LV3 -- 手裏剣LV3-C_2投目_LV3"
+        "Sen Throw - A Lot of Money"
       ]
     },
     {
       "ID": 107005100,
       "Entries": [
-        "Shuriken LV4_ Reservoir 1/3 throw -- 手裏剣LV4_溜め1/3投目"
+        "Lazulite Shuriken Charge - Throw 1 - Hit 1"
       ]
     },
     {
       "ID": 107005110,
       "Entries": [
-        "Shuriken LV4_ 2nd throw -- 手裏剣LV4_溜め2投目"
+        "Lazulite Shuriken Charge - Throw 2 - Hit 1"
       ]
     },
     {
       "ID": 107005150,
       "Entries": [
-        "Shuriken LV4_1 / 3 throw -- 手裏剣LV4_1/3投目"
+        "Lazulite Shuriken - Throw 1"
       ]
     },
     {
       "ID": 107005160,
       "Entries": [
-        "Shuriken LV4_2 -- 手裏剣LV4_2投目"
+        "Lazulite Shuriken - Throw 2"
       ]
     },
     {
       "ID": 107100100,
       "Entries": [
-        "Firecracker_parent_reservoir -- 爆竹_親_溜め"
+        "Firecracker - Charge Parent"
       ]
     },
     {
       "ID": 107100110,
       "Entries": [
-        "Firecracker _ Parent _ Reservoir _ Anti-Special Attack Character -- 爆竹_親_溜め_対特攻キャラ"
+        "Firecracker Against Beast - Charge Parent"
       ]
     },
     {
       "ID": 107100120,
       "Entries": [
-        "Firecracker_air_parent -- 爆竹_空中_親"
+        "Firecracker - Aerial Parent"
       ]
     },
     {
       "ID": 107100130,
       "Entries": [
-        "Firecracker_Aerial_Parent_Vs. Special Attack Character -- 爆竹_空中_親_対特攻キャラ"
+        "Firecracker Against Beast - Aerial Parent"
       ]
     },
     {
       "ID": 107100150,
       "Entries": [
-        "Firecracker_parent -- 爆竹_親"
+        "Firecracker - Parent"
       ]
     },
     {
       "ID": 107100160,
       "Entries": [
-        "Firecracker_parent_ vs. special attack character -- 爆竹_親_対特攻キャラ"
+        "Firecracker Against Beast - Parent"
       ]
     },
     {
       "ID": 107100184,
       "Entries": [
-        "Right-handed sword_strong thunder enchantment additional bullet -- 右手刀_強雷エンチャント追加弾丸"
+        "Divine Dragon Lightning Reversal"
       ]
     },
     {
       "ID": 107100190,
       "Entries": [
-        "Right hand sword_red blood enchantment additional bullet (thrust) -- 右手刀_赤血エンチャント追加弾丸（突き）"
+        "Bestowal Ninjutsu Thrust Attack"
       ]
     },
     {
       "ID": 107100191,
       "Entries": [
-        "Right hand sword_poison blood enchantment additional bullet (thrust) -- 右手刀_毒血エンチャント追加弾丸（突き）"
+        "Bestowal Ninjutsu Poison Thrust Attack"
       ]
     },
     {
       "ID": 107100192,
       "Entries": [
-        "Right hand sword_white blood enchantment additional bullet (thrust) -- 右手刀_白血エンチャント追加弾丸（突き）"
+        "Bestowal Ninjutsu Lifesteal Thrust Attack"
       ]
     },
     {
       "ID": 107100193,
       "Entries": [
-        "Right-handed sword_Weak thunder enchantment additional bullet (thrust) -- 右手刀_弱雷エンチャント追加弾丸（突き）"
+        "Non Divine Dragon Lightning Reversal"
       ]
     },
     {
       "ID": 107100195,
       "Entries": [
-        "Right-handed sword_Orange-style enchantment additional bullet (thrust) -- 右手刀_橙風エンチャント追加弾丸（突き）"
+        ""
       ]
     },
     {
       "ID": 107100196,
       "Entries": [
-        "Right hand sword_Kinfu enchantment additional bullet (thrust) -- 右手刀_金風エンチャント追加弾丸（突き）"
+        ""
       ]
     },
     {
       "ID": 107100290,
       "Entries": [
-        "Firecracker _ Anti-spirit force -- 爆竹_対霊フォース"
+        "Anti-Apparition Force"
       ]
     },
     {
       "ID": 107100295,
       "Entries": [
-        "Firecracker _ Depression Force -- 爆竹_恐慌フォース"
+        "Red Eyes Scare Parent"
       ]
     },
     {
       "ID": 107102100,
       "Entries": [
-        "Firecracker LV3-A_parent_reservoir -- 爆竹LV3-A_親_溜め"
+        "Long Spark - Charge Parent"
       ]
     },
     {
       "ID": 107102110,
       "Entries": [
-        "Firecracker LV3-A_Parent_Reservoir_Anti-Special Attack Character -- 爆竹LV3-A_親_溜め_対特攻キャラ"
+        "Long Spark Against Beast - Charge Parent"
       ]
     },
     {
       "ID": 107102120,
       "Entries": [
-        "Firecracker LV3-A_Aerial_Parent -- 爆竹LV3-A_空中_親"
+        "Long Spark - Aerial Parent"
       ]
     },
     {
       "ID": 107102130,
       "Entries": [
-        "Firecracker LV3-A_Aerial_Parent_Vs. Special Attack Character -- 爆竹LV3-A_空中_親_対特攻キャラ"
+        "Long Spark Against Beast - Aerial Parent"
       ]
     },
     {
       "ID": 107102150,
       "Entries": [
-        "Firecracker LV3-A_parent -- 爆竹LV3-A_親"
+        "Long Spark - Parent"
       ]
     },
     {
       "ID": 107102160,
       "Entries": [
-        "Firecracker LV3-A_parent_ vs. special attack character -- 爆竹LV3-A_親_対特攻キャラ"
+        "Long Spark Against Beast - Parent"
       ]
     },
     {
       "ID": 107103100,
       "Entries": [
-        "Firecracker LV3-B_parent_reservoir -- 爆竹LV3-B_親_溜め"
+        "Purple Fume Spark - Charge Parent"
       ]
     },
     {
       "ID": 107103110,
       "Entries": [
-        "Firecracker LV3-B_Parent_Reservoir_Anti-Special Attack Character -- 爆竹LV3-B_親_溜め_対特攻キャラ"
+        "Purple Fume Spark Against Beast - Charge Parent"
       ]
     },
     {
       "ID": 107103120,
       "Entries": [
-        "Firecracker LV3-B_Aerial_Parent -- 爆竹LV3-B_空中_親"
+        "Purple Fume Spark - Aerial Parent"
       ]
     },
     {
       "ID": 107103130,
       "Entries": [
-        "Firecracker LV3-B_Aerial_Parent_Vs. Special Attack Character -- 爆竹LV3-B_空中_親_対特攻キャラ"
+        "Purple Fume Spark Against Beast - Aerial Parent"
       ]
     },
     {
       "ID": 107103150,
       "Entries": [
-        "Firecracker LV3-B_parent -- 爆竹LV3-B_親"
+        "Purple Fume Spark - Parent"
       ]
     },
     {
       "ID": 107103160,
       "Entries": [
-        "Firecracker LV3-B_parent_ vs. special attack character -- 爆竹LV3-B_親_対特攻キャラ"
+        "Purple Fume Spark Against Beast - Parent"
       ]
     },
     {
       "ID": 107200100,
       "Entries": [
-        "Ignition_Pump shooting -- 発火_溜め撃ち"
+        "Flame Vent Charge - Hit 1"
       ]
     },
     {
       "ID": 107200110,
       "Entries": [
-        "Ignition_normal shooting -- 発火_通常撃ち"
+        "Flame Vent - Normal"
       ]
     },
     {
       "ID": 107200120,
       "Entries": [
-        "Ignition_Aerial shooting -- 発火_空中撃ち"
+        "Flame Vent - Aerial"
       ]
     },
     {
       "ID": 107200130,
       "Entries": [
-        "Ignition_flamethrower_start -- 発火_火炎放射_開始"
+        "Flame Vent - Flamethrower Start"
       ]
     },
     {
       "ID": 107200131,
       "Entries": [
-        "Ignition_flamethrower_loop -- 発火_火炎放射_ループ"
+        "Flame Vent - Flamethrower Loop"
       ]
     },
     {
       "ID": 107200140,
       "Entries": [
-        "Ignition_Derived Attack Enchantment Dummy -- 発火_派生攻撃エンチャント用ダミー"
+        "Flame Vent - Dummy for Living Force"
       ]
     },
     {
       "ID": 107200184,
       "Entries": [
-        "Right-handed sword_strong thunder enchantment additional bullet -- 右手刀_強雷エンチャント追加弾丸"
+        "Divine Dragon Lightning Reversal"
       ]
     },
     {
       "ID": 107200190,
       "Entries": [
-        "Right hand sword_red blood enchantment additional bullet (thrust) -- 右手刀_赤血エンチャント追加弾丸（突き）"
+        "Bestowal Ninjutsu Thrust Attack"
       ]
     },
     {
       "ID": 107200191,
       "Entries": [
-        "Right hand sword_poison blood enchantment additional bullet (thrust) -- 右手刀_毒血エンチャント追加弾丸（突き）"
+        "Bestowal Ninjutsu Poison Thrust Attack"
       ]
     },
     {
       "ID": 107200192,
       "Entries": [
-        "Right hand sword_white blood enchantment additional bullet (thrust) -- 右手刀_白血エンチャント追加弾丸（突き）"
+        "Bestowal Ninjutsu Lifesteal Thrust Attack"
       ]
     },
     {
       "ID": 107200193,
       "Entries": [
-        "Right-handed sword_Weak thunder enchantment additional bullet (thrust) -- 右手刀_弱雷エンチャント追加弾丸（突き）"
+        "Non Divine Dragon Lightning Reversal"
       ]
     },
     {
       "ID": 107200195,
       "Entries": [
-        "Right-handed sword_Orange-style enchantment additional bullet (thrust) -- 右手刀_橙風エンチャント追加弾丸（突き）"
+        ""
       ]
     },
     {
       "ID": 107200196,
       "Entries": [
-        "Right hand sword_Kinfu enchantment additional bullet (thrust) -- 右手刀_金風エンチャント追加弾丸（突き）"
+        ""
       ]
     },
     {
       "ID": 107200290,
       "Entries": [
-        "Ignition_Anti-spirit force -- 発火_対霊フォース"
+        "Anti-Apparition Force"
       ]
     },
     {
       "ID": 107200295,
       "Entries": [
-        "Ignition_Crisis Force -- 発火_恐慌フォース"
+        "Red Eyes Scare Parent"
       ]
     },
     {
       "ID": 107200297,
       "Entries": [
-        "Ignition_Crisis Force_Encha not required Ver. -- 発火_恐慌フォース_エンチャ不要Ver."
+        "Red Eyes Scare Parent"
       ]
     },
     {
       "ID": 107200999,
       "Entries": [
-        "Ignition_form consumption dummy -- 発火_形代消費ダミー"
+        "Prosthetic Tool - Spirit Emblem Consumption Dummy"
       ]
     },
     {
       "ID": 107203100,
       "Entries": [
-        "Ignition LV4_ Accumulation shooting -- 発火LV4_溜め撃ち"
+        "Lazulite Sacred Flame - Charge - Hit 1"
       ]
     },
     {
       "ID": 107203110,
       "Entries": [
-        "Ignition LV4_normal shooting -- 発火LV4_通常撃ち"
+        "Lazulite Sacred Flame - Normal"
       ]
     },
     {
       "ID": 107203120,
       "Entries": [
-        "Ignition LV4_Aerial shooting -- 発火LV4_空中撃ち"
+        "Lazulite Sacred Flame - Aerial"
       ]
     },
     {
       "ID": 107203130,
       "Entries": [
-        "Ignition LV4_flamethrower_start -- 発火LV4_火炎放射_開始"
+        "Lazulite Sacred Flame - Flamethrower Start"
       ]
     },
     {
       "ID": 107203131,
       "Entries": [
-        "Ignition LV4_flamethrower_loop -- 発火LV4_火炎放射_ループ"
+        "Lazulite Sacred Flame - Flamethrower Loop"
       ]
     },
     {
       "ID": 107203140,
       "Entries": [
-        "Ignition LV4_ Derived Attack Enchantment Dummy -- 発火LV4_派生攻撃エンチャント用ダミー"
+        "Lazulite Sacred Flame - Dummy for Living Force"
       ]
     },
     {
       "ID": 107203292,
       "Entries": [
-        "Ignition LV4_Anti-spirit force_ Reach far -- 発火LV4_対霊フォース_遠くまで届く"
+        "Lazulite Sacred Flame - Far reaching Anti-apparition"
       ]
     },
     {
       "ID": 107300100,
       "Entries": [
-        "Ax_Pump Attack 1 -- 斧_溜め攻撃1"
+        "Axe - Charge - Hit 1"
       ]
     },
     {
       "ID": 107300101,
       "Entries": [
-        "Ax_Pump Attack 2 -- 斧_溜め攻撃2"
+        "Axe - Charge - Hit 2"
       ]
     },
     {
       "ID": 107300102,
       "Entries": [
-        "Ax_single attack -- 斧_単発攻撃"
+        "Axe - Charge - Hit 2"
       ]
     },
     {
       "ID": 107300110,
       "Entries": [
-        "Ax _ front slash _ ax -- 斧_前宙斬り_斧"
+        "Axe - Normal"
       ]
     },
     {
       "ID": 107300121,
       "Entries": [
-        "Ax_Aerial attack -- 斧_空中攻撃"
+        "Axe - Aerial"
       ]
     },
     {
       "ID": 107300122,
       "Entries": [
-        "Ax_Aerial Attack_Loop / Landing -- 斧_空中攻撃_ループ/着地"
+        "Axe - Aerial Loop / Landing"
       ]
     },
     {
       "ID": 107300184,
       "Entries": [
-        "Right-handed sword_strong thunder enchantment additional bullet -- 右手刀_強雷エンチャント追加弾丸"
+        "Divine Dragon Lightning Reversal"
       ]
     },
     {
       "ID": 107300190,
       "Entries": [
-        "Right hand sword_red blood enchantment additional bullet (thrust) -- 右手刀_赤血エンチャント追加弾丸（突き）"
+        "Bestowal Ninjutsu Thrust Attack"
       ]
     },
     {
       "ID": 107300191,
       "Entries": [
-        "Right hand sword_poison blood enchantment additional bullet (thrust) -- 右手刀_毒血エンチャント追加弾丸（突き）"
+        "Bestowal Ninjutsu Poison Thrust Attack"
       ]
     },
     {
       "ID": 107300192,
       "Entries": [
-        "Right hand sword_white blood enchantment additional bullet (thrust) -- 右手刀_白血エンチャント追加弾丸（突き）"
+        "Bestowal Ninjutsu Lifesteal Thrust Attack"
       ]
     },
     {
       "ID": 107300193,
       "Entries": [
-        "Right-handed sword_Weak thunder enchantment additional bullet (thrust) -- 右手刀_弱雷エンチャント追加弾丸（突き）"
+        "Non Divine Dragon Lightning Reversal"
       ]
     },
     {
       "ID": 107300195,
       "Entries": [
-        "Right-handed sword_Orange-style enchantment additional bullet (thrust) -- 右手刀_橙風エンチャント追加弾丸（突き）"
+        ""
       ]
     },
     {
       "ID": 107300196,
       "Entries": [
-        "Right hand sword_Kinfu enchantment additional bullet (thrust) -- 右手刀_金風エンチャント追加弾丸（突き）"
+        ""
       ]
     },
     {
       "ID": 107300290,
       "Entries": [
-        "Ax_anti-spirit force -- 斧_対霊フォース"
+        "Anti-Apparition Force"
       ]
     },
     {
       "ID": 107300295,
       "Entries": [
-        "Ax_Crisis Force -- 斧_恐慌フォース"
+        "Red Eyes Scare Parent"
       ]
     },
     {
       "ID": 107302100,
       "Entries": [
-        "Ax LV3_ Reservoir Attack 1 -- 斧LV3_溜め攻撃1"
+        "Sparking Axe - Charge - Hit 1"
       ]
     },
     {
       "ID": 107302101,
       "Entries": [
-        "Ax LV3_ Reservoir Attack 2 -- 斧LV3_溜め攻撃2"
+        "Sparking Axe - Charge - Hit 2"
       ]
     },
     {
       "ID": 107302102,
       "Entries": [
-        "Ax LV3_ single attack -- 斧LV3_単発攻撃"
+        "Sparking Axe - Charge - Hit 2"
       ]
     },
     {
       "ID": 107302110,
       "Entries": [
-        "Ax LV3_Front Slasher_Ax -- 斧LV3_前宙斬り_斧"
+        "Sparking Axe - Normal"
       ]
     },
     {
       "ID": 107302121,
       "Entries": [
-        "Ax LV3_ aerial attack -- 斧LV3_空中攻撃"
+        "Sparking Axe - Aerial"
       ]
     },
     {
       "ID": 107302122,
       "Entries": [
-        "Ax LV3_Aerial Attack_Loop / Landing -- 斧LV3_空中攻撃_ループ/着地"
+        "Sparking Axe - Aerial Loop / Landing"
       ]
     },
     {
       "ID": 107302130,
       "Entries": [
-        "Ax LV3_ shock wave -- 斧LV3_衝撃波"
+        "Sparking Axe - Explosion"
       ]
     },
     {
       "ID": 107302297,
       "Entries": [
-        "Ax LV3_ Depression Force -- 斧LV3_恐慌フォース"
+        "Sparking Axe - Red Eyes Scare Parent"
       ]
     },
     {
       "ID": 107303100,
       "Entries": [
-        "Ax LV4_ Reservoir Attack 1 -- 斧LV4_溜め攻撃1"
+        "Lazulite Axe - Charge - Hit 1"
       ]
     },
     {
       "ID": 107303101,
       "Entries": [
-        "Ax LV4_ Reservoir Attack 2 -- 斧LV4_溜め攻撃2"
+        "Lazulite Axe - Charge - Hit 2"
       ]
     },
     {
       "ID": 107303102,
       "Entries": [
-        "Ax LV4_ single attack -- 斧LV4_単発攻撃"
+        "Lazulite Axe - Charge - Hit 2"
       ]
     },
     {
       "ID": 107303110,
       "Entries": [
-        "Ax LV4_Front Slasher_Ax -- 斧LV4_前宙斬り_斧"
+        "Lazulite Axe - Normal"
       ]
     },
     {
       "ID": 107303121,
       "Entries": [
-        "Ax LV4_ aerial attack -- 斧LV4_空中攻撃"
+        "Lazulite Axe - Aerial"
       ]
     },
     {
       "ID": 107303122,
       "Entries": [
-        "Ax LV4_Aerial Attack_Loop / Landing -- 斧LV4_空中攻撃_ループ/着地"
+        "Lazulite Axe - Aerial Loop / Landing"
       ]
     },
     {
       "ID": 107303130,
       "Entries": [
-        "Ax LV4_ shock wave -- 斧LV4_衝撃波"
+        "Lazulite Axe - Explosion"
       ]
     },
     {
       "ID": 107303140,
       "Entries": [
-        "Ax LV4_Shockwave_Phantom Eraser -- 斧LV4_衝撃波_幻影消し"
+        "Lazulite Axe - Snap Seed Effect"
       ]
     },
     {
       "ID": 107400184,
       "Entries": [
-        "Right-handed sword_strong thunder enchantment additional bullet -- 右手刀_強雷エンチャント追加弾丸"
+        "Divine Dragon Lightning Reversal"
       ]
     },
     {
       "ID": 107400190,
       "Entries": [
-        "Right hand sword_red blood enchantment additional bullet (thrust) -- 右手刀_赤血エンチャント追加弾丸（突き）"
+        "Bestowal Ninjutsu Thrust Attack"
       ]
     },
     {
       "ID": 107400191,
       "Entries": [
-        "Right hand sword_poison blood enchantment additional bullet (thrust) -- 右手刀_毒血エンチャント追加弾丸（突き）"
+        "Bestowal Ninjutsu Poison Thrust Attack"
       ]
     },
     {
       "ID": 107400192,
       "Entries": [
-        "Right hand sword_white blood enchantment additional bullet (thrust) -- 右手刀_白血エンチャント追加弾丸（突き）"
+        "Bestowal Ninjutsu Lifesteal Thrust Attack"
       ]
     },
     {
       "ID": 107400193,
       "Entries": [
-        "Right-handed sword_Weak thunder enchantment additional bullet (thrust) -- 右手刀_弱雷エンチャント追加弾丸（突き）"
+        "Non Divine Dragon Lightning Reversal"
       ]
     },
     {
       "ID": 107400195,
       "Entries": [
-        "Right-handed sword_Orange-style enchantment additional bullet (thrust) -- 右手刀_橙風エンチャント追加弾丸（突き）"
+        ""
       ]
     },
     {
       "ID": 107400196,
       "Entries": [
-        "Right hand sword_Kinfu enchantment additional bullet (thrust) -- 右手刀_金風エンチャント追加弾丸（突き）"
+        ""
       ]
     },
     {
       "ID": 107400290,
       "Entries": [
-        "Transformation_Anti-spirit force -- 変わり身_対霊フォース"
+        "Anti-Apparition Force"
       ]
     },
     {
       "ID": 107400295,
       "Entries": [
-        "Transformation_Crisis Force -- 変わり身_恐慌フォース"
+        "Red Eyes Scare Parent"
       ]
     },
     {
       "ID": 107400999,
       "Entries": [
-        "Transformation_form consumption dummy -- 変わり身_形代消費ダミー"
+        "Prosthetic Tool - Spirit Emblem Consumption Dummy"
       ]
     },
     {
       "ID": 107402100,
       "Entries": [
-        "Transformation LV3_ activation impact -- 変わり身LV3_発動衝撃"
+        "Great Feather Mist Raven - Activation Parent"
       ]
     },
     {
       "ID": 107402297,
       "Entries": [
-        "Transformation LV3_ Depression Force -- 変わり身LV3_恐慌フォース"
+        "Great Feather Mist Raven - Red Eyes Scare Parent"
       ]
     },
     {
       "ID": 107500100,
       "Entries": [
-        "Kodachi_Table 1st stage_Left hand sword -- 小太刀_表1段目_左手刀"
+        "Sabimaru - Hit 1"
       ]
     },
     {
       "ID": 107500102,
       "Entries": [
-        "Kodachi _ Table 3rd _ Left hand sword -- 小太刀_表3段目_左手刀"
+        "Sabimaru - Hit 3"
       ]
     },
     {
       "ID": 107500104,
       "Entries": [
-        "Kodachi _ Table 5th _ Left hand sword -- 小太刀_表5段目_左手刀"
+        "Sabimaru - Hit 5"
       ]
     },
     {
       "ID": 107500105,
       "Entries": [
-        "Kodachi _ Table 6th _ Left hand sword -- 小太刀_表6段目_左手刀"
+        "Sabimaru - Hit 6"
       ]
     },
     {
       "ID": 107500110,
       "Entries": [
-        "Kodachi _ back 1st stage _ left hand sword -- 小太刀_裏1段目_左手刀"
+        "Improved Sabimaru Follow-up - Hit 1"
       ]
     },
     {
       "ID": 107500111,
       "Entries": [
-        "Kodachi _ back 2nd stage _ left hand sword -- 小太刀_裏2段目_左手刀"
+        "Improved Sabimaru Follow-up - Hit 2"
       ]
     },
     {
       "ID": 107500112,
       "Entries": [
-        "Kodachi_back 3rd stage_left hand sword -- 小太刀_裏3段目_左手刀"
+        "Improved Sabimaru Follow-up - Hit 3"
       ]
     },
     {
       "ID": 107500113,
       "Entries": [
-        "Kodachi_back 4th stage_left hand sword -- 小太刀_裏4段目_左手刀"
+        "Improved Sabimaru Follow-up - Hit 4"
       ]
     },
     {
       "ID": 107500114,
       "Entries": [
-        "Kodachi_back 5th stage_left hand sword -- 小太刀_裏5段目_左手刀"
+        "Improved Sabimaru Follow-up - Hit 5"
       ]
     },
     {
       "ID": 107500115,
       "Entries": [
-        "Kodachi_back 6th stage_left hand sword -- 小太刀_裏6段目_左手刀"
+        "Improved Sabimaru Follow-up - Hit 6"
       ]
     },
     {
       "ID": 107500140,
       "Entries": [
-        "Kodachi_Aerial 1st stage_Left hand sword 1 -- 小太刀_空中1段目_左手刀1"
+        "Sabimaru - Aerial - Hit 1"
       ]
     },
     {
       "ID": 107500141,
       "Entries": [
-        "Kodachi_Aerial 1st stage_Left hand sword 2 -- 小太刀_空中1段目_左手刀2"
+        "Sabimaru - Aerial - Hit 1"
       ]
     },
     {
       "ID": 107500184,
       "Entries": [
-        "Right-handed sword_strong thunder enchantment additional bullet -- 右手刀_強雷エンチャント追加弾丸"
+        "Divine Dragon Lightning Reversal"
       ]
     },
     {
       "ID": 107500190,
       "Entries": [
-        "Right hand sword_red blood enchantment additional bullet (thrust) -- 右手刀_赤血エンチャント追加弾丸（突き）"
+        "Bestowal Ninjutsu Thrust Attack"
       ]
     },
     {
       "ID": 107500191,
       "Entries": [
-        "Right hand sword_poison blood enchantment additional bullet (thrust) -- 右手刀_毒血エンチャント追加弾丸（突き）"
+        "Bestowal Ninjutsu Poison Thrust Attack"
       ]
     },
     {
       "ID": 107500192,
       "Entries": [
-        "Right hand sword_white blood enchantment additional bullet (thrust) -- 右手刀_白血エンチャント追加弾丸（突き）"
+        "Bestowal Ninjutsu Lifesteal Thrust Attack"
       ]
     },
     {
       "ID": 107500193,
       "Entries": [
-        "Right-handed sword_Weak thunder enchantment additional bullet (thrust) -- 右手刀_弱雷エンチャント追加弾丸（突き）"
+        "Non Divine Dragon Lightning Reversal"
       ]
     },
     {
       "ID": 107500195,
       "Entries": [
-        "Right-handed sword_Orange-style enchantment additional bullet (thrust) -- 右手刀_橙風エンチャント追加弾丸（突き）"
+        ""
       ]
     },
     {
       "ID": 107500196,
       "Entries": [
-        "Right hand sword_Kinfu enchantment additional bullet (thrust) -- 右手刀_金風エンチャント追加弾丸（突き）"
+        ""
       ]
     },
     {
       "ID": 107500290,
       "Entries": [
-        "Kodachi_Anti-spirit force -- 小太刀_対霊フォース"
+        "Anti-Apparition Force"
       ]
     },
     {
       "ID": 107500295,
       "Entries": [
-        "Kodachi_Crisis Force -- 小太刀_恐慌フォース"
+        "Red Eyes Scare Parent"
       ]
     },
     {
       "ID": 107502100,
       "Entries": [
-        "Kodachi LV3-A_Table 1st stage_Left hand sword -- 小太刀LV3-A_表1段目_左手刀"
+        "Piercing Sabimaru - Hit 1"
       ]
     },
     {
       "ID": 107502102,
       "Entries": [
-        "Kodachi LV3-A_Table 3rd stage_Left hand sword -- 小太刀LV3-A_表3段目_左手刀"
+        "Piercing Sabimaru - Hit 3"
       ]
     },
     {
       "ID": 107502104,
       "Entries": [
-        "Kodachi LV3-A_Table 5th stage_Left hand sword -- 小太刀LV3-A_表5段目_左手刀"
+        "Piercing Sabimaru - Hit 5"
       ]
     },
     {
       "ID": 107502105,
       "Entries": [
-        "Kodachi LV3-A_Table 6th row_Left hand sword -- 小太刀LV3-A_表6段目_左手刀"
+        "Piercing Sabimaru - Hit 6"
       ]
     },
     {
       "ID": 107502110,
       "Entries": [
-        "Kodachi LV3-A_back 1st stage_left hand sword -- 小太刀LV3-A_裏1段目_左手刀"
+        "Piercing Sabimaru Follow-up - Hit 1"
       ]
     },
     {
       "ID": 107502111,
       "Entries": [
-        "Kodachi LV3-A_back 2nd stage_left hand sword -- 小太刀LV3-A_裏2段目_左手刀"
+        "Piercing Sabimaru Follow-up - Hit 3"
       ]
     },
     {
       "ID": 107502112,
       "Entries": [
-        "Kodachi LV3-A_back 3rd stage_left hand sword -- 小太刀LV3-A_裏3段目_左手刀"
+        "Piercing Sabimaru Follow-up - Hit 3"
       ]
     },
     {
       "ID": 107502113,
       "Entries": [
-        "Kodachi LV3-A_back 4th stage_left hand sword -- 小太刀LV3-A_裏4段目_左手刀"
+        "Piercing Sabimaru Follow-up - Hit 4"
       ]
     },
     {
       "ID": 107502114,
       "Entries": [
-        "Kodachi LV3-A_back 5th stage_left hand sword -- 小太刀LV3-A_裏5段目_左手刀"
+        "Piercing Sabimaru Follow-up - Hit 5"
       ]
     },
     {
       "ID": 107502115,
       "Entries": [
-        "Kodachi LV3-A_Back 6th stage_Left hand sword -- 小太刀LV3-A_裏6段目_左手刀"
+        "Piercing Sabimaru Follow-up - Hit 6"
       ]
     },
     {
       "ID": 107502140,
       "Entries": [
-        "Kodachi LV3-A_Aerial 1st stage_Left hand sword 1 -- 小太刀LV3-A_空中1段目_左手刀1"
+        "Piercing Sabimaru - Aerial - Hit 1"
       ]
     },
     {
       "ID": 107502141,
       "Entries": [
-        "Kodachi LV3-A_Aerial 1st stage_Left hand sword 2 -- 小太刀LV3-A_空中1段目_左手刀2"
+        "Piercing Sabimaru - Aerial - Hit 1"
       ]
     },
     {
       "ID": 107503100,
       "Entries": [
-        "Kodachi LV3-B_Table 1st stage_Left hand sword -- 小太刀LV3-B_表1段目_左手刀"
+        "Lazulite Sabimaru - Hit 1"
       ]
     },
     {
       "ID": 107503102,
       "Entries": [
-        "Kodachi LV3-B_Table 3rd stage_Left hand sword -- 小太刀LV3-B_表3段目_左手刀"
+        "Lazulite Sabimaru - Hit 3"
       ]
     },
     {
       "ID": 107503104,
       "Entries": [
-        "Kodachi LV3-B_Table 5th stage_Left hand sword -- 小太刀LV3-B_表5段目_左手刀"
+        "Lazulite Sabimaru - Hit 5"
       ]
     },
     {
       "ID": 107503105,
       "Entries": [
-        "Kodachi LV3-B_Table 6th row_Left hand sword -- 小太刀LV3-B_表6段目_左手刀"
+        "Lazulite Sabimaru - Hit 6"
       ]
     },
     {
       "ID": 107503110,
       "Entries": [
-        "Kodachi LV3-B_Back 1st stage_Left hand sword -- 小太刀LV3-B_裏1段目_左手刀"
+        "Lazulite Sabimaru Follow-up - Hit 1"
       ]
     },
     {
       "ID": 107503111,
       "Entries": [
-        "Kodachi LV3-B_Back 2nd stage_Left hand sword -- 小太刀LV3-B_裏2段目_左手刀"
+        "Lazulite Sabimaru Follow-up - Hit 2"
       ]
     },
     {
       "ID": 107503112,
       "Entries": [
-        "Kodachi LV3-B_back 3rd stage_left hand sword -- 小太刀LV3-B_裏3段目_左手刀"
+        "Lazulite Sabimaru Follow-up - Hit 3"
       ]
     },
     {
       "ID": 107503113,
       "Entries": [
-        "Kodachi LV3-B_back 4th stage_left hand sword -- 小太刀LV3-B_裏4段目_左手刀"
+        "Lazulite Sabimaru Follow-up - Hit 4"
       ]
     },
     {
       "ID": 107503114,
       "Entries": [
-        "Kodachi LV3-B_back 5th stage_left hand sword -- 小太刀LV3-B_裏5段目_左手刀"
+        "Lazulite Sabimaru Follow-up - Hit 5"
       ]
     },
     {
       "ID": 107503115,
       "Entries": [
-        "Kodachi LV3-B_Back 6th stage_Left hand sword -- 小太刀LV3-B_裏6段目_左手刀"
+        "Lazulite Sabimaru Follow-up - Hit 6"
       ]
     },
     {
       "ID": 107503140,
       "Entries": [
-        "Kodachi LV3-B_Aerial 1st stage_Left hand sword 1 -- 小太刀LV3-B_空中1段目_左手刀1"
+        "Lazulite Sabimaru - Aerial - Hit 1"
       ]
     },
     {
       "ID": 107503141,
       "Entries": [
-        "Kodachi LV3-B_Aerial 1st stage_Left hand sword 2 -- 小太刀LV3-B_空中1段目_左手刀2"
+        "Lazulite Sabimaru - Aerial - Hit 1"
       ]
     },
     {
       "ID": 107503150,
       "Entries": [
-        "Kodachi LV3-B_poison fog_front -- 小太刀LV3-B_毒霧_正面へ"
+        "Lazulite Sabimaru - Poison Mist"
       ]
     },
     {
       "ID": 107503151,
       "Entries": [
-        "Kodachi LV3-B_Poison fog_Left front -- 小太刀LV3-B_毒霧_左前へ"
+        "Lazulite Sabimaru - Poison Mist"
       ]
     },
     {
       "ID": 107503152,
       "Entries": [
-        "Kodachi LV3-B_Poison fog_To the front right -- 小太刀LV3-B_毒霧_右前へ"
+        "Lazulite Sabimaru - Poison Mist"
       ]
     },
     {
       "ID": 107600100,
       "Entries": [
-        "Iron fan_guard -- 鉄扇_ガード"
+        "Loaded Umbrella Guard"
       ]
     },
     {
       "ID": 107600200,
       "Entries": [
-        "Iron fan _ Shooting attack _ Iron fan _ Bullet LV1 -- 鉄扇_放つ攻撃_鉄扇_弾丸LV1"
+        "Projected Force - Loaded Umbrella - Level 1"
       ]
     },
     {
       "ID": 107600210,
       "Entries": [
-        "Iron fan _ Shooting attack _ Iron fan _ Bullet LV2 -- 鉄扇_放つ攻撃_鉄扇_弾丸LV2"
+        "Projected Force - Loaded Umbrella - Level 2"
       ]
     },
     {
       "ID": 107600211,
       "Entries": [
-        "Iron fan_Shoot attack_Iron fan_Bullet LV2_SFX only -- 鉄扇_放つ攻撃_鉄扇_弾丸LV2_SFXのみ"
+        "Projected Force - Loaded Umbrella - Level 2 SFX"
       ]
     },
     {
       "ID": 107600220,
       "Entries": [
-        "Iron fan _ Shooting attack _ Iron fan _ Bullet LV3 -- 鉄扇_放つ攻撃_鉄扇_弾丸LV3"
+        "Projected Force - Loaded Umbrella - Level 3"
       ]
     },
     {
       "ID": 107600221,
       "Entries": [
-        "Iron fan_Shoot attack_Iron fan_Bullet LV3_SFX only -- 鉄扇_放つ攻撃_鉄扇_弾丸LV3_SFXのみ"
+        "Projected Force - Loaded Umbrella - Level 3 SFX"
       ]
     },
     {
       "ID": 107600240,
       "Entries": [
-        "Iron fan_shooting attack -- 鉄扇_放つ攻撃"
+        "Projected Force - Umbrella"
       ]
     },
     {
       "ID": 107600241,
       "Entries": [
-        "Iron fan _ Unleash attack _ Red blood enchantment -- 鉄扇_放つ攻撃_赤血エンチャ"
+        "Projected Force - Bestowal Ninjutsu"
       ]
     },
     {
       "ID": 107600242,
       "Entries": [
-        "Iron fan _ Shooting attack _ Poison blood enchantment -- 鉄扇_放つ攻撃_毒血エンチャ"
+        "Projected Force - Poison Bestowal Ninjutsu"
       ]
     },
     {
       "ID": 107600243,
       "Entries": [
-        "Iron fan _ Unleash attack _ White blood enchantment -- 鉄扇_放つ攻撃_白血エンチャ"
+        "Projected Force - Lifesteal Bestowal Ninjutsu"
       ]
     },
     {
       "ID": 107600244,
       "Entries": [
-        "Iron fan _ Shooting attack _ Orange style enchantment -- 鉄扇_放つ攻撃_橙風エンチャ"
+        "Prosthetic Hand Ninja _ Iron Fan _ Unleashed Slash _ Orange Wind Enchantment "
       ]
     },
     {
       "ID": 107600245,
       "Entries": [
-        "Iron fan _ Unleash attack _ Gold wind enchantment -- 鉄扇_放つ攻撃_金風エンチャ"
+        "Prosthetic Hand Ninja _ Iron Fan _ Unleashed Slash _ Gold Wind Enchantment "
       ]
     },
     {
       "ID": 107600270,
       "Entries": [
-        "Iron fan _ Anti-flame Iron fan Momentary enchantment by slashing -- 鉄扇_対炎鉄扇放ち斬りによる瞬間エンチャ"
+        "Suzaku's Lotus Umbrella Weapon Effect"
       ]
     },
     {
       "ID": 107600271,
       "Entries": [
-        "Iron fan_Anti-spirit Iron fan Momentary enchantment by slashing -- 鉄扇_対霊鉄扇放ち斬りによる瞬間エンチャ"
+        "Phoenix's Lilac Umbrella Weapon Effect"
       ]
     },
     {
       "ID": 107600290,
       "Entries": [
-        "Iron fan_anti-spirit force -- 鉄扇_対霊フォース"
+        "Anti-Apparition Force"
       ]
     },
     {
       "ID": 107600295,
       "Entries": [
-        "Iron Fan_Crisis Force -- 鉄扇_恐慌フォース"
+        "Red Eyes Scare Parent"
       ]
     },
     {
       "ID": 107600999,
       "Entries": [
-        "Iron fan_form consumption dummy -- 鉄扇_形代消費ダミー"
+        "Prosthetic Tool - Spirit Emblem Consumption Dummy"
       ]
     },
     {
       "ID": 107602297,
       "Entries": [
-        "Iron Fan LV2-A_ Depression Force -- 鉄扇LV2-A_恐慌フォース"
+        "Suzaku's Lotus Umbrella - Red Eyes Scare Parent"
       ]
     },
     {
       "ID": 107603292,
       "Entries": [
-        "Iron fan LV2-B_Anti-spirit force_Jasuga / Turn receiver -- 鉄扇LV2-B_対霊フォース_ジャスガ/回し受け"
+        "Phoenix's Lilac Umbrella - Anti-apparition"
       ]
     },
     {
       "ID": 107603293,
       "Entries": [
-        "Iron fan LV2-B_Anti-spirit force_ Reach far -- 鉄扇LV2-B_対霊フォース_遠くまで届く"
+        "Phoenix's Lilac Umbrella - Anti-apparition far reach"
       ]
     },
     {
       "ID": 107700100,
       "Entries": [
-        "Enemy turning _ wind gathering -- 敵回し_風集め"
+        "Divine Abduction - Wind Collect"
       ]
     },
     {
       "ID": 107700101,
       "Entries": [
-        "Enemy turning _ Wind subtraction by slashing (1 → 0) -- 敵回し_風まとい斬りによる残り減算（1→0）"
+        "Divine Abduction Attack (1 -> 0 charges)"
       ]
     },
     {
       "ID": 107700110,
       "Entries": [
-        "Enemy turning _ Wind release body (remaining 1 → 0) -- 敵回し_風放ち本体（残り1→0）"
+        "Divine Abduction - Turn"
       ]
     },
     {
       "ID": 107700120,
       "Entries": [
-        "Enemy turning_Wind collection extension -- 敵回し_風集め延長"
+        "Divine Abduction - Wind Gather"
       ]
     },
     {
       "ID": 107700140,
       "Entries": [
-        "Enemy Turn_Dummy for Derived Attack Enchantment -- 敵回し_派生攻撃エンチャント用ダミー"
+        "Divine Abduction - Living Force Dummy"
       ]
     },
     {
       "ID": 107700184,
       "Entries": [
-        "Right-handed sword_strong thunder enchantment additional bullet -- 右手刀_強雷エンチャント追加弾丸"
+        "Divine Dragon Lightning Reversal"
       ]
     },
     {
       "ID": 107700190,
       "Entries": [
-        "Right hand sword_red blood enchantment additional bullet (thrust) -- 右手刀_赤血エンチャント追加弾丸（突き）"
+        "Bestowal Ninjutsu Thrust Attack"
       ]
     },
     {
       "ID": 107700191,
       "Entries": [
-        "Right hand sword_poison blood enchantment additional bullet (thrust) -- 右手刀_毒血エンチャント追加弾丸（突き）"
+        "Bestowal Ninjutsu Poison Thrust Attack"
       ]
     },
     {
       "ID": 107700192,
       "Entries": [
-        "Right hand sword_white blood enchantment additional bullet (thrust) -- 右手刀_白血エンチャント追加弾丸（突き）"
+        "Bestowal Ninjutsu Lifesteal Thrust Attack"
       ]
     },
     {
       "ID": 107700193,
       "Entries": [
-        "Right-handed sword_Weak thunder enchantment additional bullet (thrust) -- 右手刀_弱雷エンチャント追加弾丸（突き）"
+        "Non Divine Dragon Lightning Reversal"
       ]
     },
     {
       "ID": 107700195,
       "Entries": [
-        "Right-handed sword_Orange-style enchantment additional bullet (thrust) -- 右手刀_橙風エンチャント追加弾丸（突き）"
+        ""
       ]
     },
     {
       "ID": 107700196,
       "Entries": [
-        "Right hand sword_Kinfu enchantment additional bullet (thrust) -- 右手刀_金風エンチャント追加弾丸（突き）"
+        ""
       ]
     },
     {
       "ID": 107701100,
       "Entries": [
-        "Enemy turning LV2_Wind collection_Remaining 2 -- 敵回しLV2_風集め_残り2"
+        "Double Divine Abduction - Wind Collect"
       ]
     },
     {
       "ID": 107701101,
       "Entries": [
-        "Enemy turning LV2_ Remaining subtraction by wind slashing (2 → 1) -- 敵回しLV2_風まとい斬りによる残り減算（2→1）"
+        "Double Divine Abduction Attack (2 -> 1 charges)"
       ]
     },
     {
       "ID": 107701110,
       "Entries": [
-        "Enemy turning LV2_ Wind release body (remaining 1 → 0) -- 敵回しLV2_風放ち本体（残り1→0）"
+        "Double Divine Abduction - Turn"
       ]
     },
     {
       "ID": 107701111,
       "Entries": [
-        "Enemy turning LV2_ Wind release body (remaining 2 → 1) -- 敵回しLV2_風放ち本体（残り2→1）"
+        "Double Divine Abduction - Turn"
       ]
     },
     {
       "ID": 107701120,
       "Entries": [
-        "Enemy turning LV2_Wind collection extension_1 remaining -- 敵回しLV2_風集め延長_残り1"
+        "Double Divine Abduction - Wind Gather"
       ]
     },
     {
       "ID": 107701121,
       "Entries": [
-        "Enemy turning LV2_Wind collection extension_Remaining 2 -- 敵回しLV2_風集め延長_残り2"
+        "Double Divine Abduction - Wind Gather"
       ]
     },
     {
       "ID": 107702100,
       "Entries": [
-        "Enemy turning LV3_Wind collection_Remaining 2 -- 敵回しLV3_風集め_残り2"
+        "Golden Vortex - Wind Collect"
       ]
     },
     {
       "ID": 107702101,
       "Entries": [
-        "Enemy turning LV3_ Remaining subtraction by wind slashing (2 → 1) -- 敵回しLV3_風まとい斬りによる残り減算（2→1）"
+        "Golden Vortex Attack (2 -> 1 charges)"
       ]
     },
     {
       "ID": 107702110,
       "Entries": [
-        "Enemy turning LV3_ Wind release body (remaining 1 → 0) -- 敵回しLV3_風放ち本体（残り1→0）"
+        "Golden Vortex - Turn"
       ]
     },
     {
       "ID": 107702111,
       "Entries": [
-        "Enemy turning LV3_ Wind release body (remaining 2 → 1) -- 敵回しLV3_風放ち本体（残り2→1）"
+        "Golden Vortex - Turn"
       ]
     },
     {
       "ID": 107702120,
       "Entries": [
-        "Enemy turning LV2_Wind collection extension_1 remaining -- 敵回しLV2_風集め延長_残り1"
+        "Golden Vortex - Wind Gather"
       ]
     },
     {
       "ID": 107702121,
       "Entries": [
-        "Enemy turning LV2_Wind collection extension_Remaining 2 -- 敵回しLV2_風集め延長_残り2"
+        "Golden Vortex - Wind Gather"
       ]
     },
     {
       "ID": 107702140,
       "Entries": [
-        "Enemy Turn LV3_ Derived Attack Enchantment Dummy -- 敵回しLV3_派生攻撃エンチャント用ダミー"
+        "Golden Vortex - Living Force Dummy"
       ]
     },
     {
       "ID": 107800100,
       "Entries": [
-        "Spear_Pump Charge 1 -- 槍_溜め突撃1"
+        "Spear Thrust Type - Charge - Hit 1"
       ]
     },
     {
       "ID": 107800101,
       "Entries": [
-        "Spear_Pump Charge 2 -- 槍_溜め突撃2"
+        "Spear Thrust Type - Charge - Hit 2"
       ]
     },
     {
       "ID": 107800102,
       "Entries": [
-        "Spear_Pump Charge 3_Tip -- 槍_溜め突撃3_先端"
+        "Spear Thrust Type - Single Thrust / Charge Final - Tip"
       ]
     },
     {
       "ID": 107800103,
       "Entries": [
-        "Spear_Pump Charge 3_Intermediate -- 槍_溜め突撃3_中間"
+        "Spear Thrust Type / Normal - Single Thrust / Charge Final - Middle"
       ]
     },
     {
       "ID": 107800104,
       "Entries": [
-        "Spear_Pump Charge 3_Root -- 槍_溜め突撃3_根元"
+        "Spear Thrust Type / Normal - Single Thrust / Charge Final - Root"
       ]
     },
     {
       "ID": 107800105,
       "Entries": [
-        "Spear_single thrust_tip -- 槍_単発突き_先端"
+        "Spear Thrust Type - Single Thrust / Charge Final - Tip"
       ]
     },
     {
       "ID": 107800106,
       "Entries": [
-        "Spear _ single shot _ middle -- 槍_単発突き_中間"
+        "Spear Thrust Type / Normal - Single Thrust / Charge Final - Middle"
       ]
     },
     {
       "ID": 107800107,
       "Entries": [
-        "Spear _ single shot _ root -- 槍_単発突き_根元"
+        "Spear Thrust Type / Normal - Single Thrust / Charge Final - Root"
       ]
     },
     {
       "ID": 107800110,
       "Entries": [
-        "Spear_Attract 1 -- 槍_引き寄せ1"
+        "Spear Thrust Type / Normal - Pull - Beginning"
       ]
     },
     {
       "ID": 107800115,
       "Entries": [
-        "Spear_pull 2_tip -- 槍_引き寄せ2_先端"
+        "Spear Thrust Type / Normal - Pull - Tip"
       ]
     },
     {
       "ID": 107800116,
       "Entries": [
-        "Spear_Attract 2_Intermediate -- 槍_引き寄せ2_中間"
+        "Spear Thrust Type / Normal - Middle"
       ]
     },
     {
       "ID": 107800117,
       "Entries": [
-        "Spear_Attract 2_Root -- 槍_引き寄せ2_根元"
+        "Spear Thrust Type / Normal - Root"
       ]
     },
     {
       "ID": 107800184,
       "Entries": [
-        "Right-handed sword_strong thunder enchantment additional bullet -- 右手刀_強雷エンチャント追加弾丸"
+        "Divine Dragon Lightning Reversal"
       ]
     },
     {
       "ID": 107800190,
       "Entries": [
-        "Right hand sword_red blood enchantment additional bullet (thrust) -- 右手刀_赤血エンチャント追加弾丸（突き）"
+        "Bestowal Ninjutsu Thrust Attack"
       ]
     },
     {
       "ID": 107800191,
       "Entries": [
-        "Right hand sword_poison blood enchantment additional bullet (thrust) -- 右手刀_毒血エンチャント追加弾丸（突き）"
+        "Bestowal Ninjutsu Poison Thrust Attack"
       ]
     },
     {
       "ID": 107800192,
       "Entries": [
-        "Right hand sword_white blood enchantment additional bullet (thrust) -- 右手刀_白血エンチャント追加弾丸（突き）"
+        "Bestowal Ninjutsu Lifesteal Thrust Attack"
       ]
     },
     {
       "ID": 107800193,
       "Entries": [
-        "Right-handed sword_Weak thunder enchantment additional bullet (thrust) -- 右手刀_弱雷エンチャント追加弾丸（突き）"
+        "Non Divine Dragon Lightning Reversal"
       ]
     },
     {
       "ID": 107800195,
       "Entries": [
-        "Right-handed sword_Orange-style enchantment additional bullet (thrust) -- 右手刀_橙風エンチャント追加弾丸（突き）"
+        ""
       ]
     },
     {
       "ID": 107800196,
       "Entries": [
-        "Right hand sword_Kinfu enchantment additional bullet (thrust) -- 右手刀_金風エンチャント追加弾丸（突き）"
+        ""
       ]
     },
     {
       "ID": 107800290,
       "Entries": [
-        "Spear_Ghost Force -- 槍_対霊フォース"
+        "Anti-Apparition Force"
       ]
     },
     {
       "ID": 107800295,
       "Entries": [
-        "Spear_Crisis Force -- 槍_恐慌フォース"
+        "Red Eyes Scare Parent"
       ]
     },
     {
       "ID": 107802100,
       "Entries": [
-        "Spear LV2-B_ Reservoir _ Tip -- 槍LV2-B_溜めなぎ払い_先端"
+        "Spear Cleave Type - Charge - Tip"
       ]
     },
     {
       "ID": 107802101,
       "Entries": [
-        "Spear LV2-B_Reservoir _Intermediate -- 槍LV2-B_溜めなぎ払い_中間"
+        "Spear Cleave Type - Charge - Middle"
       ]
     },
     {
       "ID": 107802102,
       "Entries": [
-        "Spear LV2-B_ Reservoir _ Root -- 槍LV2-B_溜めなぎ払い_根元"
+        "Spear Cleave Type - Charge Final - Root"
       ]
     },
     {
       "ID": 107802105,
       "Entries": [
-        "Spear LV2-B_single thrust_tip -- 槍LV2-B_単発突き_先端"
+        "Spear Cleave Type - Single Thrust - Tip"
       ]
     },
     {
       "ID": 107802106,
       "Entries": [
-        "Spear LV2-B_single thrust_intermediate -- 槍LV2-B_単発突き_中間"
+        "Spear Cleave Type - Single Thrust - Middle"
       ]
     },
     {
       "ID": 107802107,
       "Entries": [
-        "Spear LV2-B_single thrust_root -- 槍LV2-B_単発突き_根元"
+        "Spear Cleave Type - Single Thrust - Root"
       ]
     },
     {
       "ID": 107802110,
       "Entries": [
-        "Spear LV2-B_Attract 1 -- 槍LV2-B_引き寄せ1"
+        "Spear Cleave Type - Pull - Beginning"
       ]
     },
     {
       "ID": 107802115,
       "Entries": [
-        "Spear LV2-B_Pulling 2_Tip -- 槍LV2-B_引き寄せ2_先端"
+        "Spear Cleave Type - Pull - Tip"
       ]
     },
     {
       "ID": 107802116,
       "Entries": [
-        "Spear LV2-B_Attract 2_Intermediate -- 槍LV2-B_引き寄せ2_中間"
+        "Spear Cleave Type - Pull - Middle"
       ]
     },
     {
       "ID": 107802117,
       "Entries": [
-        "Spear LV2-B_Attract 2_Root -- 槍LV2-B_引き寄せ2_根元"
+        "Spear Cleave Type - Pull - Root"
       ]
     },
     {
       "ID": 107803100,
       "Entries": [
-        "Spear LV3-A_ Reservoir Charge 1 -- 槍LV3-A_溜め突撃1"
+        "Spiral Spear - Charge - Hit 1"
       ]
     },
     {
       "ID": 107803101,
       "Entries": [
-        "Spear LV3-A_ Reservoir Assault 2 -- 槍LV3-A_溜め突撃2"
+        "Spiral Spear - Charge - Hit 2"
       ]
     },
     {
       "ID": 107803102,
       "Entries": [
-        "Spear LV3-A_ Reservoir Assault 3_ Tip -- 槍LV3-A_溜め突撃3_先端"
+        "Spiral Spear - Single Thrust / Charge Final - Tip"
       ]
     },
     {
       "ID": 107803103,
       "Entries": [
-        "Spear LV3-A_Pump Charge 3_Intermediate -- 槍LV3-A_溜め突撃3_中間"
+        "Spiral Spear - Single Thrust / Charge Final - Middle"
       ]
     },
     {
       "ID": 107803104,
       "Entries": [
-        "Spear LV3-A_ Reservoir Assault 3_ Root -- 槍LV3-A_溜め突撃3_根元"
+        "Spiral Spear - Single Thrust / Charge Final - Root"
       ]
     },
     {
       "ID": 107803105,
       "Entries": [
-        "Spear LV3-A_single thrust_tip -- 槍LV3-A_単発突き_先端"
+        "Spiral Spear - Single Thrust / Charge Final - Tip"
       ]
     },
     {
       "ID": 107803106,
       "Entries": [
-        "Spear LV3-A_single thrust_intermediate -- 槍LV3-A_単発突き_中間"
+        "Spiral Spear - Single Thrust / Charge Final - Middle"
       ]
     },
     {
       "ID": 107803107,
       "Entries": [
-        "Spear LV3-A_single thrust_root -- 槍LV3-A_単発突き_根元"
+        "Spiral Spear - Single Thrust / Charge Final - Root"
       ]
     },
     {
       "ID": 107803110,
       "Entries": [
-        "Spear LV3-A_Attract 1 -- 槍LV3-A_引き寄せ1"
+        "Spiral Spear - Pull - Beginning"
       ]
     },
     {
       "ID": 107803115,
       "Entries": [
-        "Spear LV3-A_Attract 2_ Tip -- 槍LV3-A_引き寄せ2_先端"
+        "Spiral Spear - Pull - Tip"
       ]
     },
     {
       "ID": 107803116,
       "Entries": [
-        "Spear LV3-A_Attract 2_Intermediate -- 槍LV3-A_引き寄せ2_中間"
+        "Spiral Spear - Pull - Middle"
       ]
     },
     {
       "ID": 107803117,
       "Entries": [
-        "Spear LV3-A_Attract 2_Root -- 槍LV3-A_引き寄せ2_根元"
+        "Spiral Spear - Pull - Root"
       ]
     },
     {
       "ID": 107804100,
       "Entries": [
-        "Spear LV3-B_ Reservoir _ Tip -- 槍LV3-B_溜めなぎ払い_先端"
+        "Leaping Flame - Charge - Tip"
       ]
     },
     {
       "ID": 107804101,
       "Entries": [
-        "Spear LV3-B_Pump-up _Intermediate -- 槍LV3-B_溜めなぎ払い_中間"
+        "Leaping Flame - Charge - Middle"
       ]
     },
     {
       "ID": 107804102,
       "Entries": [
-        "Spear LV3-B_ Reservoir _ Root -- 槍LV3-B_溜めなぎ払い_根元"
+        "Leaping Flame - Charge - Root"
       ]
     },
     {
       "ID": 107804105,
       "Entries": [
-        "Spear LV3-B_single thrust_tip -- 槍LV3-B_単発突き_先端"
+        "Leaping Flame - Single Thrust - Tip"
       ]
     },
     {
       "ID": 107804106,
       "Entries": [
-        "Spear LV3-B_single thrust_intermediate -- 槍LV3-B_単発突き_中間"
+        "Leaping Flame - Single Thrust - Middle"
       ]
     },
     {
       "ID": 107804107,
       "Entries": [
-        "Spear LV3-B_single thrust_root -- 槍LV3-B_単発突き_根元"
+        "Leaping Flame - Single Thrust - Root"
       ]
     },
     {
       "ID": 107804110,
       "Entries": [
-        "Spear LV3-B_Attract 1 -- 槍LV3-B_引き寄せ1"
+        "Leaping Flame - Pull - Beginning"
       ]
     },
     {
       "ID": 107804115,
       "Entries": [
-        "Spear LV3-B_Pulling 2_Tips -- 槍LV3-B_引き寄せ2_先端"
+        "Leaping Flame - Pull - Tip"
       ]
     },
     {
       "ID": 107804116,
       "Entries": [
-        "Spear LV3-B_Attract 2_Intermediate -- 槍LV3-B_引き寄せ2_中間"
+        "Leaping Flame - Pull - Middle"
       ]
     },
     {
       "ID": 107804117,
       "Entries": [
-        "Spear LV3-B_Attract 2_Root -- 槍LV3-B_引き寄せ2_根元"
+        "Leaping Flame - Pull - Root"
       ]
     },
     {
       "ID": 107804297,
       "Entries": [
-        "Spear LV3-B_ Depression Force -- 槍LV3-B_恐慌フォース"
+        "Leaping Flame - Red Eyes Scare Parent"
       ]
     },
     {
       "ID": 107900100,
       "Entries": [
-        "Finger whistle_no lock_reservoir -- 指笛_ノーロック_溜め"
+        "Finger Whistle No Lock - Charge Parent"
       ]
     },
     {
       "ID": 107900101,
       "Entries": [
-        "Finger whistle_no lock -- 指笛_ノーロック"
+        "Finger Whistle No Lock - Parent"
       ]
     },
     {
       "ID": 107900110,
       "Entries": [
-        "Finger whistle_lock-on_reservoir -- 指笛_ロックオン_溜め"
+        "Finger Whistle Lock - Charge"
       ]
     },
     {
       "ID": 107900111,
       "Entries": [
-        "Finger whistle_lock on -- 指笛_ロックオン"
+        "Finger Whistle Lock - Charge Release"
       ]
     },
     {
       "ID": 107900112,
       "Entries": [
-        "Finger whistle_lock on (hanging) -- 指笛_ロックオン（ぶら下がり）"
+        "Finger Whistle Lock - Hanging"
       ]
     },
     {
       "ID": 107900114,
       "Entries": [
-        "Finger whistle_lock-on (peeping-left) -- 指笛_ロックオン（覗き込み_左）"
+        "Finger Whistle Lock - Peeping Left"
       ]
     },
     {
       "ID": 107900115,
       "Entries": [
-        "Finger whistle_lock-on (peeping-right) -- 指笛_ロックオン（覗き込み_右）"
+        "Finger Whistle Lock - Peeping Right"
       ]
     },
     {
       "ID": 107900175,
       "Entries": [
-        "Finger whistle _ sound feed slash _ accumulated bullet -- 指笛_音送り斬り_溜め弾丸"
+        "Finger Whistle - Living Force - Charge Bullet"
       ]
     },
     {
       "ID": 107900176,
       "Entries": [
-        "Finger whistle _ sound feed slash _ bullet -- 指笛_音送り斬り_弾丸"
+        "Finger Whistle - Living Force - Bullet"
       ]
     },
     {
       "ID": 107900184,
       "Entries": [
-        "Right-handed sword_strong thunder enchantment additional bullet -- 右手刀_強雷エンチャント追加弾丸"
+        "Divine Dragon Lightning Reversal"
       ]
     },
     {
       "ID": 107900190,
       "Entries": [
-        "Right hand sword_red blood enchantment additional bullet (thrust) -- 右手刀_赤血エンチャント追加弾丸（突き）"
+        "Bestowal Ninjutsu Thrust Attack"
       ]
     },
     {
       "ID": 107900191,
       "Entries": [
-        "Right hand sword_poison blood enchantment additional bullet (thrust) -- 右手刀_毒血エンチャント追加弾丸（突き）"
+        "Bestowal Ninjutsu Poison Thrust Attack"
       ]
     },
     {
       "ID": 107900192,
       "Entries": [
-        "Right hand sword_white blood enchantment additional bullet (thrust) -- 右手刀_白血エンチャント追加弾丸（突き）"
+        "Bestowal Ninjutsu Lifesteal Thrust Attack"
       ]
     },
     {
       "ID": 107900193,
       "Entries": [
-        "Right-handed sword_Weak thunder enchantment additional bullet (thrust) -- 右手刀_弱雷エンチャント追加弾丸（突き）"
+        "Non Divine Dragon Lightning Reversal"
       ]
     },
     {
       "ID": 107900195,
       "Entries": [
-        "Right-handed sword_Orange-style enchantment additional bullet (thrust) -- 右手刀_橙風エンチャント追加弾丸（突き）"
+        ""
       ]
     },
     {
       "ID": 107900196,
       "Entries": [
-        "Right hand sword_Kinfu enchantment additional bullet (thrust) -- 右手刀_金風エンチャント追加弾丸（突き）"
+        ""
       ]
     },
     {
       "ID": 107900999,
       "Entries": [
-        "Finger whistle_form consumption dummy -- 指笛_形代消費ダミー"
+        "Prosthetic Tool - Spirit Emblem Consumption Dummy"
       ]
     },
     {
       "ID": 107902100,
       "Entries": [
-        "Finger whistle LV3_no lock_reservoir -- 指笛LV3_ノーロック_溜め"
+        "Malcontent No Lock - Charge Parent"
       ]
     },
     {
       "ID": 107902101,
       "Entries": [
-        "Finger whistle LV3_ no lock -- 指笛LV3_ノーロック"
+        "Malcontent No Lock - Parent"
       ]
     },
     {
       "ID": 107902110,
       "Entries": [
-        "Finger whistle LV3_lock-on_reservoir -- 指笛LV3_ロックオン_溜め"
+        "Malcontent Lock - Charge"
       ]
     },
     {
       "ID": 107902111,
       "Entries": [
-        "Finger whistle LV3_ lock on -- 指笛LV3_ロックオン"
+        "Malcontent Lock - Charge Release"
       ]
     },
     {
       "ID": 107902112,
       "Entries": [
-        "Finger whistle LV3_ lock on (hanging) -- 指笛LV3_ロックオン（ぶら下がり）"
+        "Malcontent Lock - Hanging"
       ]
     },
     {
       "ID": 107902114,
       "Entries": [
-        "Finger whistle LV3_lock on (peeping_left) -- 指笛LV3_ロックオン（覗き込み_左）"
+        "Malcontent Lock - Peeping Left"
       ]
     },
     {
       "ID": 107902115,
       "Entries": [
-        "Finger whistle LV3_lock on (peeping_right) -- 指笛LV3_ロックオン（覗き込み_右）"
+        "Malcontent Lock - Peeping Right"
       ]
     },
     {
       "ID": 107902175,
       "Entries": [
-        "Finger whistle LV3_Sound feed slash_Reservoir bullet -- 指笛LV3_音送り斬り_溜め弾丸"
+        "Malcontent - Living Force - Charge Bullet"
       ]
     },
     {
       "ID": 107902176,
       "Entries": [
-        "Finger whistle LV3_sound feed slash_bullet -- 指笛LV3_音送り斬り_弾丸"
+        "Malcontent - Living Force - Bullet"
       ]
     },
     {
       "ID": 109500000,
       "Entries": [
-        "Wire Weapon_Injection -- ワイヤー武器_射出"
+        "Grappling Hook Stab"
       ]
     },
     {

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/BehaviorParam_PC.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/BehaviorParam_PC.json
@@ -16,67 +16,67 @@
     {
       "ID": 10,
       "Entries": [
-        "PC_common_ egg attack -- PC_共通_卵攻撃"
+        ""
       ]
     },
     {
       "ID": 200,
       "Entries": [
-        "Contact impact_in-game start -- 接触衝撃_インゲーム開始"
+        "Impact"
       ]
     },
     {
       "ID": 210,
       "Entries": [
-        "Contact impact_weak_upper and lower wrap -- 接触衝撃_弱_上下包み"
+        "Impact"
       ]
     },
     {
       "ID": 211,
       "Entries": [
-        "Contact impact_weak_origin wrap -- 接触衝撃_弱_原点包み"
+        "Impact"
       ]
     },
     {
       "ID": 220,
       "Entries": [
-        "Contact impact_middle_upper and lower wrap -- 接触衝撃_中_上下包み"
+        "Impact"
       ]
     },
     {
       "ID": 221,
       "Entries": [
-        "Contact impact_medium_origin wrap -- 接触衝撃_中_原点包み"
+        "Impact"
       ]
     },
     {
       "ID": 222,
       "Entries": [
-        "Contact impact_middle_below origin -- 接触衝撃_中_原点下方"
+        "Impact"
       ]
     },
     {
       "ID": 280,
       "Entries": [
-        "Foot for SFX / right foot -- フットSFX用/右足"
+        "Right foot for SFX"
       ]
     },
     {
       "ID": 281,
       "Entries": [
-        "Foot for SFX / left foot -- フットSFX用/左足"
+        "Left foot for SFX"
       ]
     },
     {
       "ID": 285,
       "Entries": [
-        "Hand for SFX / right hand -- ハンドSFX用/右手"
+        "Right hand for SFX"
       ]
     },
     {
       "ID": 286,
       "Entries": [
-        "Hand for SFX / left hand -- ハンドSFX用/左手"
+        "Left hand for SFX"
       ]
     },
     {
@@ -964,13 +964,13 @@
     {
       "ID": 105002200,
       "Entries": [
-        "School Technique_Dive Slash 1 -- 流派技_飛び込み斬り1"
+        "Nightjar Slash"
       ]
     },
     {
       "ID": 105002201,
       "Entries": [
-        "School Technique_Dive Slash 2 -- 流派技_飛び込み斬り2"
+        "Nightjar Slash Reversal"
       ]
     },
     {
@@ -3622,49 +3622,49 @@
     {
       "ID": 150100000,
       "Entries": [
-        "Test Shinobi 1 Grab -- テスト忍殺1掴み"
+        ""
       ]
     },
     {
       "ID": 150100010,
       "Entries": [
-        "Test Shinobi 2 Grab -- テスト忍殺2掴み"
+        ""
       ]
     },
     {
       "ID": 150200000,
       "Entries": [
-        "Test Shinobi 1 Grab -- テスト忍殺1掴み"
+        ""
       ]
     },
     {
       "ID": 150200010,
       "Entries": [
-        "Test Shinobi 2 Grab -- テスト忍殺2掴み"
+        ""
       ]
     },
     {
       "ID": 150300000,
       "Entries": [
-        "Test Shinobi 1 Grab -- テスト忍殺1掴み"
+        ""
       ]
     },
     {
       "ID": 150300010,
       "Entries": [
-        "Test Shinobi 2 Grab -- テスト忍殺2掴み"
+        ""
       ]
     },
     {
       "ID": 150400000,
       "Entries": [
-        "Test Shinobi 1 Grab -- テスト忍殺1掴み"
+        ""
       ]
     },
     {
       "ID": 150400010,
       "Entries": [
-        "Test Shinobi 2 Grab -- テスト忍殺2掴み"
+        ""
       ]
     }
   ]

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/BudgetParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/BudgetParam.json
@@ -4,7 +4,7 @@
     {
       "ID": 0,
       "Entries": [
-        "Default (no deletion) -- デフォルト(削除禁止)"
+        "Default"
       ]
     }
   ]

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/Bullet.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/Bullet.json
@@ -4,79 +4,79 @@
     {
       "ID": 0,
       "Entries": [
-        "test -- テスト"
+        ""
       ]
     },
     {
       "ID": 1,
       "Entries": [
-        "Magic test -- 魔法テスト"
+        ""
       ]
     },
     {
       "ID": 2,
       "Entries": [
-        "Funnel test -- ファンネルテスト"
+        ""
       ]
     },
     {
       "ID": 3,
       "Entries": [
-        "Flying Dragon Breath Test -- 飛竜\u3000ブレステスト"
+        ""
       ]
     },
     {
       "ID": 4,
       "Entries": [
-        "For destroying automatic patrol objects -- 自動巡回オブジェ破壊用"
+        "For destroying automatic patrol objects"
       ]
     },
     {
       "ID": 6,
       "Entries": [
-        "For automatic patrol object destruction_for debug function verification -- 自動巡回オブジェ破壊用_デバッグ機能検証用"
+        "Dummy for debug"
       ]
     },
     {
       "ID": 50,
       "Entries": [
-        "Bonfire recovery effect -- かがり火回復効果"
+        "Idol Recovery Effect"
       ]
     },
     {
       "ID": 60,
       "Entries": [
-        "Bullet Random Number Test_Parent -- 弾丸乱数テスト_親"
+        ""
       ]
     },
     {
       "ID": 61,
       "Entries": [
-        "Bullet random number test_child -- 弾丸乱数テスト_子"
+        ""
       ]
     },
     {
       "ID": 62,
       "Entries": [
-        "Long-range magic: Flame to pierce_Begin to appear -- 遠距離魔法：穿つ炎_出始め"
+        ""
       ]
     },
     {
       "ID": 63,
       "Entries": [
-        "Long-range magic: Flame to wear_Parent -- 遠距離魔法：穿つ炎_親"
+        ""
       ]
     },
     {
       "ID": 64,
       "Entries": [
-        "Long-range magic: Flame to pierce_Search bullet -- 遠距離魔法：穿つ炎_検索弾"
+        ""
       ]
     },
     {
       "ID": 65,
       "Entries": [
-        "Long-range magic: Flame _ child to wear -- 遠距離魔法：穿つ炎_子"
+        ""
       ]
     },
     {
@@ -100,229 +100,229 @@
     {
       "ID": 300,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Normal_Reaction Playback -- 忍殺忍術_血煙_通常_リアクション再生"
+        "Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 301,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Normal_Blind Effect + Eye Shield -- 忍殺忍術_血煙_通常_盲目効果 + 視線遮蔽"
+        "Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 360,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_Red Blood_Parent_Early_Early_Reaction Playback -- 忍殺忍術_血煙_放射_赤血_親_序盤_リアクション再生"
+        "Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 361,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_Red Blood_Parent_Early_Blind Effect + Eye Shield -- 忍殺忍術_血煙_放射_赤血_親_序盤_盲目効果 + 視線遮蔽"
+        "Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 362,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_Red Blood_Parent_Middle_Reaction Playback -- 忍殺忍術_血煙_放射_赤血_親_中盤_リアクション再生"
+        "Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 363,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_Red Blood_Parent_Middle_Blind Effect + Eye Shield -- 忍殺忍術_血煙_放射_赤血_親_中盤_盲目効果 + 視線遮蔽"
+        "Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 364,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_Red Blood_Parent_Late Stage_Reaction Playback -- 忍殺忍術_血煙_放射_赤血_親_終盤_リアクション再生"
+        "Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 365,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_Red Blood_Parent_Late Stage_Blind Effect + Eye Shield -- 忍殺忍術_血煙_放射_赤血_親_終盤_盲目効果 + 視線遮蔽"
+        "Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 366,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_Red Blood_Child_Early_Reaction Playback -- 忍殺忍術_血煙_放射_赤血_子_序盤_リアクション再生"
+        "Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 367,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_Red Blood_Child_Early_Blind Effect + Eye Shield -- 忍殺忍術_血煙_放射_赤血_子_序盤_盲目効果 + 視線遮蔽"
+        "Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 368,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_Red Blood_Child_Middle_Reaction Playback -- 忍殺忍術_血煙_放射_赤血_子_中盤_リアクション再生"
+        "Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 369,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_Red Blood_Child_Middle_Blind Effect + Eye Shield -- 忍殺忍術_血煙_放射_赤血_子_中盤_盲目効果 + 視線遮蔽"
+        "Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 370,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_Red Blood_Child_Late Stage_Reaction Playback -- 忍殺忍術_血煙_放射_赤血_子_終盤_リアクション再生"
+        "Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 371,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_Red Blood_Child_Late Stage_Blind Effect + Eye Shield -- 忍殺忍術_血煙_放射_赤血_子_終盤_盲目効果 + 視線遮蔽"
+        "Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 375,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_Poisonous Blood_Parent_Early_Reaction Playback -- 忍殺忍術_血煙_放射_毒血_親_序盤_リアクション再生"
+        "Poison Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 376,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_Poisonous Blood_Parent_Early_Blind Effect + Eye Shield + Poison -- 忍殺忍術_血煙_放射_毒血_親_序盤_盲目効果 + 視線遮蔽 + 毒"
+        "Poison Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 377,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_Poisonous Blood_Parent_Middle_Reaction Playback -- 忍殺忍術_血煙_放射_毒血_親_中盤_リアクション再生"
+        "Poison Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 378,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_Poisonous Blood_Parent_Middle_Blind Effect + Line of Sight + Poison -- 忍殺忍術_血煙_放射_毒血_親_中盤_盲目効果 + 視線遮蔽 + 毒"
+        "Poison Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 379,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_Poisonous Blood_Parent_Late Stage_Reaction Playback -- 忍殺忍術_血煙_放射_毒血_親_終盤_リアクション再生"
+        "Poison Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 380,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_Poisonous Blood_Parent_Late Stage_Blind Effect + Eye Shield + Poison -- 忍殺忍術_血煙_放射_毒血_親_終盤_盲目効果 + 視線遮蔽 + 毒"
+        "Poison Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 381,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_Poisonous Blood_Child_Early_Reaction Playback -- 忍殺忍術_血煙_放射_毒血_子_序盤_リアクション再生"
+        "Poison Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 382,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_Poisonous Blood_Child_Early_Blind Effect + Gaze Shielding + Poison -- 忍殺忍術_血煙_放射_毒血_子_序盤_盲目効果 + 視線遮蔽 + 毒"
+        "Poison Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 383,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_Poisonous Blood_Child_Middle_Reaction Playback -- 忍殺忍術_血煙_放射_毒血_子_中盤_リアクション再生"
+        "Poison Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 384,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_Poisonous Blood_Child_Middle_Blind Effect + Line of Sight + Poison -- 忍殺忍術_血煙_放射_毒血_子_中盤_盲目効果 + 視線遮蔽 + 毒"
+        "Poison Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 385,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_Poisonous Blood_Child_Late Stage_Reaction Playback -- 忍殺忍術_血煙_放射_毒血_子_終盤_リアクション再生"
+        "Poison Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 386,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_Poisonous Blood_Child_Late _Blind Effect + Eye-shielding + Poison -- 忍殺忍術_血煙_放射_毒血_子_終盤_盲目効果 + 視線遮蔽 + 毒"
+        "Poison Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 390,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_White Blood_Parent_Early_Early_Reaction Playback -- 忍殺忍術_血煙_放射_白血_親_序盤_リアクション再生"
+        "Lifesteal Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 391,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_White Blood_Parent_Early_Blind Effect + Gaze Shielding + Recovery -- 忍殺忍術_血煙_放射_白血_親_序盤_盲目効果 + 視線遮蔽 + 回復"
+        "Lifesteal Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 392,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_White Blood_Parent_Middle_Reaction Playback -- 忍殺忍術_血煙_放射_白血_親_中盤_リアクション再生"
+        "Lifesteal Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 393,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_White Blood_Parent_Middle_Blind Effect + Gaze Shielding + Recovery -- 忍殺忍術_血煙_放射_白血_親_中盤_盲目効果 + 視線遮蔽 + 回復"
+        "Lifesteal Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 394,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_White Blood_Parent_Late Stage_Reaction Playback -- 忍殺忍術_血煙_放射_白血_親_終盤_リアクション再生"
+        "Lifesteal Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 395,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_White Blood_Parent_Late Stage_Blind Effect + Gaze Shielding + Recovery -- 忍殺忍術_血煙_放射_白血_親_終盤_盲目効果 + 視線遮蔽 + 回復"
+        "Lifesteal Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 396,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_White Blood_Child_Early_Reaction Playback -- 忍殺忍術_血煙_放射_白血_子_序盤_リアクション再生"
+        "Lifesteal Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 397,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_White Blood_Child_Early_Blind Effect + Gaze Shielding + Recovery -- 忍殺忍術_血煙_放射_白血_子_序盤_盲目効果 + 視線遮蔽 + 回復"
+        "Lifesteal Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 398,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_White Blood_Child_Middle_Reaction Playback -- 忍殺忍術_血煙_放射_白血_子_中盤_リアクション再生"
+        "Lifesteal Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 399,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_White Blood_Child_Middle_Blind Effect + Gaze Shielding + Recovery -- 忍殺忍術_血煙_放射_白血_子_中盤_盲目効果 + 視線遮蔽 + 回復"
+        "Lifesteal Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 400,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_White Blood_Child_Late Stage_Reaction Playback -- 忍殺忍術_血煙_放射_白血_子_終盤_リアクション再生"
+        "Lifesteal Bloodsmoke Ninjutsu"
       ]
     },
     {
       "ID": 401,
       "Entries": [
-        "Ninjutsu Ninjutsu_Blood Smoke_Radiation_White Blood_Child_Late Stage_Blind Effect + Eye Shield + Recovery -- 忍殺忍術_血煙_放射_白血_子_終盤_盲目効果 + 視線遮蔽 + 回復"
+        "Lifesteal Bloodsmoke Ninjutsu"
       ]
     },
     {
@@ -5956,3235 +5956,3235 @@
     {
       "ID": 50000300,
       "Entries": [
-        "c5000_Recon Monk_Pinpoint Magic [Searching Enemies] -- c5000_破戒僧_ピンポイント呪術【索敵】"
+        "Corrupted Monk"
       ]
     },
     {
       "ID": 50000301,
       "Entries": [
-        "c5000_Burning Monk_Pinpoint Magic [Omen] -- c5000_破戒僧_ピンポイント呪術【予兆】"
+        "Corrupted Monk"
       ]
     },
     {
       "ID": 50000302,
       "Entries": [
-        "c5000_Burning Monk_Pinpoint Magic [Main Body] -- c5000_破戒僧_ピンポイント呪術【本体】"
+        "Corrupted Monk"
       ]
     },
     {
       "ID": 50000310,
       "Entries": [
-        "c5000_Burning Monk_Wide Range Magic_Center (with SFX) -- c5000_破戒僧_広範囲幻術_中央（SFX有）"
+        "Corrupted Monk"
       ]
     },
     {
       "ID": 50000311,
       "Entries": [
-        "c5000_Burning Monk_Wide Range Magic_End (without SFX) -- c5000_破戒僧_広範囲幻術_端（SFX無）"
+        "Corrupted Monk"
       ]
     },
     {
       "ID": 50000400,
       "Entries": [
-        "c5000_Burning Monk_Naginata_Normal Position_Mushi Radiation_Parent 1 -- c5000_破戒僧_薙刀_通常構え_蟲放射_親1"
+        "Corrupted Monk"
       ]
     },
     {
       "ID": 50000401,
       "Entries": [
-        "c5000_Burning Monk_Naginata_Normal Position_Mushi Radiation_Parent 2 -- c5000_破戒僧_薙刀_通常構え_蟲放射_親2"
+        "Corrupted Monk"
       ]
     },
     {
       "ID": 50000402,
       "Entries": [
-        "c5000_Burning Monk_Naginata_Normal Position_Mushi Radiation_Parent 3 -- c5000_破戒僧_薙刀_通常構え_蟲放射_親3"
+        "Corrupted Monk"
       ]
     },
     {
       "ID": 50000408,
       "Entries": [
-        "c5000_Burning Monk_Naginata_Normal Position_Mushi Radiation_Child -- c5000_破戒僧_薙刀_通常構え_蟲放射_子"
+        "Corrupted Monk"
       ]
     },
     {
       "ID": 50000409,
       "Entries": [
-        "c5000_Burning Monk_Naginata_Normal Position_Mushi Radiation_Grandson -- c5000_破戒僧_薙刀_通常構え_蟲放射_孫"
+        "Corrupted Monk"
       ]
     },
     {
       "ID": 50000980,
       "Entries": [
-        "c5000_Burning Monk_Dummy Bullet_Dangerous Attack -- c5000_破戒僧_ダミー弾丸_危険な攻撃"
+        "Corrupted Monk - Perilous Attack Warning"
       ]
     },
     {
       "ID": 50000981,
       "Entries": [
-        "c5000_Burning Monk_Dummy Bullet_Dangerous Attack_Running Bottom -- c5000_破戒僧_ダミー弾丸_危険な攻撃_走り込み下段"
+        "Corrupted Monk - Perilous Attack Warning"
       ]
     },
     {
       "ID": 50100100,
       "Entries": [
-        "c5010_Large snake_Snow splash_For grounding judgment -- c5010_大蛇_雪飛沫_接地判定用"
+        "Great Serpent - Snow"
       ]
     },
     {
       "ID": 50100101,
       "Entries": [
-        "c5010_Large snake_Snow splash_Main body -- c5010_大蛇_雪飛沫_本体"
+        "Great Serpent - Snow"
       ]
     },
     {
       "ID": 50100990,
       "Entries": [
-        "c5010_Large Snake_Dummy Bullet_Dangerous Attack -- c5010_大蛇_ダミー弾丸_危険な攻撃"
+        "Great Serpent - Perilous Attack Warning"
       ]
     },
     {
       "ID": 50102800,
       "Entries": [
-        "c5010_Large snake_Stuck vibration_Suspension bridge -- c5010_大蛇_足止め振動_吊り橋"
+        "Great Serpent"
       ]
     },
     {
       "ID": 50103930,
       "Entries": [
-        "c5010_Large snake_Geyser_Poisonous fog_Spout -- c5010_大蛇_間欠泉_毒霧_噴出"
+        "Great Serpent - Cave Poison Mist"
       ]
     },
     {
       "ID": 50103940,
       "Entries": [
-        "c5010_Large snake_Geyser_Poison fog_Stay -- c5010_大蛇_間欠泉_毒霧_滞留"
+        "Great Serpent - Cave Poison Mist"
       ]
     },
     {
       "ID": 50200101,
       "Entries": [
-        "c5020_Akaoni_Earthquake [Searching enemy] 1 -- c5020_赤鬼_地震【索敵】1"
+        "Chained Ogre - Breakable Object Attack"
       ]
     },
     {
       "ID": 50200102,
       "Entries": [
-        "c5020_Akaoni_Earthquake [Prediction] 1 -- c5020_赤鬼_地震【予兆】1"
+        "Chained Ogre - Breakable Object Attack"
       ]
     },
     {
       "ID": 50200103,
       "Entries": [
-        "c5020_Red Demon_Parent_Remains -- c5020_赤鬼_親_残る"
+        "Chained Ogre - Breakable Object Attack"
       ]
     },
     {
       "ID": 50200104,
       "Entries": [
-        "c5020_ Red Demon [Searching enemy] 2 -- c5020_赤鬼【索敵】2"
+        "Chained Ogre - Breakable Object Attack"
       ]
     },
     {
       "ID": 50200105,
       "Entries": [
-        "c5020_ Red Demon [Sign] 2 -- c5020_赤鬼【予兆】2"
+        "Chained Ogre - Breakable Object Attack"
       ]
     },
     {
       "ID": 50200106,
       "Entries": [
-        "c5020_Akaoni_Parent_Birth a child -- c5020_赤鬼_親_子を産む"
+        "Chained Ogre - Breakable Object Attack"
       ]
     },
     {
       "ID": 50200107,
       "Entries": [
-        "c5020_Akaoni_Child_Remains -- c5020_赤鬼_子_残る"
+        "Chained Ogre - Breakable Object Attack"
       ]
     },
     {
       "ID": 50200108,
       "Entries": [
-        "c5020_ Red Demon [Searching enemy] 3 -- c5020_赤鬼【索敵】3"
+        "Chained Ogre - Breakable Object Attack"
       ]
     },
     {
       "ID": 50200109,
       "Entries": [
-        "c5020_ Red Demon [Sign] 3 -- c5020_赤鬼【予兆】3"
+        "Chained Ogre - Breakable Object Attack"
       ]
     },
     {
       "ID": 50200110,
       "Entries": [
-        "c5020_Akaoni_Parent_Grandchildren -- c5020_赤鬼_親_孫を産む子を産む"
+        "Chained Ogre - Breakable Object Attack"
       ]
     },
     {
       "ID": 50200111,
       "Entries": [
-        "c5020_Akaoni_Child_Grandchild -- c5020_赤鬼_子_孫を産む"
+        "Chained Ogre - Breakable Object Attack"
       ]
     },
     {
       "ID": 50200112,
       "Entries": [
-        "c5020_Red Demon_Grandson_Remains -- c5020_赤鬼_孫_残る"
+        "Chained Ogre - Breakable Object Attack"
       ]
     },
     {
       "ID": 50200560,
       "Entries": [
-        "c5020_Akaoni_Earthquake [Searching enemy] 1 -- c5020_赤鬼_地震【索敵】1"
+        "Chained Ogre - Breakable Object Attack"
       ]
     },
     {
       "ID": 50200561,
       "Entries": [
-        "c5020_Akaoni_Earthquake [Prediction] 1 -- c5020_赤鬼_地震【予兆】1"
+        "Chained Ogre - Breakable Object Attack"
       ]
     },
     {
       "ID": 50200562,
       "Entries": [
-        "c5020_Red Demon_Parent_Remains -- c5020_赤鬼_親_残る"
+        "Chained Ogre - Breakable Object Attack"
       ]
     },
     {
       "ID": 50200563,
       "Entries": [
-        "c5020_ Red Demon [Searching enemy] 2 -- c5020_赤鬼【索敵】2"
+        "Chained Ogre - Breakable Object Attack"
       ]
     },
     {
       "ID": 50200564,
       "Entries": [
-        "c5020_ Red Demon [Sign] 2 -- c5020_赤鬼【予兆】2"
+        "Chained Ogre - Breakable Object Attack"
       ]
     },
     {
       "ID": 50200565,
       "Entries": [
-        "c5020_Akaoni_Parent_Birth a child -- c5020_赤鬼_親_子を産む"
+        "Chained Ogre - Breakable Object Attack"
       ]
     },
     {
       "ID": 50200566,
       "Entries": [
-        "c5020_Akaoni_Child_Remains -- c5020_赤鬼_子_残る"
+        "Chained Ogre - Breakable Object Attack"
       ]
     },
     {
       "ID": 50200600,
       "Entries": [
-        "c5020_ Red Demon [Searching enemy] 2 -- c5020_赤鬼【索敵】2"
+        "Chained Ogre - Breakable Object Attack"
       ]
     },
     {
       "ID": 50200601,
       "Entries": [
-        "c5020_ Red Demon [Sign] 2 -- c5020_赤鬼【予兆】2"
+        "Chained Ogre - Breakable Object Attack"
       ]
     },
     {
       "ID": 50200602,
       "Entries": [
-        "c5020_Akaoni_Parent remains -- c5020_赤鬼_親\u3000残る"
+        "Chained Ogre - Breakable Object Attack"
       ]
     },
     {
       "ID": 50200980,
       "Entries": [
-        "c5020_Akaoni_Dummy bullet_Dangerous attack sign Grab both hands on the spot -- c5020_赤鬼_ダミー弾丸_危険な攻撃予兆\u3000その場両手掴み"
+        "Chained Ogre - Perilous Attack Warning"
       ]
     },
     {
       "ID": 50200981,
       "Entries": [
-        "c5020_Red Demon_Dummy Bullet_Dangerous Attack Prediction Medium-range two-handed grab -- c5020_赤鬼_ダミー弾丸_危険な攻撃予兆\u3000中距離両手掴み"
+        "Chained Ogre - Perilous Attack Warning"
       ]
     },
     {
       "ID": 50200982,
       "Entries": [
-        "c5020_Akaoni_Dummy bullet_Dangerous attack sign -- c5020_赤鬼_ダミー弾丸_危険な攻撃予兆\u3000遠距離両手掴み"
+        "Chained Ogre - Perilous Attack Warning"
       ]
     },
     {
       "ID": 50200983,
       "Entries": [
-        "c5020_Red Demon_Dummy Bullet_Dangerous Attack Prediction Medium Range Tackle -- c5020_赤鬼_ダミー弾丸_危険な攻撃予兆\u3000中距離タックル"
+        "Chained Ogre - Perilous Attack Warning"
       ]
     },
     {
       "ID": 50200984,
       "Entries": [
-        "c5020_Red Demon_Dummy Bullet_Dangerous Attack Prediction Long Range Tackle -- c5020_赤鬼_ダミー弾丸_危険な攻撃予兆\u3000遠距離タックル"
+        "Chained Ogre - Perilous Attack Warning"
       ]
     },
     {
       "ID": 50310110,
       "Entries": [
-        "c5031_Straw doll bug_Venom -- c5031_藁人形の蟲_毒液"
+        ""
       ]
     },
     {
       "ID": 50500071,
       "Entries": [
-        "c5050_Nishikigoi_Rampaging_Underwater tornado -- c5050_錦鯉_暴れる_水中竜巻"
+        "Great Colored Carp - Attack"
       ]
     },
     {
       "ID": 50500900,
       "Entries": [
-        "c5050_Nishikigoi_Collision detection sonar -- c5050_錦鯉_衝突検出ソナー"
+        "Great Colored Carp - Collision Detection"
       ]
     },
     {
       "ID": 50500901,
       "Entries": [
-        "c5050_Nishikigoi_Collision detection sonar_Reflection -- c5050_錦鯉_衝突検出ソナー_反射"
+        "Great Colored Carp - Collision Detection"
       ]
     },
     {
       "ID": 50500980,
       "Entries": [
-        "c5050_Nishikigoi_Dummy bullet_Dangerous attack sign_100m -- c5050_錦鯉_ダミー弾丸_危険な攻撃予兆_100m"
+        "Great Colored Carp - Perilous Attack Warning"
       ]
     },
     {
       "ID": 50500981,
       "Entries": [
-        "c5050_Nishikigoi_Dummy bullet_Dangerous attack sign_30m -- c5050_錦鯉_ダミー弾丸_危険な攻撃予兆_30m"
+        "Great Colored Carp - Perilous Attack Warning"
       ]
     },
     {
       "ID": 50600131,
       "Entries": [
-        "c5060: Chief of Ninja Army_Somersault Shuriken -- c5060：忍軍の長_宙返り手裏剣"
+        "Owl - Kickoff Shuriken"
       ]
     },
     {
       "ID": 50600150,
       "Entries": [
-        "c5060: Chief of Ninja Army_Shuriken -- c5060：忍軍の長_手裏剣"
+        "Owl - Shuriken"
       ]
     },
     {
       "ID": 50600160,
       "Entries": [
-        "c5060: Chief of Ninja Army_Firecracker Parent A -- c5060：忍軍の長_爆竹親A"
+        "Owl - Firecracker"
       ]
     },
     {
       "ID": 50600161,
       "Entries": [
-        "c5060: Chief of Ninja Army_Firecracker Parent B -- c5060：忍軍の長_爆竹親B"
+        "Owl - Firecracker"
       ]
     },
     {
       "ID": 50600162,
       "Entries": [
-        "c5060: Chief of Ninja Army_Firecracker Parent C -- c5060：忍軍の長_爆竹親C"
+        "Owl - Firecracker"
       ]
     },
     {
       "ID": 50600163,
       "Entries": [
-        "c5060: Chief of Ninja Army_Firecracker Parent D -- c5060：忍軍の長_爆竹親D"
+        "Owl - Firecracker"
       ]
     },
     {
       "ID": 50600164,
       "Entries": [
-        "c5060: Chief of Ninja Army_Firecracker A -- c5060：忍軍の長_爆竹子A"
+        "Owl - Firecracker"
       ]
     },
     {
       "ID": 50600165,
       "Entries": [
-        "c5060: Chief of Ninja Army_Firecracker B -- c5060：忍軍の長_爆竹子B"
+        "Owl - Firecracker"
       ]
     },
     {
       "ID": 50600166,
       "Entries": [
-        "c5060: Chief of Ninja Army_Firecracker C -- c5060：忍軍の長_爆竹子C"
+        "Owl - Firecracker"
       ]
     },
     {
       "ID": 50600167,
       "Entries": [
-        "c5060: Chief of Ninja Army_Firecracker D -- c5060：忍軍の長_爆竹子D"
+        "Owl - Firecracker"
       ]
     },
     {
       "ID": 50600168,
       "Entries": [
-        "c5060: Chief of Ninja Army_Firecracker Grandson -- c5060：忍軍の長_爆竹孫"
+        "Owl - Firecracker"
       ]
     },
     {
       "ID": 50600190,
       "Entries": [
-        "c5060: Chief of Ninja Army_Firecracker Parent A -- c5060：忍軍の長_爆竹親A"
+        "Owl - Firecracker"
       ]
     },
     {
       "ID": 50600195,
       "Entries": [
-        "c5060: Chief of Ninja Army_Firecracker A -- c5060：忍軍の長_爆竹子A"
+        "Owl - Firecracker"
       ]
     },
     {
       "ID": 50600200,
       "Entries": [
-        "c5060: Chief of Ninja Army_Firecracker Grandson_Firecracker Explosion &amp; Damage -- c5060：忍軍の長_爆竹孫_爆竹破裂＆ダメージ"
+        "Owl - Firecracker"
       ]
     },
     {
       "ID": 50600201,
       "Entries": [
-        "c5060: Chief of Ninja Army_Firecracker Son_Flame -- c5060：忍軍の長_爆竹孫_炎"
+        "Owl - Firecracker"
       ]
     },
     {
       "ID": 50600250,
       "Entries": [
-        "c5060: Chief of Ninja Army_Explosion Parent Dummy A -- c5060：忍軍の長_爆炎親ダミーA"
+        "Owl - Firecracker Explosion Attack"
       ]
     },
     {
       "ID": 50600251,
       "Entries": [
-        "c5060: Chief of Ninja Army_Explosion Parent Dummy B -- c5060：忍軍の長_爆炎親ダミーB"
+        "Owl - Firecracker Explosion Attack"
       ]
     },
     {
       "ID": 50600252,
       "Entries": [
-        "c5060: Chief of Ninja Army_Explosion Parent Dummy C -- c5060：忍軍の長_爆炎親ダミーC"
+        "Owl - Firecracker Explosion Attack"
       ]
     },
     {
       "ID": 50600253,
       "Entries": [
-        "c5060: Chief of Ninja Army_Explosion Parent Dummy D -- c5060：忍軍の長_爆炎親ダミーD"
+        "Owl - Firecracker Explosion Attack"
       ]
     },
     {
       "ID": 50600254,
       "Entries": [
-        "c5060: Chief of Ninja Army_Explosion Parent Dummy E -- c5060：忍軍の長_爆炎親ダミーE"
+        "Owl - Firecracker Explosion Attack"
       ]
     },
     {
       "ID": 50600255,
       "Entries": [
-        "c5060: Chief of Ninja Army_Explosive Child Dummy A -- c5060：忍軍の長_爆炎子ダミーA"
+        "Owl - Firecracker Explosion Attack"
       ]
     },
     {
       "ID": 50600256,
       "Entries": [
-        "c5060: Chief of Ninja Army_Bomb Flame Child Dummy B -- c5060：忍軍の長_爆炎子ダミーB"
+        "Owl - Firecracker Explosion Attack"
       ]
     },
     {
       "ID": 50600257,
       "Entries": [
-        "c5060: Chief of Ninja Army_Bomb Flame Child Dummy C -- c5060：忍軍の長_爆炎子ダミーC"
+        "Owl - Firecracker Explosion Attack"
       ]
     },
     {
       "ID": 50600258,
       "Entries": [
-        "c5060: Ninja Army Chief_Explosion Child Dummy D -- c5060：忍軍の長_爆炎子ダミーD"
+        "Owl - Firecracker Explosion Attack"
       ]
     },
     {
       "ID": 50600259,
       "Entries": [
-        "c5060: Chief of Ninja Army_Bomb Flame Child Dummy E -- c5060：忍軍の長_爆炎子ダミーE"
+        "Owl - Firecracker Explosion Attack"
       ]
     },
     {
       "ID": 50600260,
       "Entries": [
-        "c5060: Chief of Ninja Army_Explosion Grandson_Explosion of Firecracker -- c5060：忍軍の長_爆炎孫_爆竹破裂"
+        "Owl - Firecracker Explosion Attack"
       ]
     },
     {
       "ID": 50600261,
       "Entries": [
-        "c5060: Chief of Ninja Army_Explosion Grandson_Flame -- c5060：忍軍の長_爆炎孫_炎"
+        "Owl - Firecracker Explosion Attack"
       ]
     },
     {
       "ID": 50600700,
       "Entries": [
-        "c5060: Chief of Ninja Army_Poison Ball Throwing A_Parent -- c5060：忍軍の長_毒玉投擲A_親"
+        "Owl - Poison Throw"
       ]
     },
     {
       "ID": 50600701,
       "Entries": [
-        "c5060: Chief of Ninja Army_Poison Ball Throwing A_Poison Floor Drop -- c5060：忍軍の長_毒玉投擲A_毒床落とし"
+        "Owl - Poison Throw"
       ]
     },
     {
       "ID": 50600702,
       "Entries": [
-        "c5060: Chief of Ninja Army_Poison Ball Throwing A_Poison Bed Installation -- c5060：忍軍の長_毒玉投擲A_毒床設置"
+        "Owl - Poison Throw"
       ]
     },
     {
       "ID": 50600710,
       "Entries": [
-        "c5060: Chief of Ninja Army_Recovery Sealed Throwing_Parent -- c5060：忍軍の長_回復封じ投擲_親"
+        "Owl - Heal Block"
       ]
     },
     {
       "ID": 50600711,
       "Entries": [
-        "c5060: Chief of Ninja Army_Recovery Sealed Throwing_Child -- c5060：忍軍の長_回復封じ投擲_子"
+        "Owl - Heal Block"
       ]
     },
     {
       "ID": 50600720,
       "Entries": [
-        "c5060: Chief of Ninja Army_Smoke Screen -- c5060：忍軍の長_煙幕"
+        "Owl - Smoke Bomb"
       ]
     },
     {
       "ID": 50600721,
       "Entries": [
-        "c5060: Chief of Ninja Army_Smoke Screen_Dazzle -- c5060：忍軍の長_煙幕_目くらまし"
+        "Owl - Smoke Bomb"
       ]
     },
     {
       "ID": 50600730,
       "Entries": [
-        "c5060: Chief of Ninja Army_Poison Ball Throwing B_Parent -- c5060：忍軍の長_毒玉投擲B_親"
+        "Owl - Poison Throw"
       ]
     },
     {
       "ID": 50600731,
       "Entries": [
-        "c5060: Chief of Ninja Army_Poison Ball Throwing B_Poison Floor Drop -- c5060：忍軍の長_毒玉投擲B_毒床落とし"
+        "Owl - Poison Throw"
       ]
     },
     {
       "ID": 50600732,
       "Entries": [
-        "c5060: Chief of Ninja Army_Poison Ball Throwing B_Poison Bed Installation -- c5060：忍軍の長_毒玉投擲B_毒床設置"
+        "Owl - Poison Throw"
       ]
     },
     {
       "ID": 50600740,
       "Entries": [
-        "c5060: Chief of Ninja Army_Poison Ball Throwing C_Parent -- c5060：忍軍の長_毒玉投擲C_親"
+        "Owl - Poison Throw"
       ]
     },
     {
       "ID": 50600741,
       "Entries": [
-        "c5060: Chief of Ninja Army_Poison Ball Throwing C_Poison Floor Drop -- c5060：忍軍の長_毒玉投擲C_毒床落とし"
+        "Owl - Poison Throw"
       ]
     },
     {
       "ID": 50600742,
       "Entries": [
-        "c5060: Chief of Ninja Army_Poison Ball Throwing C_Poison Bed Installation -- c5060：忍軍の長_毒玉投擲C_毒床設置"
+        "Owl - Poison Throw"
       ]
     },
     {
       "ID": 50600980,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Lower fall down -- ダミー弾丸_危険な攻撃予兆_下段倒れ込み薙ぎ払い"
+        "Owl - Perilous Attack Warning"
       ]
     },
     {
       "ID": 50600981,
       "Entries": [
-        "c5060: Ninja Army Chief_Effect Dummy Bullet_Firecracker Powder A -- c5060：忍軍の長_エフェクト用ダミー弾丸_爆竹粉A"
+        "Owl - Firecracker Powder"
       ]
     },
     {
       "ID": 50600982,
       "Entries": [
-        "c5060: Ninja Army Chief_Effect Dummy Bullet_Firecracker Powder B -- c5060：忍軍の長_エフェクト用ダミー弾丸_爆竹粉B"
+        "Owl - Firecracker Powder"
       ]
     },
     {
       "ID": 50600983,
       "Entries": [
-        "c5060: Ninja Army Chief_Effect Dummy Bullet_Explosion Powder A -- c5060：忍軍の長_エフェクト用ダミー弾丸_爆炎粉A"
+        "Owl - Firecracker Explosion Powder"
       ]
     },
     {
       "ID": 50600984,
       "Entries": [
-        "c5060: Ninja Army Chief_Effect Dummy Bullet_Explosion Powder B -- c5060：忍軍の長_エフェクト用ダミー弾丸_爆炎粉B"
+        "Owl - Firecracker Explosion Powder"
       ]
     },
     {
       "ID": 50600985,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Zigzag Lower dive slash from the left -- ダミー弾丸_危険な攻撃予兆_ジグザグ左からの下段飛び込み斬り"
+        "Owl - Perilous Attack Warning"
       ]
     },
     {
       "ID": 50600986,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Left strong flow and turning from collapse Lower row -- ダミー弾丸_危険な攻撃予兆_左強流され崩れからの振り向き下段"
+        "Owl - Perilous Attack Warning"
       ]
     },
     {
       "ID": 50600987,
       "Entries": [
-        "Dummy bullet _ dangerous attack sign _ stab -- ダミー弾丸_危険な攻撃予兆_忍刺し"
+        "Owl - Perilous Attack Warning"
       ]
     },
     {
       "ID": 50600990,
       "Entries": [
-        "c5060_Ninja Army Chief_Warp SFX -- c5060_忍軍の長_ワープSFX"
+        "Owl - Warp SFX"
       ]
     },
     {
       "ID": 50601131,
       "Entries": [
-        "c5060: Chief of Ninja Army_Somersault Shuriken -- c5060：忍軍の長_宙返り手裏剣"
+        "Owl - Kickoff Shuriken"
       ]
     },
     {
       "ID": 50601150,
       "Entries": [
-        "c5060: Chief of Ninja Army_Shuriken -- c5060：忍軍の長_手裏剣"
+        "Owl - Shuriken"
       ]
     },
     {
       "ID": 50601160,
       "Entries": [
-        "c5060: Chief of Ninja Army_Firecracker Parent A -- c5060：忍軍の長_爆竹親A"
+        "Owl - Firecracker"
       ]
     },
     {
       "ID": 50601161,
       "Entries": [
-        "c5060: Chief of Ninja Army_Firecracker Parent B -- c5060：忍軍の長_爆竹親B"
+        "Owl - Firecracker"
       ]
     },
     {
       "ID": 50601162,
       "Entries": [
-        "c5060: Chief of Ninja Army_Firecracker Parent C -- c5060：忍軍の長_爆竹親C"
+        "Owl - Firecracker"
       ]
     },
     {
       "ID": 50601163,
       "Entries": [
-        "c5060: Chief of Ninja Army_Firecracker Parent D -- c5060：忍軍の長_爆竹親D"
+        "Owl - Firecracker"
       ]
     },
     {
       "ID": 50601164,
       "Entries": [
-        "c5060: Chief of Ninja Army_Firecracker A -- c5060：忍軍の長_爆竹子A"
+        "Owl - Firecracker"
       ]
     },
     {
       "ID": 50601165,
       "Entries": [
-        "c5060: Chief of Ninja Army_Firecracker B -- c5060：忍軍の長_爆竹子B"
+        "Owl - Firecracker"
       ]
     },
     {
       "ID": 50601166,
       "Entries": [
-        "c5060: Chief of Ninja Army_Firecracker C -- c5060：忍軍の長_爆竹子C"
+        "Owl - Firecracker"
       ]
     },
     {
       "ID": 50601167,
       "Entries": [
-        "c5060: Chief of Ninja Army_Firecracker D -- c5060：忍軍の長_爆竹子D"
+        "Owl - Firecracker"
       ]
     },
     {
       "ID": 50601168,
       "Entries": [
-        "c5060: Chief of Ninja Army_Firecracker Grandson -- c5060：忍軍の長_爆竹孫"
+        "Owl - Firecracker"
       ]
     },
     {
       "ID": 50601190,
       "Entries": [
-        "c5060: Chief of Ninja Army_Firecracker Parent A -- c5060：忍軍の長_爆竹親A"
+        "Owl - Firecracker"
       ]
     },
     {
       "ID": 50601195,
       "Entries": [
-        "c5060: Chief of Ninja Army_Firecracker A -- c5060：忍軍の長_爆竹子A"
+        "Owl - Firecracker"
       ]
     },
     {
       "ID": 50601200,
       "Entries": [
-        "c5060: Chief of Ninja Army_Firecracker Grandson_Firecracker Explosion &amp; Damage -- c5060：忍軍の長_爆竹孫_爆竹破裂＆ダメージ"
+        "Owl - Firecracker"
       ]
     },
     {
       "ID": 50601201,
       "Entries": [
-        "c5060: Chief of Ninja Army_Firecracker Son_Flame -- c5060：忍軍の長_爆竹孫_炎"
+        "Owl - Firecracker"
       ]
     },
     {
       "ID": 50601250,
       "Entries": [
-        "c5060: Chief of Ninja Army_Explosion Parent Dummy A -- c5060：忍軍の長_爆炎親ダミーA"
+        "Owl - Firecracker Explosion Attack"
       ]
     },
     {
       "ID": 50601251,
       "Entries": [
-        "c5060: Chief of Ninja Army_Explosion Parent Dummy B -- c5060：忍軍の長_爆炎親ダミーB"
+        "Owl - Firecracker Explosion Attack"
       ]
     },
     {
       "ID": 50601252,
       "Entries": [
-        "c5060: Chief of Ninja Army_Explosion Parent Dummy C -- c5060：忍軍の長_爆炎親ダミーC"
+        "Owl - Firecracker Explosion Attack"
       ]
     },
     {
       "ID": 50601253,
       "Entries": [
-        "c5060: Chief of Ninja Army_Explosion Parent Dummy D -- c5060：忍軍の長_爆炎親ダミーD"
+        "Owl - Firecracker Explosion Attack"
       ]
     },
     {
       "ID": 50601254,
       "Entries": [
-        "c5060: Chief of Ninja Army_Explosion Parent Dummy E -- c5060：忍軍の長_爆炎親ダミーE"
+        "Owl - Firecracker Explosion Attack"
       ]
     },
     {
       "ID": 50601255,
       "Entries": [
-        "c5060: Chief of Ninja Army_Explosive Child Dummy A -- c5060：忍軍の長_爆炎子ダミーA"
+        "Owl - Firecracker Explosion Attack"
       ]
     },
     {
       "ID": 50601256,
       "Entries": [
-        "c5060: Chief of Ninja Army_Bomb Flame Child Dummy B -- c5060：忍軍の長_爆炎子ダミーB"
+        "Owl - Firecracker Explosion Attack"
       ]
     },
     {
       "ID": 50601257,
       "Entries": [
-        "c5060: Chief of Ninja Army_Bomb Flame Child Dummy C -- c5060：忍軍の長_爆炎子ダミーC"
+        "Owl - Firecracker Explosion Attack"
       ]
     },
     {
       "ID": 50601258,
       "Entries": [
-        "c5060: Ninja Army Chief_Explosion Child Dummy D -- c5060：忍軍の長_爆炎子ダミーD"
+        "Owl - Firecracker Explosion Attack"
       ]
     },
     {
       "ID": 50601259,
       "Entries": [
-        "c5060: Chief of Ninja Army_Bomb Flame Child Dummy E -- c5060：忍軍の長_爆炎子ダミーE"
+        "Owl - Firecracker Explosion Attack"
       ]
     },
     {
       "ID": 50601260,
       "Entries": [
-        "c5060: Chief of Ninja Army_Explosion Grandson_Explosion of Firecracker -- c5060：忍軍の長_爆炎孫_爆竹破裂"
+        "Owl - Firecracker Explosion Attack"
       ]
     },
     {
       "ID": 50601261,
       "Entries": [
-        "c5060: Chief of Ninja Army_Explosion Grandson_Flame -- c5060：忍軍の長_爆炎孫_炎"
+        "Owl - Firecracker Explosion Attack"
       ]
     },
     {
       "ID": 50601700,
       "Entries": [
-        "c5060: Chief of Ninja Army_Poison Ball Throwing A_Parent -- c5060：忍軍の長_毒玉投擲A_親"
+        "Owl - Poison Throw"
       ]
     },
     {
       "ID": 50601701,
       "Entries": [
-        "c5060: Chief of Ninja Army_Poison Ball Throwing A_Poison Floor Drop -- c5060：忍軍の長_毒玉投擲A_毒床落とし"
+        "Owl - Poison Throw"
       ]
     },
     {
       "ID": 50601702,
       "Entries": [
-        "c5060: Chief of Ninja Army_Poison Ball Throwing A_Poison Bed Installation -- c5060：忍軍の長_毒玉投擲A_毒床設置"
+        "Owl - Poison Throw"
       ]
     },
     {
       "ID": 50601710,
       "Entries": [
-        "c5060: Chief of Ninja Army_Recovery Sealed Throwing_Parent -- c5060：忍軍の長_回復封じ投擲_親"
+        "Owl - Heal Block"
       ]
     },
     {
       "ID": 50601711,
       "Entries": [
-        "c5060: Chief of Ninja Army_Recovery Sealed Throwing_Child -- c5060：忍軍の長_回復封じ投擲_子"
+        "Owl - Heal Block"
       ]
     },
     {
       "ID": 50601720,
       "Entries": [
-        "c5060: Chief of Ninja Army_Smoke Screen -- c5060：忍軍の長_煙幕"
+        "Owl - Smoke Bomb"
       ]
     },
     {
       "ID": 50601721,
       "Entries": [
-        "c5060: Chief of Ninja Army_Smoke Screen_Dazzle -- c5060：忍軍の長_煙幕_目くらまし"
+        "Owl - Smoke Bomb"
       ]
     },
     {
       "ID": 50601730,
       "Entries": [
-        "c5060: Chief of Ninja Army_Poison Ball Throwing B_Parent -- c5060：忍軍の長_毒玉投擲B_親"
+        "Owl - Poison Throw"
       ]
     },
     {
       "ID": 50601731,
       "Entries": [
-        "c5060: Chief of Ninja Army_Poison Ball Throwing B_Poison Floor Drop -- c5060：忍軍の長_毒玉投擲B_毒床落とし"
+        "Owl - Poison Throw"
       ]
     },
     {
       "ID": 50601732,
       "Entries": [
-        "c5060: Chief of Ninja Army_Poison Ball Throwing B_Poison Bed Installation -- c5060：忍軍の長_毒玉投擲B_毒床設置"
+        "Owl - Poison Throw"
       ]
     },
     {
       "ID": 50601740,
       "Entries": [
-        "c5060: Chief of Ninja Army_Poison Ball Throwing C_Parent -- c5060：忍軍の長_毒玉投擲C_親"
+        "Owl - Poison Throw"
       ]
     },
     {
       "ID": 50601741,
       "Entries": [
-        "c5060: Chief of Ninja Army_Poison Ball Throwing C_Poison Floor Drop -- c5060：忍軍の長_毒玉投擲C_毒床落とし"
+        "Owl - Poison Throw"
       ]
     },
     {
       "ID": 50601742,
       "Entries": [
-        "c5060: Chief of Ninja Army_Poison Ball Throwing C_Poison Bed Installation -- c5060：忍軍の長_毒玉投擲C_毒床設置"
+        "Owl - Poison Throw"
       ]
     },
     {
       "ID": 50601980,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Lower fall down -- ダミー弾丸_危険な攻撃予兆_下段倒れ込み薙ぎ払い"
+        "Owl - Perilous Attack Warning"
       ]
     },
     {
       "ID": 50601981,
       "Entries": [
-        "c5060: Ninja Army Chief_Effect Dummy Bullet_Firecracker Powder A -- c5060：忍軍の長_エフェクト用ダミー弾丸_爆竹粉A"
+        "Owl - Firecracker Powder"
       ]
     },
     {
       "ID": 50601982,
       "Entries": [
-        "c5060: Ninja Army Chief_Effect Dummy Bullet_Firecracker Powder B -- c5060：忍軍の長_エフェクト用ダミー弾丸_爆竹粉B"
+        "Owl - Firecracker Powder"
       ]
     },
     {
       "ID": 50601983,
       "Entries": [
-        "c5060: Ninja Army Chief_Effect Dummy Bullet_Explosion Powder A -- c5060：忍軍の長_エフェクト用ダミー弾丸_爆炎粉A"
+        "Owl - Firecracker Explosion Powder"
       ]
     },
     {
       "ID": 50601984,
       "Entries": [
-        "c5060: Ninja Army Chief_Effect Dummy Bullet_Explosion Powder B -- c5060：忍軍の長_エフェクト用ダミー弾丸_爆炎粉B"
+        "Owl - Firecracker Explosion Powder"
       ]
     },
     {
       "ID": 50601985,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Zigzag Lower dive slash from the left -- ダミー弾丸_危険な攻撃予兆_ジグザグ左からの下段飛び込み斬り"
+        "Owl - Perilous Attack Warning"
       ]
     },
     {
       "ID": 50601986,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Left strong flow and turning from collapse Lower row -- ダミー弾丸_危険な攻撃予兆_左強流され崩れからの振り向き下段"
+        "Owl - Perilous Attack Warning"
       ]
     },
     {
       "ID": 50601987,
       "Entries": [
-        "Dummy bullet _ dangerous attack sign _ stab -- ダミー弾丸_危険な攻撃予兆_忍刺し"
+        "Owl - Perilous Attack Warning"
       ]
     },
     {
       "ID": 50601990,
       "Entries": [
-        "c5060_Ninja Army Chief_Warp SFX -- c5060_忍軍の長_ワープSFX"
+        "Owl - Warp SFX"
       ]
     },
     {
       "ID": 50700100,
       "Entries": [
-        "c5070_long owl_warp sign -- c5070_長の梟_ワープ予兆"
+        "Owl's Pet Owl"
       ]
     },
     {
       "ID": 50700600,
       "Entries": [
-        "c5070_long owl_sign of straight attack -- c5070_長の梟_直進攻撃の合図"
+        "Owl's Pet Owl"
       ]
     },
     {
       "ID": 50700610,
       "Entries": [
-        "c5070_long owl_left curve attack signal -- c5070_長の梟_左カーブ攻撃の合図"
+        "Owl's Pet Owl"
       ]
     },
     {
       "ID": 50700620,
       "Entries": [
-        "c5070_long owl_right curve attack signal -- c5070_長の梟_右カーブ攻撃の合図"
+        "Owl's Pet Owl"
       ]
     },
     {
       "ID": 50700630,
       "Entries": [
-        "c5070_long owl_sign of diagonal rise -- c5070_長の梟_斜め上昇の合図"
+        "Owl's Pet Owl"
       ]
     },
     {
       "ID": 50700640,
       "Entries": [
-        "c5070_Owl of the length_Sign of lower rush attack -- c5070_長の梟_下段突進攻撃の合図"
+        "Owl's Pet Owl"
       ]
     },
     {
       "ID": 50700650,
       "Entries": [
-        "c5070_long owl_bullet attack signal -- c5070_長の梟_弾丸攻撃の合図"
+        "Owl's Pet Owl"
       ]
     },
     {
       "ID": 50700660,
       "Entries": [
-        "c5070_long owl_lateral movement signal -- c5070_長の梟_横移動の合図"
+        "Owl's Pet Owl"
       ]
     },
     {
       "ID": 50700980,
       "Entries": [
-        "c5070_long owl_dummy bullet_dangerous attack -- c5070_長の梟_ダミー弾丸_危険な攻撃"
+        "Owl's Pet Owl - Perilous Attack Warning"
       ]
     },
     {
       "ID": 50800930,
       "Entries": [
-        "c5080_Cavalry Warrior_Running Collision Detection Bullet 1 -- c5080_騎馬武者_走行中衝突判定用弾丸１"
+        "Gyoubu - Collision Detection"
       ]
     },
     {
       "ID": 50800931,
       "Entries": [
-        "c5080_Cavalry Warrior_Running Collision Detection Bullet 1 -- c5080_騎馬武者_走行中衝突判定用弾丸１"
+        "Gyoubu - Collision Detection"
       ]
     },
     {
       "ID": 50800980,
       "Entries": [
-        "c5080_Cavalry Warrior_Dummy Bullet_Dangerous Attack Prediction_Near -- c5080_騎馬武者_ダミー弾丸_危険な攻撃予兆_近"
+        "Gyoubu - Perilous Attack Warning"
       ]
     },
     {
       "ID": 50800981,
       "Entries": [
-        "c5080_Cavalry Warrior_Dummy Bullet_Dangerous Attack Prediction_Far -- c5080_騎馬武者_ダミー弾丸_危険な攻撃予兆_遠"
+        "Gyoubu - Perilous Attack Warning"
       ]
     },
     {
       "ID": 50900160,
       "Entries": [
-        "c5090_butterfly_diffusion needle throwing_ground -- c5090_お蝶_拡散針投げ_地上"
+        "Lady Butterfly - Kunai"
       ]
     },
     {
       "ID": 50900170,
       "Entries": [
-        "c5090_butterfly_backstep needle throw -- c5090_お蝶_バックステップ針投げ"
+        "Lady Butterfly - Kunai"
       ]
     },
     {
       "ID": 50900100,
       "Entries": [
-        "c5090_Butterfly_Double needle throwing Steel wire jumping -- c5090_お蝶_二連針投げ鋼線飛び乗り"
+        "Lady Butterfly - Kunai"
       ]
     },
     {
       "ID": 50900300,
       "Entries": [
-        "c5090_Butterfly_Diffusion needle throw_On steel wire -- c5090_お蝶_拡散針投げ_鋼線上"
+        "Lady Butterfly - Kunai"
       ]
     },
     {
       "ID": 50900310,
       "Entries": [
-        "c5090_Butterfly_HU Time difference bullet_Parent_Short life -- c5090_お蝶_HU後時間差弾丸_親_寿命短い"
+        "Lady Butterfly - Butterflies"
       ]
     },
     {
       "ID": 50900311,
       "Entries": [
-        "c5091_Butterfly_HU Time difference bullet_Child_Short life -- c5091_お蝶_HU後時間差弾丸_子_寿命短い"
+        "Lady Butterfly - Butterflies"
       ]
     },
     {
       "ID": 50900320,
       "Entries": [
-        "c5090_Butterfly_HU Time difference bullet_Parent_Life is normal -- c5090_お蝶_HU後時間差弾丸_親_寿命普通"
+        "Lady Butterfly - Butterflies"
       ]
     },
     {
       "ID": 50900321,
       "Entries": [
-        "c5091_Butterfly_HU Time difference bullet_Child_Life Normal -- c5091_お蝶_HU後時間差弾丸_子_寿命普通"
+        "Lady Butterfly - Butterflies"
       ]
     },
     {
       "ID": 50900330,
       "Entries": [
-        "c5090_Butterfly_HU Time difference bullet_Parent_Long life -- c5090_お蝶_HU後時間差弾丸_親_寿命長い"
+        "Lady Butterfly - Butterflies"
       ]
     },
     {
       "ID": 50900331,
       "Entries": [
-        "c5091_Butterfly_HU Time difference bullet_Child_Long life -- c5091_お蝶_HU後時間差弾丸_子_寿命長い"
+        "Lady Butterfly - Butterflies"
       ]
     },
     {
       "ID": 50900420,
       "Entries": [
-        "c5090_Butterfly_HU Time difference bullet_Parent_Needle kick for continuous attack_Second stage -- c5090_お蝶_HU後時間差弾丸_親_針蹴り連撃用_二段目"
+        "Lady Butterfly - Butterflies"
       ]
     },
     {
       "ID": 50900421,
       "Entries": [
-        "c5091_Butterfly_HU Time difference bullet_Child_Needle kick For continuous attack -- c5091_お蝶_HU後時間差弾丸_子_針蹴り連撃用"
+        "Lady Butterfly - Butterflies"
       ]
     },
     {
       "ID": 50900430,
       "Entries": [
-        "c5090_Butterfly_HU Time difference bullet_Parent_Needle kick for continuous attack_First stage -- c5090_お蝶_HU後時間差弾丸_親_針蹴り連撃用_一段目"
+        "Lady Butterfly - Butterflies"
       ]
     },
     {
       "ID": 50900520,
       "Entries": [
-        "c5090_Butterfly_HU Time difference bullet_Parent_Diffusion needle throwing_Second stage -- c5090_お蝶_HU後時間差弾丸_親_拡散針投げ用_二段目"
+        "Lady Butterfly - Butterflies"
       ]
     },
     {
       "ID": 50900521,
       "Entries": [
-        "c5091_Butterfly_HU Time difference bullet_Child_Diffusion needle throwing -- c5091_お蝶_HU後時間差弾丸_子_拡散針投げ用"
+        "Lady Butterfly - Butterflies"
       ]
     },
     {
       "ID": 50900530,
       "Entries": [
-        "c5090_Butterfly_HU Time difference bullet_Parent_Diffusion needle throwing_First stage -- c5090_お蝶_HU後時間差弾丸_親_拡散針投げ用_一段目"
+        "Lady Butterfly - Butterflies"
       ]
     },
     {
       "ID": 50900920,
       "Entries": [
-        "c5090_Butterfly_Phantom activation -- c5090_お蝶_幻術発動"
+        "Lady Butterfly - Illusion Activation"
       ]
     },
     {
       "ID": 50900921,
       "Entries": [
-        "c5090_butterfly_butterfly change -- c5090_お蝶_蝶々変化"
+        "Lady Butterfly - Release Illusion"
       ]
     },
     {
       "ID": 50900930,
       "Entries": [
-        "c5090_Butterfly_Forced release when beam falls -- c5090_お蝶_梁落下時強制解除"
+        "Lady Butterfly - Release Illusion On Death"
       ]
     },
     {
       "ID": 50900980,
       "Entries": [
-        "c5090_Butterfly_Dummy bullet_Dangerous attack sign -- c5090_お蝶_ダミー弾丸_危険な攻撃予兆"
+        "Lady Butterfly - Perilous Attack Warning"
       ]
     },
     {
       "ID": 50900981,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Strong lower slash -- ダミー弾丸_危険な攻撃予兆_強下段斬り抜け"
+        "Lady Butterfly - Perilous Attack Warning"
       ]
     },
     {
       "ID": 50900982,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Needle &amp; kick continuous attack final stage -- ダミー弾丸_危険な攻撃予兆_針&蹴り連撃最終段"
+        "Lady Butterfly - Perilous Attack Warning"
       ]
     },
     {
       "ID": 50900983,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Lower slash from kicking -- ダミー弾丸_危険な攻撃予兆_蹴り弾かれからの下段斬り抜け"
+        "Lady Butterfly - Perilous Attack Warning"
       ]
     },
     {
       "ID": 50900984,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Steel wire → Fall throw start _ Start -- ダミー弾丸_危険な攻撃予兆_鋼線→落下投げ始動_開始"
+        "Lady Butterfly - Perilous Attack Warning"
       ]
     },
     {
       "ID": 51000280,
       "Entries": [
-        "c5100_Yasha Ape_Skip the skull from your mouth -- c5100_夜叉猿_髑髏を口から飛ばす"
+        "Guardian Ape"
       ]
     },
     {
       "ID": 51000290,
       "Entries": [
-        "c5100_Yasha Ape_Dung throwing -- c5100_夜叉猿_糞投げ"
+        "Guardian Ape - Poo Throw"
       ]
     },
     {
       "ID": 51000291,
       "Entries": [
-        "c5100_Yasha Ape_Dung Throw_Go underwater -- c5100_夜叉猿_糞投げ_水中を進む"
+        "Guardian Ape - Poo Throw Underwater"
       ]
     },
     {
       "ID": 51000310,
       "Entries": [
-        "c5100_Yasha Monkey_Flatulence_ (Tentative) Valley Enemy_Cannon_Fire -- c5100_夜叉猿_屁_（仮）谷敵_大砲_発射"
+        "Guardian Ape - Fart"
       ]
     },
     {
       "ID": 51000311,
       "Entries": [
-        "c5100_Yasha Ape_Flatulence_Remains -- c5100_夜叉猿_屁_残る"
+        "Guardian Ape - Fart"
       ]
     },
     {
       "ID": 51000330,
       "Entries": [
-        "c5100_Yasha Ape_Sprinkling feces -- c5100_夜叉猿_糞ばら撒き"
+        "Guardian Ape - Poo Remains"
       ]
     },
     {
       "ID": 51000331,
       "Entries": [
-        "c5100_Yasha Ape_Sprinkling feces_Impact_Bouncing -- c5100_夜叉猿_糞ばら撒き_着弾_跳ねる"
+        "Guardian Ape - Poo Remains"
       ]
     },
     {
       "ID": 51000332,
       "Entries": [
-        "c5100_Yasha Ape_Sprinkling feces_Landing_Falling -- c5100_夜叉猿_糞ばら撒き_着弾_落ちる"
+        "Guardian Ape - Poo Remains"
       ]
     },
     {
       "ID": 51000333,
       "Entries": [
-        "c5100_Yasha Ape_Sprinkling feces_Remaining -- c5100_夜叉猿_糞ばら撒き_残る"
+        "Guardian Ape - Poo Remains"
       ]
     },
     {
       "ID": 51000480,
       "Entries": [
-        "c5100_Yasha Ape_Dummy bullet_Dangerous attack sign HU -- c5100_夜叉猿_ダミー弾丸_危険な攻撃予兆 HU前"
+        "Guardian Ape - Perilous Attack Warning"
       ]
     },
     {
       "ID": 51000580,
       "Entries": [
-        "c5100_Yasha Ape_Roar -- c5100_夜叉猿_咆哮"
+        "Guardian Ape - Roar"
       ]
     },
     {
       "ID": 51000581,
       "Entries": [
-        "c5100_Yasha Ape_Roar_Afterglow -- c5100_夜叉猿_咆哮_余韻"
+        "Guardian Ape - Roar Remainings"
       ]
     },
     {
       "ID": 51000630,
       "Entries": [
-        "c5100_Yasha Ape_Weak Roar -- c5100_夜叉猿_弱咆哮"
+        "Guardian Ape - Summon Wife"
       ]
     },
     {
       "ID": 51000900,
       "Entries": [
-        "c5100_Yasha Ape_Bride Monkey Command Bullet -- c5100_夜叉猿_嫁猿命令用弾丸"
+        "Guardian Ape - Wife Command"
       ]
     },
     {
       "ID": 51000980,
       "Entries": [
-        "c5100_Yasha Ape_Dummy Bullet_Dangerous Attack Prediction After HU -- c5100_夜叉猿_ダミー弾丸_危険な攻撃予兆 HU後"
+        "Guardian Ape - Perilous Attack Warning"
       ]
     },
     {
       "ID": 52000500,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning Strike_Appearance -- c5200_人魚竜_落雷_出現"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000501,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning Strike_Move -- c5200_人魚竜_落雷_移動"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000502,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning Strike_Fall -- c5200_人魚竜_落雷_落下"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000503,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning Strike_Attack -- c5200_人魚竜_落雷_攻撃"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000504,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning Strike_Effect -- c5200_人魚竜_落雷_エフェクト"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000505,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning Strike_Propagation -- c5200_人魚竜_落雷_伝播"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000510,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning strike (for lightning strike) _Appearance -- c5200_人魚竜_落雷(雷返し用)_出現"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000511,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning strike (for lightning strike) _Move -- c5200_人魚竜_落雷(雷返し用)_移動"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000512,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning strike (for lightning strike) _Signal loop 0 -- c5200_人魚竜_落雷(雷返し用)_予兆ループ0"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000513,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning strike (for lightning strike) _Signal loop 1 -- c5200_人魚竜_落雷(雷返し用)_予兆ループ1"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000514,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning strike (for lightning strike) _Signal loop 2 -- c5200_人魚竜_落雷(雷返し用)_予兆ループ2"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000515,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning strike (for lightning strike) _Signal loop 3 -- c5200_人魚竜_落雷(雷返し用)_予兆ループ3"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000516,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning strike (for lightning strike) _Signal loop 4 -- c5200_人魚竜_落雷(雷返し用)_予兆ループ4"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000517,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning strike (for lightning strike) _Signal loop 5 -- c5200_人魚竜_落雷(雷返し用)_予兆ループ5"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000518,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning strike (for lightning strike) _Signal loop 6 -- c5200_人魚竜_落雷(雷返し用)_予兆ループ6"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000519,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning strike (for lightning strike) _Signal loop 7 -- c5200_人魚竜_落雷(雷返し用)_予兆ループ7"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000520,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning strike (for lightning strike) _Signal loop 8 -- c5200_人魚竜_落雷(雷返し用)_予兆ループ8"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000521,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning strike (for lightning strike) _Signal loop 9 -- c5200_人魚竜_落雷(雷返し用)_予兆ループ9"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000530,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning Strike_Appearance -- c5200_人魚竜_落雷_出現"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000531,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning Strike_Move -- c5200_人魚竜_落雷_移動"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000532,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning Strike_Fall -- c5200_人魚竜_落雷_落下"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000533,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning Strike_Attack -- c5200_人魚竜_落雷_攻撃"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000534,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning Strike_Effect -- c5200_人魚竜_落雷_エフェクト"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000535,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning Strike_Propagation -- c5200_人魚竜_落雷_伝播"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000540,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning Strike_Appearance -- c5200_人魚竜_落雷_出現"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000541,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning Strike_Move -- c5200_人魚竜_落雷_移動"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000542,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning Strike_Fall -- c5200_人魚竜_落雷_落下"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000543,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning Strike_Attack -- c5200_人魚竜_落雷_攻撃"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000544,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning Strike_Effect -- c5200_人魚竜_落雷_エフェクト"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000545,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning Strike_Propagation -- c5200_人魚竜_落雷_伝播"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000550,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning Strike_PC Direct Hit_Effect -- c5200_人魚竜_落雷_PC直撃_エフェクト"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000555,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning Strike_PC Direct Hit_Attack -- c5200_人魚竜_落雷_PC直撃_攻撃"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000600,
       "Entries": [
-        "c5200_Mermaid Dragon_Pinpoint Weak Lightning_Sign -- c5200_人魚竜_ピンポイント弱落雷_予兆"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000601,
       "Entries": [
-        "c5200_Mermaid Dragon_Pinpoint Weak Lightning_Attack -- c5200_人魚竜_ピンポイント弱落雷_攻撃"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000602,
       "Entries": [
-        "c5200_Mermaid Dragon_Pinpoint Weak Lightning_Effect -- c5200_人魚竜_ピンポイント弱落雷_エフェクト"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000603,
       "Entries": [
-        "c5200_Mermaid Dragon_Pinpoint Weak Lightning_Predictive Effect -- c5200_人魚竜_ピンポイント弱落雷_予兆エフェクト"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000610,
       "Entries": [
-        "c5200_Mermaid Dragon_Pinpoint Lightning Strike_Sign -- c5200_人魚竜_ピンポイント強落雷_予兆"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000611,
       "Entries": [
-        "c5200_Mermaid Dragon_Pinpoint Lightning Strike_Attack -- c5200_人魚竜_ピンポイント強落雷_攻撃"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000612,
       "Entries": [
-        "c5200_Mermaid Dragon_Pinpoint Lightning Strike_Effect -- c5200_人魚竜_ピンポイント強落雷_エフェクト"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000613,
       "Entries": [
-        "c5200_Mermaid Dragon_Pinpoint Lightning Strike_Predictive Effect -- c5200_人魚竜_ピンポイント強落雷_予兆エフェクト"
+        "Divine Dragon - Lightning"
       ]
     },
     {
       "ID": 52000620,
       "Entries": [
-        "c5200_Mermaid Dragon_Distance Attack_Sword Flash Wave_Vertical_Parent -- c5200_人魚竜_遠距離攻撃_剣閃光波_縦_親"
+        "Divine Dragon - Sword Projectile"
       ]
     },
     {
       "ID": 52000629,
       "Entries": [
-        "c5200_Mermaid Dragon_Distance Attack_Sword Flash Wave_Vertical_Child -- c5200_人魚竜_遠距離攻撃_剣閃光波_縦_子"
+        "Divine Dragon - Sword Projectile"
       ]
     },
     {
       "ID": 52000630,
       "Entries": [
-        "c5200_Mermaid Dragon_Distance Attack_Sword Flash Wave_Horizontal_Parent -- c5200_人魚竜_遠距離攻撃_剣閃光波_横_親"
+        "Divine Dragon - Sword Projectile"
       ]
     },
     {
       "ID": 52000639,
       "Entries": [
-        "c5200_Mermaid Dragon_Distance Attack_Sword Flash Wave_Horizontal_Child -- c5200_人魚竜_遠距離攻撃_剣閃光波_横_子"
+        "Divine Dragon - Sword Projectile"
       ]
     },
     {
       "ID": 52000640,
       "Entries": [
-        "c5200_Mermaid Dragon_Full Range Attack -- c5200_人魚竜_全範囲攻撃"
+        "Divine Dragon - Sword Projectile"
       ]
     },
     {
       "ID": 52000650,
       "Entries": [
-        "c5200_Mermaid Dragon_Lower Range Attack -- c5200_人魚竜_下段範囲攻撃"
+        "Divine Dragon - Sword Projectile"
       ]
     },
     {
       "ID": 52000660,
       "Entries": [
-        "c5200_Mermaid Dragon_Storm Jump_Lightning Omen 0 -- c5200_人魚竜_ストームジャンプ_雷予兆0"
+        "Divine Dragon - Storm Jump"
       ]
     },
     {
       "ID": 52000661,
       "Entries": [
-        "c5200_Mermaid Dragon_Storm Jump_Lightning Omen 1 -- c5200_人魚竜_ストームジャンプ_雷予兆1"
+        "Divine Dragon - Storm Jump"
       ]
     },
     {
       "ID": 52000665,
       "Entries": [
-        "c5200_Mermaid Dragon_Storm Jump_Updraft -- c5200_人魚竜_ストームジャンプ_上昇気流"
+        "Divine Dragon - Storm Jump"
       ]
     },
     {
       "ID": 52000670,
       "Entries": [
-        "c5200_Mermaid Dragon_Distance Attack_Sword Flash Wave_Kasaya_Parent -- c5200_人魚竜_遠距離攻撃_剣閃光波_袈裟_親"
+        "Divine Dragon - Sword Projectile"
       ]
     },
     {
       "ID": 52000679,
       "Entries": [
-        "c5200_Mermaid Dragon_Distance Attack_Sword Flash Wave_Kasaya_Child -- c5200_人魚竜_遠距離攻撃_剣閃光波_袈裟_子"
+        "Divine Dragon - Sword Projectile"
       ]
     },
     {
       "ID": 52000680,
       "Entries": [
-        "c5200_Mermaid Dragon_Distance Attack_Sword Flash Wave_Reverse Kasaya_Parent -- c5200_人魚竜_遠距離攻撃_剣閃光波_逆袈裟_親"
+        "Divine Dragon - Sword Projectile"
       ]
     },
     {
       "ID": 52000689,
       "Entries": [
-        "c5200_Mermaid Dragon_Distance Attack_Sword Flash Wave_Reverse Kasaya_Child -- c5200_人魚竜_遠距離攻撃_剣閃光波_逆袈裟_子"
+        "Divine Dragon - Sword Projectile"
       ]
     },
     {
       "ID": 52000700,
       "Entries": [
-        "c5200_Mermaid Dragon_Slamming effect bullet -- c5200_人魚竜_叩きつけエフェクト弾"
+        "Divine Dragon - Sword Projectile"
       ]
     },
     {
       "ID": 52000701,
       "Entries": [
-        "c5200_Mermaid Dragon_Slamming effect bullet -- c5200_人魚竜_叩きつけエフェクト弾"
+        "Divine Dragon - Sword Projectile"
       ]
     },
     {
       "ID": 52000800,
       "Entries": [
-        "c5200_Mermaid Dragon_Updraft Bullet -- c5200_人魚竜_上昇気流弾丸"
+        "Divine Dragon - Storm Jump"
       ]
     },
     {
       "ID": 52000801,
       "Entries": [
-        "c5200_Mermaid Dragon_Sign of lightning strike during updraft -- c5200_人魚竜_上昇気流中落雷予兆"
+        "Divine Dragon - Storm Jump"
       ]
     },
     {
       "ID": 52000820,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning Return_PC Blow-off Explosion -- c5200_人魚竜_雷返し_PC吹っ飛び爆発"
+        "Divine Dragon - Storm Jump"
       ]
     },
     {
       "ID": 52000830,
       "Entries": [
-        "c5200_Mermaid Dragon_Strong Wind_Blows Off After PC -- c5200_人魚竜_強風_PC後吹っ飛び"
+        "Divine Dragon - Storm Jump"
       ]
     },
     {
       "ID": 52000850,
       "Entries": [
-        "c5200_Mermaid Dragon_Lightning strike sign deleted -- c5200_人魚竜_落雷予兆削除"
+        "Divine Dragon - Storm Jump"
       ]
     },
     {
       "ID": 52000899,
       "Entries": [
-        "c5200_Mermaid Dragon_Dbg_Updraft Direct -- c5200_人魚竜_Dbg_上昇気流直出し"
+        "Divine Dragon"
       ]
     },
     {
       "ID": 52000910,
       "Entries": [
-        "c5200_Mermaid Dragon_Dbg_Storm Wall_Before -- c5200_人魚竜_Dbg_嵐の壁_前"
+        "Divine Dragon"
       ]
     },
     {
       "ID": 52000911,
       "Entries": [
-        "c5200_Mermaid Dragon_Dbg_Storm Wall_After -- c5200_人魚竜_Dbg_嵐の壁_後"
+        "Divine Dragon"
       ]
     },
     {
       "ID": 52000912,
       "Entries": [
-        "c5200_Mermaid Dragon_Dbg_Storm Wall_Deleted -- c5200_人魚竜_Dbg_嵐の壁_削除"
+        "Divine Dragon"
       ]
     },
     {
       "ID": 52000913,
       "Entries": [
-        "c5200_Mermaid Dragon_Dbg_Storm Wall_Fall -- c5200_人魚竜_Dbg_嵐の壁_落下"
+        "Divine Dragon"
       ]
     },
     {
       "ID": 52000914,
       "Entries": [
-        "c5200_Mermaid Dragon_Dbg_Storm Wall_Body -- c5200_人魚竜_Dbg_嵐の壁_本体"
+        "Divine Dragon"
       ]
     },
     {
       "ID": 52000920,
       "Entries": [
-        "c5200_Mermaid Dragon_Dbg_Danger mark -- c5200_人魚竜_Dbg_危険マークを出す"
+        "Divine Dragon"
       ]
     },
     {
       "ID": 52000930,
       "Entries": [
-        "c5200_Mermaid Dragon_Dbg_Updraft_Necessary -- c5200_人魚竜_Dbg_上昇気流_必中"
+        "Divine Dragon"
       ]
     },
     {
       "ID": 52000980,
       "Entries": [
-        "c5200_Mermaid Dragon_Dummy Bullet_Dangerous Attack Prediction -- c5200_人魚竜_ダミー弾丸_危険な攻撃予兆"
+        "Divine Dragon - Perilous Attack"
       ]
     },
     {
       "ID": 53000140,
       "Entries": [
-        "c5300_Okina Dragon_Continuous magic bullet -- c5300_翁竜_連続魔法弾"
+        "Old Dragon"
       ]
     },
     {
       "ID": 53000150,
       "Entries": [
-        "c5300_Okina Dragon_Induced magic bullet -- c5300_翁竜_誘導魔法弾"
+        "Old Dragon"
       ]
     },
     {
       "ID": 53000160,
       "Entries": [
-        "c5300_Okinayu_Coughing_Parent -- c5300_翁竜_大咳き込み_親"
+        "Old Dragon"
       ]
     },
     {
       "ID": 53000180,
       "Entries": [
-        "c5300_Okina Dragon_Big coughing_Child -- c5300_翁竜_大咳き込み_子"
+        "Old Dragon"
       ]
     },
     {
       "ID": 53100210,
       "Entries": [
-        "c5310_tentacle_attack sign -- c5310_触手_攻撃予兆"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100600,
       "Entries": [
-        "c5310_Tentacle_Lightning strike_Omen bullet_SFX dummy 1 -- c5310_触手_落雷_予兆弾丸_SFX用ダミー1"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100610,
       "Entries": [
-        "c5310_Tentacle_Lightning strike_Omen bullet_SFX dummy 2 -- c5310_触手_落雷_予兆弾丸_SFX用ダミー2"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100620,
       "Entries": [
-        "c5310_Tentacle_Lightning strike_Dummy for erasing signs -- c5310_触手_落雷_予兆消す用ダミー"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100630,
       "Entries": [
-        "c5310_Tentacle_Lightning strike_Dummy B for erasing signs -- c5310_触手_落雷_予兆消す用ダミーB"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100640,
       "Entries": [
-        "c5310_tentacles_updraft bullets -- c5310_触手_上昇気流弾丸"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100650,
       "Entries": [
-        "c5310_tentacles_lightning strikes_body bullets -- c5310_触手_落雷_本体弾丸"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100661,
       "Entries": [
-        "c5310_tentacles_lightning strike_predictive bullets_appearance 1 -- c5310_触手_落雷_予兆弾丸_出現1"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100662,
       "Entries": [
-        "c5310_tentacles_lightning strike_predictive bullets_appearance 2 -- c5310_触手_落雷_予兆弾丸_出現2"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100663,
       "Entries": [
-        "c5310_tentacles_lightning strike_predictive bullets_appearance 3 -- c5310_触手_落雷_予兆弾丸_出現3"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100664,
       "Entries": [
-        "c5310_tentacles_lightning strike_predictive bullets_appearance 4 -- c5310_触手_落雷_予兆弾丸_出現4"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100665,
       "Entries": [
-        "c5310_tentacles_lightning strike_predictive bullets_appearance 5 -- c5310_触手_落雷_予兆弾丸_出現5"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100666,
       "Entries": [
-        "c5310_tentacles_lightning strike_predictive bullets_appearance 6 -- c5310_触手_落雷_予兆弾丸_出現6"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100667,
       "Entries": [
-        "c5310_tentacles_lightning strike_predictive bullets_appearance 7 -- c5310_触手_落雷_予兆弾丸_出現7"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100668,
       "Entries": [
-        "c5310_tentacles_lightning strike_predictive bullets_appearance 8 -- c5310_触手_落雷_予兆弾丸_出現8"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100669,
       "Entries": [
-        "c5310_tentacles_lightning strike_predictive bullets_appearance 9 -- c5310_触手_落雷_予兆弾丸_出現9"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100671,
       "Entries": [
-        "c5310_tentacles_lightning strike_predictive bullets_launch 1 -- c5310_触手_落雷_予兆弾丸_発射1"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100672,
       "Entries": [
-        "c5310_tentacles_lightning strike_predictive bullets_launch 2 -- c5310_触手_落雷_予兆弾丸_発射2"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100673,
       "Entries": [
-        "c5310_tentacles_lightning strike_predictive bullets_launch 3 -- c5310_触手_落雷_予兆弾丸_発射3"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100674,
       "Entries": [
-        "c5310_tentacles_lightning strike_predictive bullets_launch 4 -- c5310_触手_落雷_予兆弾丸_発射4"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100675,
       "Entries": [
-        "c5310_tentacles_lightning strike_predictive bullets_launch 5 -- c5310_触手_落雷_予兆弾丸_発射5"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100676,
       "Entries": [
-        "c5310_tentacles_lightning strike_predictive bullets_launch 6 -- c5310_触手_落雷_予兆弾丸_発射6"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100677,
       "Entries": [
-        "c5310_tentacles_lightning strike_predictive bullets_launch 7 -- c5310_触手_落雷_予兆弾丸_発射7"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100678,
       "Entries": [
-        "c5310_tentacles_lightning strike_predictive bullets_launch 8 -- c5310_触手_落雷_予兆弾丸_発射8"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100679,
       "Entries": [
-        "c5310_tentacles_lightning strike_predictive bullets_launch 9 -- c5310_触手_落雷_予兆弾丸_発射9"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100681,
       "Entries": [
-        "c5310_tentacles_lightning strike_predictive bullets_place 1 -- c5310_触手_落雷_予兆弾丸_置き1"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100682,
       "Entries": [
-        "c5310_tentacles_lightning strike_predictive bullets_place 2 -- c5310_触手_落雷_予兆弾丸_置き2"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100683,
       "Entries": [
-        "c5310_tentacles_lightning strike_predictive bullets_place 3 -- c5310_触手_落雷_予兆弾丸_置き3"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100684,
       "Entries": [
-        "c5310_tentacles_lightning strike_predictive bullets_place 4 -- c5310_触手_落雷_予兆弾丸_置き4"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100685,
       "Entries": [
-        "c5310_tentacles_lightning strike_predictive bullets_place 5 -- c5310_触手_落雷_予兆弾丸_置き5"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100686,
       "Entries": [
-        "c5310_tentacles_lightning strike_predictive bullets_place 6 -- c5310_触手_落雷_予兆弾丸_置き6"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100687,
       "Entries": [
-        "c5310_tentacles_lightning strike_predictive bullets_place 7 -- c5310_触手_落雷_予兆弾丸_置き7"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100688,
       "Entries": [
-        "c5310_tentacles_lightning strike_predictive bullets_place 8 -- c5310_触手_落雷_予兆弾丸_置き8"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53100689,
       "Entries": [
-        "c5310_tentacles_lightning strike_predictive bullets_place 9 -- c5310_触手_落雷_予兆弾丸_置き9"
+        "Old Dragon Tentacle"
       ]
     },
     {
       "ID": 53200030,
       "Entries": [
-        "c5300_Okinayu_Coughing_Parent -- c5300_翁竜_咳き込み_親"
+        "Old Dragon"
       ]
     },
     {
       "ID": 53200031,
       "Entries": [
-        "c5300_Okinayu_Coughing_Dummy_Parent -- c5300_翁竜_咳き込み_ダミー_親"
+        "Old Dragon"
       ]
     },
     {
       "ID": 53200032,
       "Entries": [
-        "c5300_Okina Dragon_Coughing_Dummy_Child -- c5300_翁竜_咳き込み_ダミー_子"
+        "Old Dragon"
       ]
     },
     {
       "ID": 53200033,
       "Entries": [
-        "c5300_Okinayu_Coughing_Dummy_Grandchild -- c5300_翁竜_咳き込み_ダミー_孫"
+        "Old Dragon"
       ]
     },
     {
       "ID": 53200035,
       "Entries": [
-        "c5300_Okina Dragon_Coughing_Main body -- c5300_翁竜_咳き込み_本体"
+        "Old Dragon"
       ]
     },
     {
       "ID": 54000250,
       "Entries": [
-        "c5400_Revived Kensei_Strong Iai_Horizontal (search bullet) -- c5400_蘇った剣聖_強い居合_横（検索弾丸）"
+        "Sword Saint Isshin"
       ]
     },
     {
       "ID": 54000251,
       "Entries": [
-        "c5400_Revived Kensei_Strong Iai_Horizontal (preparatory bullet) -- c5400_蘇った剣聖_強い居合_横（準備弾）"
+        "Sword Saint Isshin"
       ]
     },
     {
       "ID": 54000252,
       "Entries": [
-        "c5400_Revived Kensei_Strong Iai_Horizontal (main body) -- c5400_蘇った剣聖_強い居合_横(本体)"
+        "Sword Saint Isshin"
       ]
     },
     {
       "ID": 54000253,
       "Entries": [
-        "c5400_Revived Kensei_Strong Iai_Horizontal (SFX) -- c5400_蘇った剣聖_強い居合_横(SFX)"
+        "Sword Saint Isshin"
       ]
     },
     {
       "ID": 54000270,
       "Entries": [
-        "c5400_Revived Kensei_Strong Iai_Vertical (dummy live ammunition) -- c5400_蘇った剣聖_強い居合_縦(ダミー実弾)"
+        "Sword Saint Isshin"
       ]
     },
     {
       "ID": 54000271,
       "Entries": [
-        "c5400_Revived Kensei_Strong Iai_Vertical (live bullet) -- c5400_蘇った剣聖_強い居合_縦(実弾)"
+        "Sword Saint Isshin"
       ]
     },
     {
       "ID": 54000272,
       "Entries": [
-        "c5400_Revived Kensei_Strong Iai_Vertical (child) -- c5400_蘇った剣聖_強い居合_縦(子)"
+        "Sword Saint Isshin"
       ]
     },
     {
       "ID": 54000273,
       "Entries": [
-        "c5400_Revived Kensei_Strong Iai_Vertical (grandchild) -- c5400_蘇った剣聖_強い居合_縦(孫)"
+        "Sword Saint Isshin"
       ]
     },
     {
       "ID": 54000274,
       "Entries": [
-        "c5400_Revived Kensei_Strong Iai_Vertical (live bullet) -- c5400_蘇った剣聖_強い居合_縦(実弾)"
+        "Sword Saint Isshin"
       ]
     },
     {
       "ID": 54000275,
       "Entries": [
-        "c5400_Revived Kensei_Strong Iai_Vertical (Parent) -- c5400_蘇った剣聖_強い居合_縦(親)"
+        "Sword Saint Isshin"
       ]
     },
     {
       "ID": 54000310,
       "Entries": [
-        "c5400_Revived Kensei_Desperate Vertical Cut_Bullet 1_Additional Damage -- c5400_蘇った剣聖_必殺の縦切り_弾丸1_加算ダメージ"
+        "Isshin Ashina"
       ]
     },
     {
       "ID": 54000311,
       "Entries": [
-        "c5400_Revived Kensei_Desperate Vertical Cut_Bullet 2_Blow-off Damage -- c5400_蘇った剣聖_必殺の縦切り_弾丸2_吹っ飛びダメージ"
+        "Isshin Ashina"
       ]
     },
     {
       "ID": 54000350,
       "Entries": [
-        "c5400_Revived Kensei_Stomping on the ground_Blow-off damage -- c5400_蘇った剣聖_地面踏みつけ_吹っ飛びダメージ"
+        "Isshin Ashina"
       ]
     },
     {
       "ID": 54000355,
       "Entries": [
-        "c5400_Revived Kensei_Stomping on the ground_Staying on the spot and burning -- c5400_蘇った剣聖_地面踏みつけ_その場に残って炎上"
+        "Isshin Ashina"
       ]
     },
     {
       "ID": 54000360,
       "Entries": [
-        "c5400_Revived Kensei_Flame Slash Test_Spreading Flame_Search Bullet -- c5400_蘇った剣聖_炎斬りテスト_広がる炎_検索弾丸"
+        "Isshin Ashina - Fire"
       ]
     },
     {
       "ID": 54000361,
       "Entries": [
-        "c5400_Revived Kensei_Flame Slash Test_Spreading Flame_Falls to the Ground -- c5400_蘇った剣聖_炎斬りテスト_広がる炎_地面に落ちる"
+        "Isshin Ashina - Fire"
       ]
     },
     {
       "ID": 54000362,
       "Entries": [
-        "c5400_Revived Kensei_Flame Slash Test_Spreading Flame_Damage Bullet -- c5400_蘇った剣聖_炎斬りテスト_広がる炎_ダメージ弾丸"
+        "Isshin Ashina - Fire"
       ]
     },
     {
       "ID": 54000370,
       "Entries": [
-        "c5400_Revived Kensei_Flame Slasher_Fan-shaped Appearance -- c5400_蘇った剣聖_炎斬り_扇状\u3000見た目"
+        "Isshin Ashina - Fire"
       ]
     },
     {
       "ID": 54000371,
       "Entries": [
-        "c5400_Revived Kensei_Flame Slasher_Fan-shaped Atari -- c5400_蘇った剣聖_炎斬り_扇状\u3000アタリ"
+        "Isshin Ashina - Fire"
       ]
     },
     {
       "ID": 54000372,
       "Entries": [
-        "c5400_Revived Kensei_Flame Slasher_Flame Damage -- c5400_蘇った剣聖_炎斬り_炎ダメージ"
+        "Isshin Ashina - Fire"
       ]
     },
     {
       "ID": 54000380,
       "Entries": [
-        "c5400_Revived Kensei_Two consecutive Iai_Launch from player Damipoli_Spread -- c5400_蘇った剣聖_二連居合_プレイヤーのダミポリから発射_広がる"
+        "Sword Saint Isshin"
       ]
     },
     {
       "ID": 54000381,
       "Entries": [
-        "c5400_Revived Kensei_Two consecutive Iai_Fall -- c5400_蘇った剣聖_二連居合_落ちる"
+        "Sword Saint Isshin"
       ]
     },
     {
       "ID": 54000382,
       "Entries": [
-        "c5400_Revived Kensei_Two consecutive Iai_Stay on the ground -- c5400_蘇った剣聖_二連居合_地面にとどまる"
+        "Sword Saint Isshin"
       ]
     },
     {
       "ID": 54000383,
       "Entries": [
-        "c5400_Revived Kensei_Two consecutive Iai_Launch damage -- c5400_蘇った剣聖_二連居合_打ち上げダメージ"
+        "Sword Saint Isshin"
       ]
     },
     {
       "ID": 54000385,
       "Entries": [
-        "c5400_Revived Kensei_Two consecutive Iai_Launched from player Damipoli_Near -- c5400_蘇った剣聖_二連居合_プレイヤーのダミポリから発射_近く"
+        "Sword Saint Isshin"
       ]
     },
     {
       "ID": 54000391,
       "Entries": [
-        "c5400_Revived Kensei_Stomping on the ground_Blow-off damage -- c5400_蘇った剣聖_地面踏みつけ_吹っ飛びダメージ"
+        "Sword Saint Isshin"
       ]
     },
     {
       "ID": 54000392,
       "Entries": [
-        "c5400_Revived Kensei_Delayed Bullet 2_Stay on the Ground -- c5400_蘇った剣聖_遅延弾丸2_地面にとどまる"
+        "Isshin Ashina"
       ]
     },
     {
       "ID": 54000393,
       "Entries": [
-        "c5400_Revived Kensei_Delayed Bullet 3_Burning -- c5400_蘇った剣聖_遅延弾丸3_炎上する"
+        "Isshin Ashina"
       ]
     },
     {
       "ID": 54000630,
       "Entries": [
-        "c5400_Revived Kensei_Weakness Slash (Power Wave Body) -- c5400_蘇った剣聖_脱力斬り（パワーウェイブの本体）"
+        "Isshin Ashina"
       ]
     },
     {
       "ID": 54000631,
       "Entries": [
-        "c5400_Revived Kensei_Weakness Slash (Search Bullet 1) -- c5400_蘇った剣聖_脱力斬り（検索弾丸1）"
+        "Isshin Ashina"
       ]
     },
     {
       "ID": 54000632,
       "Entries": [
-        "c5400_Revived Kensei_Weakness Slash (Search bullet 2_Birth 149 after landing) -- c5400_蘇った剣聖_脱力斬り（検索弾丸2_着弾後149を産む）"
+        "Isshin Ashina"
       ]
     },
     {
       "ID": 54000635,
       "Entries": [
-        "c5400_Revived Kensei_Weakness Slash (SFX) -- c5400_蘇った剣聖_脱力斬り(SFX)"
+        "Isshin Ashina"
       ]
     },
     {
       "ID": 54000639,
       "Entries": [
-        "c5400_Revived Kensei_Weakness Slash (predictive bullet) -- c5400_蘇った剣聖_脱力斬り（予兆弾丸）"
+        "Isshin Ashina"
       ]
     },
     {
       "ID": 54000691,
       "Entries": [
-        "c5400_Revived Kensei_Kounami First Stage_Appearance -- c5400_蘇った剣聖_光波初段_見た目"
+        "Isshin Ashina"
       ]
     },
     {
       "ID": 54000692,
       "Entries": [
-        "c5400_Revived Kensei_Kounami First Stage_Hit -- c5400_蘇った剣聖_光波初段_当たり"
+        "Isshin Ashina"
       ]
     },
     {
       "ID": 54000693,
       "Entries": [
-        "c5400_Revived Kensei_Kounami 2nd Stage_Appearance -- c5400_蘇った剣聖_光波二段_見た目"
+        "Isshin Ashina"
       ]
     },
     {
       "ID": 54000694,
       "Entries": [
-        "c5400_Revived Kensei_Kounami 2nd Stage_Hit -- c5400_蘇った剣聖_光波二段_当たり"
+        "Isshin Ashina"
       ]
     },
     {
       "ID": 54000800,
       "Entries": [
-        "c5400_Revived Kensei_After HU_Pistol -- c5400_蘇った剣聖_HU後_短銃"
+        "Sword Saint Isshin - Pistol"
       ]
     },
     {
       "ID": 54000801,
       "Entries": [
-        "c5400_Revived Kensei_After HU_Pistol_Power Attenuation -- c5400_蘇った剣聖_HU後_短銃_威力減衰"
+        "Sword Saint Isshin - Pistol"
       ]
     },
     {
       "ID": 54000810,
       "Entries": [
-        "c5400_Revived Kensei_After HU_Pistol_Rapid Fire_Left -- c5400_蘇った剣聖_HU後_短銃_連射_左"
+        "Sword Saint Isshin - Pistol"
       ]
     },
     {
       "ID": 54000811,
       "Entries": [
-        "c5400_Revived Kensei_After HU_Pistol_Rapid Fire_Right -- c5400_蘇った剣聖_HU後_短銃_連射_右"
+        "Sword Saint Isshin - Pistol"
       ]
     },
     {
       "ID": 54000812,
       "Entries": [
-        "c5400_Revived Kensei_After HU_Pistol_Rapid Fire_Left_Weak -- c5400_蘇った剣聖_HU後_短銃_連射_左_弱"
+        "Sword Saint Isshin - Pistol"
       ]
     },
     {
       "ID": 54000813,
       "Entries": [
-        "c5400_Revived Kensei_After HU_Pistol_Rapid Fire_Right_Weak -- c5400_蘇った剣聖_HU後_短銃_連射_右_弱"
+        "Sword Saint Isshin - Pistol"
       ]
     },
     {
       "ID": 54000820,
       "Entries": [
-        "c5400_EX Revived Kensei_Strong Iai_Horizontal (First Wave) -- c5400_EX蘇った剣聖_強い居合_横(第一波)"
+        "Inner Isshin"
       ]
     },
     {
       "ID": 54000821,
       "Entries": [
-        "c5400_EX Revived Kensei_Strong Iai_Horizontal (Second Wave_Parent) -- c5400_EX蘇った剣聖_強い居合_横(第二波_親)"
+        "Inner Isshin"
       ]
     },
     {
       "ID": 54000822,
       "Entries": [
-        "c5400_EX Revived Kensei_Strong Iai_Horizontal (Second Wave_Child) -- c5400_EX蘇った剣聖_強い居合_横(第二波_子)"
+        "Inner Isshin"
       ]
     },
     {
       "ID": 54000828,
       "Entries": [
-        "c5400_EX Revived Kensei Strong Iai_Horizontal_Inside SFX -- c5400_EX蘇った剣聖 強い居合_横_内側SFX"
+        "Inner Isshin"
       ]
     },
     {
       "ID": 54000829,
       "Entries": [
-        "c5400_EX Revived Kensei Strong Iai_Horizontal_Outside SFX -- c5400_EX蘇った剣聖 強い居合_横_外側SFX"
+        "Inner Isshin"
       ]
     },
     {
       "ID": 54000830,
       "Entries": [
-        "c5400_EX Revived Kensei_Strong Iai_Vertical -- c5400_EX蘇った剣聖_強い居合_縦"
+        "Inner Isshin"
       ]
     },
     {
       "ID": 54000831,
       "Entries": [
-        "c5400_EX Revived Kensei_Strong Iai_Vertical_Follow-up (parent) -- c5400_EX蘇った剣聖_強い居合_縦_後追い(親)"
+        "Inner Isshin"
       ]
     },
     {
       "ID": 54000832,
       "Entries": [
-        "c5400_EX Revived Kensei_Strong Iai_Vertical_Follow-up (child) -- c5400_EX蘇った剣聖_強い居合_縦_後追い(子)"
+        "Inner Isshin"
       ]
     },
     {
       "ID": 54000833,
       "Entries": [
-        "c5400_EX Revived Kensei_Strong Iai_Vertical_Follow-up (grandchild) -- c5400_EX蘇った剣聖_強い居合_縦_後追い(孫)"
+        "Inner Isshin"
       ]
     },
     {
       "ID": 54000834,
       "Entries": [
-        "c5400_EX Revived Kensei_Strong Iai_Vertical_Follow-up (live bullet) -- c5400_EX蘇った剣聖_強い居合_縦_後追い(実弾)"
+        "Inner Isshin"
       ]
     },
     {
       "ID": 54000835,
       "Entries": [
-        "c5400_EX Revived Kensei_Strong Iai_Vertical_Crawling ver (parent) -- c5400_EX蘇った剣聖_強い居合_縦_這ver(親)"
+        "Inner Isshin"
       ]
     },
     {
       "ID": 54000836,
       "Entries": [
-        "c5400_EX Revived Kensei_Strong Iai_Vertical_Crawling ver (child) -- c5400_EX蘇った剣聖_強い居合_縦_這ver(子)"
+        "Inner Isshin"
       ]
     },
     {
       "ID": 54000837,
       "Entries": [
-        "c5400_EX Revived Kensei_Strong Iai_Vertical_Crawling ver (grandson) -- c5400_EX蘇った剣聖_強い居合_縦_這ver(孫)"
+        "Inner Isshin"
       ]
     },
     {
       "ID": 54000838,
       "Entries": [
-        "c5400_EX Revived Kensei_Strong Iai_Vertical_Crawling ver (live bullet) -- c5400_EX蘇った剣聖_強い居合_縦_這ver(実弾)"
+        "Inner Isshin"
       ]
     },
     {
       "ID": 54000980,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign thrust -- ダミー弾丸_危険な攻撃予兆\u3000突き"
+        "Isshin - Perilous Attack Warning"
       ]
     },
     {
       "ID": 54000981,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign Lower -- ダミー弾丸_危険な攻撃予兆\u3000下段"
+        "Isshin - Perilous Attack Warning"
       ]
     },
     {
       "ID": 54000982,
       "Entries": [
-        "Dummy Bullet_Dangerous Attack Prediction Lower Level from Lifting -- ダミー弾丸_危険な攻撃予兆\u3000かち上げからの下段"
+        "Isshin - Perilous Attack Warning"
       ]
     },
     {
       "ID": 54000983,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign Yokoi Ai -- ダミー弾丸_危険な攻撃予兆\u3000横居合"
+        "Isshin - Perilous Attack Warning"
       ]
     },
     {
       "ID": 54000984,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign Vertical Iai -- ダミー弾丸_危険な攻撃予兆\u3000縦居合"
+        "Isshin - Perilous Attack Warning"
       ]
     },
     {
       "ID": 54000985,
       "Entries": [
-        "Dummy Bullet_Dangerous Attack Prediction Deadly Vertical Slash -- ダミー弾丸_危険な攻撃予兆\u3000必殺の縦斬り"
+        "Isshin - Perilous Attack Warning"
       ]
     },
     {
       "ID": 54000986,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign Thrust with a spear -- ダミー弾丸_危険な攻撃予兆\u3000槍で突き"
+        "Isshin - Perilous Attack Warning"
       ]
     },
     {
       "ID": 54000987,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign Lower with spear -- ダミー弾丸_危険な攻撃予兆\u3000槍で下段"
+        "Isshin - Perilous Attack Warning"
       ]
     },
     {
       "ID": 54000988,
       "Entries": [
-        "Dummy Bullet_Dangerous Attack Prediction Aikido Throw -- ダミー弾丸_危険な攻撃予兆\u3000合気道投げ"
+        "Isshin - Perilous Attack Warning"
       ]
     },
     {
       "ID": 70000980,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Mai continuous attack 3 _ Lower tightening -- ダミー弾丸_危険な攻撃予兆_舞連撃3_下段締め"
+        "O'Rin - Perilous Attack Warning"
       ]
     },
     {
       "ID": 70000981,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Slash around _ Left _ Lower -- ダミー弾丸_危険な攻撃予兆_回り込み斬り_左_下段"
+        "O'Rin - Perilous Attack Warning"
       ]
     },
     {
       "ID": 70000982,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Slash around _ Left _ Lower -- ダミー弾丸_危険な攻撃予兆_回り込み斬り_左_下段"
+        "O'Rin - Perilous Attack Warning"
       ]
     },
     {
       "ID": 70100000,
       "Entries": [
-        "c7010_Busshi (NPC) _Buddha image throwing -- c7010_仏師（NPC）_仏像投げ"
+        "Sculptor"
       ]
     },
     {
       "ID": 70200122,
       "Entries": [
-        "c7020_Busshi Demon_FW_Dummy_Parent -- c7020_仏師鬼_FW_ダミー_親"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70200123,
       "Entries": [
-        "c7020_Busshi demon_FW_dummy_child -- c7020_仏師鬼_FW_ダミー_子"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70200124,
       "Entries": [
-        "c7020_Busshi Demon_FW_Grandson -- c7020_仏師鬼_FW_孫"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70200125,
       "Entries": [
-        "c7020_Busshi demon_FW_main body -- c7020_仏師鬼_FW_本体"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70200126,
       "Entries": [
-        "c7020_Busshi Demon_Long Jump Right Hand Slamming_Shock Wave_ -- c7020_仏師鬼_幅跳び右手叩き付け_衝撃波_"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70200222,
       "Entries": [
-        "c7020_Busshi Demon_Flame Ranbu_Dummy_Diffusion -- c7020_仏師鬼_炎乱舞_ダミー_拡散"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70200223,
       "Entries": [
-        "c7020_Busshi Demon_Flame Ranbu_Demon Buddha_Rise -- c7020_仏師鬼_炎乱舞_鬼仏_上昇"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70200224,
       "Entries": [
-        "c7020_Busshi Oni_Flame Ranbu_Onibutsu_Staying -- c7020_仏師鬼_炎乱舞_鬼仏_滞空"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70200225,
       "Entries": [
-        "c7020_Busshi Oni_Flame Ranbu_Onibutsu_Main body -- c7020_仏師鬼_炎乱舞_鬼仏_本体"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70200231,
       "Entries": [
-        "c7020_Busshi Demon_Landing Shockwave_Dummy -- c7020_仏師鬼_着地衝撃波_ダミー"
+        "Demon of Hatred - Self-explosion Shockwave"
       ]
     },
     {
       "ID": 70200232,
       "Entries": [
-        "c7020_Busshi demon_landing shock wave -- c7020_仏師鬼_着地衝撃波"
+        "Demon of Hatred - Self-explosion Shockwave"
       ]
     },
     {
       "ID": 70200233,
       "Entries": [
-        "c7020_Busshi demon_Wide range shock wave_First stage_DL3 -- c7020_仏師鬼_広範囲衝撃波_一段目_DL3"
+        "Demon of Hatred - Self-explosion Shockwave"
       ]
     },
     {
       "ID": 70200234,
       "Entries": [
-        "c7020_Busshi demon_Wide range shock wave_Second stage_DL10 -- c7020_仏師鬼_広範囲衝撃波_二段目_DL10"
+        "Demon of Hatred - Self-explosion Shockwave"
       ]
     },
     {
       "ID": 70200270,
       "Entries": [
-        "c7020_Busshi Demon_Breath_Dummy_Parent -- c7020_仏師鬼_ブレス_ダミー_親"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70200271,
       "Entries": [
-        "c7020_Busshi Demon_Breath_Dummy_Child -- c7020_仏師鬼_ブレス_ダミー_子"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70200272,
       "Entries": [
-        "c7020_Busshi Demon_Breath_Dummy_Grandson -- c7020_仏師鬼_ブレス_ダミー_孫"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70200273,
       "Entries": [
-        "c7020_Busshi Demon_Breath_Center -- c7020_仏師鬼_ブレス_中心"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70200274,
       "Entries": [
-        "c7020_Busshi Demon_Breath_Around -- c7020_仏師鬼_ブレス_周辺"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70200280,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_Main Body -- c7020_仏師鬼_ダメージ床用_炎_本体"
+        "Demon of Hatred - Self-explosion"
       ]
     },
     {
       "ID": 70200281,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_Short Life -- c7020_仏師鬼_ダメージ床用_炎_寿命短め"
+        "Demon of Hatred - Self-explosion"
       ]
     },
     {
       "ID": 70200282,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_Short Life -- c7020_仏師鬼_ダメージ床用_炎_寿命短め"
+        "Demon of Hatred - Self-explosion"
       ]
     },
     {
       "ID": 70200290,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_Diffusion dmp51_00 -- c7020_仏師鬼_ダメージ床用_炎_拡散dmp51_00"
+        "Demon of Hatred - Self-explosion"
       ]
     },
     {
       "ID": 70200300,
       "Entries": [
-        "c7020_Busshi demon_extending flame -- c7020_仏師鬼_延びる炎"
+        "Demon of Hatred - Self-explosion"
       ]
     },
     {
       "ID": 70200301,
       "Entries": [
-        "c7020_Busshi Demon_Extending Flame_Floor Flame Dummy -- c7020_仏師鬼_延びる炎_床炎上用ダミー"
+        "Demon of Hatred - Self-explosion"
       ]
     },
     {
       "ID": 70200310,
       "Entries": [
-        "c7020_Busshi Demon_Range Explosion_Dummy_Parent -- c7020_仏師鬼_範囲爆発_ダミー_親"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70200311,
       "Entries": [
-        "c7020_Busshi Demon_Range Explosion_Dummy_Child -- c7020_仏師鬼_範囲爆発_ダミー_子"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70200312,
       "Entries": [
-        "c7020_Busshi Demon_Range Explosion_Dummy_Grandson -- c7020_仏師鬼_範囲爆発_ダミー_孫"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70200313,
       "Entries": [
-        "c7020_Busshi Demon_Range Explosion_Dummy_Great Grandson -- c7020_仏師鬼_範囲爆発_ダミー_曾孫"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70200315,
       "Entries": [
-        "c7020_Busshi Demon_Range Explosion__Main Body_Parent -- c7020_仏師鬼_範囲爆発__本体_親"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70200316,
       "Entries": [
-        "c7020_Busshi Demon_Range Explosion__Main Body_Child -- c7020_仏師鬼_範囲爆発__本体_子"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70200320,
       "Entries": [
-        "c7020_Busshi demon_FB_First stage_Before division -- c7020_仏師鬼_FB_一段目_分裂前"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70200321,
       "Entries": [
-        "c7020_Busshi demon_FB_second stage -- c7020_仏師鬼_FB_二段目"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70200322,
       "Entries": [
-        "c7020_Busshi Demon_FB_Explosion -- c7020_仏師鬼_FB_爆発"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70200323,
       "Entries": [
-        "c7020_Busshi demon_FB_First stage_After division -- c7020_仏師鬼_FB_一段目_分裂後"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70200350,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp50_01_Horizontal Dummy -- c7020_仏師鬼_ダメージ床用_炎_dmp50_01_水平取り用ダミー"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200351,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp50_02_Horizontal Dummy -- c7020_仏師鬼_ダメージ床用_炎_dmp50_02_水平取り用ダミー"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200352,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp50_03_Horizontal Dummy -- c7020_仏師鬼_ダメージ床用_炎_dmp50_03_水平取り用ダミー"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200353,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp50_04_Horizontal Dummy -- c7020_仏師鬼_ダメージ床用_炎_dmp50_04_水平取り用ダミー"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200354,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp50_05_Horizontal Dummy -- c7020_仏師鬼_ダメージ床用_炎_dmp50_05_水平取り用ダミー"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200355,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp50_06_Horizontal Dummy -- c7020_仏師鬼_ダメージ床用_炎_dmp50_06_水平取り用ダミー"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200356,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp50_07_Horizontal Dummy -- c7020_仏師鬼_ダメージ床用_炎_dmp50_07_水平取り用ダミー"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200357,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp51_01_Horizontal Dummy -- c7020_仏師鬼_ダメージ床用_炎_dmp51_01_水平取り用ダミー"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200358,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp51_02_Horizontal Dummy -- c7020_仏師鬼_ダメージ床用_炎_dmp51_02_水平取り用ダミー"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200359,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp51_03_Horizontal Dummy -- c7020_仏師鬼_ダメージ床用_炎_dmp51_03_水平取り用ダミー"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200360,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp51_04_Horizontal Dummy -- c7020_仏師鬼_ダメージ床用_炎_dmp51_04_水平取り用ダミー"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200361,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp51_05_Horizontal Dummy -- c7020_仏師鬼_ダメージ床用_炎_dmp51_05_水平取り用ダミー"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200362,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp51_06_Horizontal Dummy -- c7020_仏師鬼_ダメージ床用_炎_dmp51_06_水平取り用ダミー"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200363,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp51_07_Horizontal Dummy -- c7020_仏師鬼_ダメージ床用_炎_dmp51_07_水平取り用ダミー"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200364,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp52_01_Horizontal Dummy -- c7020_仏師鬼_ダメージ床用_炎_dmp52_01_水平取り用ダミー"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200365,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp52_02_Horizontal Dummy -- c7020_仏師鬼_ダメージ床用_炎_dmp52_02_水平取り用ダミー"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200366,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp52_03_Horizontal Dummy -- c7020_仏師鬼_ダメージ床用_炎_dmp52_03_水平取り用ダミー"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200367,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp52_04_Horizontal Dummy -- c7020_仏師鬼_ダメージ床用_炎_dmp52_04_水平取り用ダミー"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200368,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp52_05_Horizontal Dummy -- c7020_仏師鬼_ダメージ床用_炎_dmp52_05_水平取り用ダミー"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200369,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp52_06_Horizontal Dummy -- c7020_仏師鬼_ダメージ床用_炎_dmp52_06_水平取り用ダミー"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200370,
       "Entries": [
-        "c7020_Busshi Demon__Damage Floor_Flame_dmp52_07_Horizontal Dummy -- c7020_仏師鬼__ダメージ床用_炎_dmp52_07_水平取り用ダミー"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200380,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_Diffusion dmp51_00 -- c7020_仏師鬼_ダメージ床用_炎_拡散dmp51_00"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200390,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp50_01_Horizontal Dummy -- c7020_仏師鬼_ダメージ床用_炎_dmp50_01_水平取り用ダミー"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200440,
       "Entries": [
-        "c7020_Busshi Demon_Flame Wall_Dummy -- c7020_仏師鬼_炎壁_ダミー"
+        "Demon of Hatred - Flame Wall"
       ]
     },
     {
       "ID": 70200441,
       "Entries": [
-        "c7020_Busshi Demon_Flame Wall -- c7020_仏師鬼_炎壁"
+        "Demon of Hatred - Flame Wall"
       ]
     },
     {
       "ID": 70200450,
       "Entries": [
-        "c7020_Busshi Demon_Self-centered Explosion_HU2 -- c7020_仏師鬼_自己中心爆発_HU2"
+        "Demon of Hatred - Self-explosion"
       ]
     },
     {
       "ID": 70200451,
       "Entries": [
-        "c7020_Busshi demon_Wide range shock wave HU2_First stage_DL3 -- c7020_仏師鬼_広範囲衝撃波HU2_一段目_DL3"
+        "Demon of Hatred - Self-explosion"
       ]
     },
     {
       "ID": 70200452,
       "Entries": [
-        "c7020_Busshi demon_Wide range shock wave HU2_Second stage_DL10 -- c7020_仏師鬼_広範囲衝撃波HU2_二段目_DL10"
+        "Demon of Hatred - Self-explosion"
       ]
     },
     {
       "ID": 70200460,
       "Entries": [
-        "c7020_Busshi Demon_Meteor_Diffusion -- c7020_仏師鬼_メテオ_拡散"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70200461,
       "Entries": [
-        "c7020_Busshi Demon_Meteor_Rise -- c7020_仏師鬼_メテオ_上昇"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70200462,
       "Entries": [
-        "c7020_Busshi Demon_Meteor_Staying -- c7020_仏師鬼_メテオ_滞空"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70200463,
       "Entries": [
-        "c7020_Busshi demon_Meteor_body -- c7020_仏師鬼_メテオ_本体"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70200500,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp50_01 -- c7020_仏師鬼_ダメージ床用_炎_dmp50_01"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200501,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp50_02 -- c7020_仏師鬼_ダメージ床用_炎_dmp50_02"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200502,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp50_03 -- c7020_仏師鬼_ダメージ床用_炎_dmp50_03"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200503,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp50_04 -- c7020_仏師鬼_ダメージ床用_炎_dmp50_04"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200504,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp50_05 -- c7020_仏師鬼_ダメージ床用_炎_dmp50_05"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200505,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp50_06 -- c7020_仏師鬼_ダメージ床用_炎_dmp50_06"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200506,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp50_07 -- c7020_仏師鬼_ダメージ床用_炎_dmp50_07"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200507,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp51_01 -- c7020_仏師鬼_ダメージ床用_炎_dmp51_01"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200508,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp51_02 -- c7020_仏師鬼_ダメージ床用_炎_dmp51_02"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200509,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp51_03 -- c7020_仏師鬼_ダメージ床用_炎_dmp51_03"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200510,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp51_04 -- c7020_仏師鬼_ダメージ床用_炎_dmp51_04"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200511,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp51_05 -- c7020_仏師鬼_ダメージ床用_炎_dmp51_05"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200512,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp51_06 -- c7020_仏師鬼_ダメージ床用_炎_dmp51_06"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200513,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp51_07 -- c7020_仏師鬼_ダメージ床用_炎_dmp51_07"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200514,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp52_01 -- c7020_仏師鬼_ダメージ床用_炎_dmp52_01"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200515,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp52_02 -- c7020_仏師鬼_ダメージ床用_炎_dmp52_02"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200516,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp52_03 -- c7020_仏師鬼_ダメージ床用_炎_dmp52_03"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200517,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp52_04 -- c7020_仏師鬼_ダメージ床用_炎_dmp52_04"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200518,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp52_05 -- c7020_仏師鬼_ダメージ床用_炎_dmp52_05"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200519,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp52_06 -- c7020_仏師鬼_ダメージ床用_炎_dmp52_06"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200520,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp52_07 -- c7020_仏師鬼_ダメージ床用_炎_dmp52_07"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200530,
       "Entries": [
-        "c7020_Busshi Demon_Damage Floor_Flame_dmp50_01 -- c7020_仏師鬼_ダメージ床用_炎_dmp50_01"
+        "Demon of Hatred - Flame Ground"
       ]
     },
     {
       "ID": 70200950,
       "Entries": [
-        "Special effect bullet for foot judgment -- 足元判定用特殊効果弾"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70200960,
       "Entries": [
-        "Bullet for erasing demon Buddha bullets -- 鬼仏弾消去用弾丸"
+        "Delete Demon of Hatred's Bullets"
       ]
     },
     {
       "ID": 70200980,
       "Entries": [
-        "Dummy bullets _ Dangerous attack sign _ Slashing through _ Lower row -- ダミー弾丸_危険な攻撃予兆_斬り抜けなぎ払い_下段"
+        "Demon of Hatred - Perilous Attack Warning"
       ]
     },
     {
       "ID": 70200981,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Flame surrounding attack _ Lower -- ダミー弾丸_危険な攻撃予兆_炎取り囲み攻撃_下段"
+        "Demon of Hatred - Perilous Attack Warning"
       ]
     },
     {
       "ID": 70200982,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Fire wave _ Lower -- ダミー弾丸_危険な攻撃予兆_ファイアウェーブ_下段"
+        "Demon of Hatred - Perilous Attack Warning"
       ]
     },
     {
       "ID": 70210100,
       "Entries": [
-        "c7021_demon Buddha_temporary bullet -- c7021_鬼仏_仮弾丸"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 71000500,
       "Entries": [
-        "c7100_Rival bow_Short distance 0 -- c7100_ライバル\u3000弓_近距離0"
+        "Genichiro - Bow Short Distance"
       ]
     },
     {
       "ID": 71000501,
       "Entries": [
-        "c7100_rival bow_long distance 0 -- c7100_ライバル\u3000弓_遠距離0"
+        "Genichiro - Bow Long Distance"
       ]
     },
     {
       "ID": 71000502,
       "Entries": [
-        "c7100_Rival Bow_Short Distance 1 -- c7100_ライバル\u3000弓_近距離1"
+        "Genichiro - Bow Short Distance"
       ]
     },
     {
       "ID": 71000503,
       "Entries": [
-        "c7100_Rival Bow_Long Distance 1 -- c7100_ライバル\u3000弓_遠距離1"
+        "Genichiro - Bow Long Distance"
       ]
     },
     {
       "ID": 71000510,
       "Entries": [
-        "c7100_Rival Reservoir Bow -- c7100_ライバル\u3000溜め弓"
+        "Genichiro - Charged Bow"
       ]
     },
     {
       "ID": 71000520,
       "Entries": [
-        "c7100_ rival thunder bow -- c7100_ライバル\u3000雷弓"
+        "Genichiro"
       ]
     },
     {
       "ID": 71000530,
       "Entries": [
-        "c7100_Rival bow four-shot 1 -- c7100_ライバル\u3000弓四連射1"
+        "Genichiro - Quadruple Bow Shot"
       ]
     },
     {
       "ID": 71000531,
       "Entries": [
-        "c7100_Rival bow four-shot 2 -- c7100_ライバル\u3000弓四連射2"
+        "Genichiro - Quadruple Bow Shot"
       ]
     },
     {
       "ID": 71000532,
       "Entries": [
-        "c7100_Rival bow four-shot 3 -- c7100_ライバル\u3000弓四連射3"
+        "Genichiro - Quadruple Bow Shot"
       ]
     },
     {
       "ID": 71000533,
       "Entries": [
-        "c7100_Rival bow four-shot 4 -- c7100_ライバル\u3000弓四連射4"
+        "Genichiro - Quadruple Bow Shot"
       ]
     },
     {
       "ID": 71000540,
       "Entries": [
-        "c7100_ Rival Brake Bow Predictive Shooting Ali -- c7100_ライバル\u3000ブレーキ弓\u3000予測射撃アリ"
+        "Genichiro - Bow"
       ]
     },
     {
       "ID": 71000600,
       "Entries": [
-        "c7100_EX Rival Vertical Rise Rotation Slash 1_SFX -- c7100_EXライバル\u3000垂直上昇回転斬り1_SFX"
+        "Inner Genichiro - Sakura Dance"
       ]
     },
     {
       "ID": 71000601,
       "Entries": [
-        "c7100_EX Rival Vertical Rise Rotation Slash 2_SFX -- c7100_EXライバル\u3000垂直上昇回転斬り2_SFX"
+        "Inner Genichiro - Sakura Dance"
       ]
     },
     {
       "ID": 71000602,
       "Entries": [
-        "c7100_EX Rival Vertical Rise Rotation Slash 3_SFX -- c7100_EXライバル\u3000垂直上昇回転斬り3_SFX"
+        "Inner Genichiro - Sakura Dance"
       ]
     },
     {
       "ID": 71000610,
       "Entries": [
-        "c7100_EX Rival Vertical Rise Rotation Slash 1_SFX_ Petals -- c7100_EXライバル\u3000垂直上昇回転斬り1_SFX_花弁"
+        "Inner Genichiro - Sakura Dance"
       ]
     },
     {
       "ID": 71000611,
       "Entries": [
-        "c7100_EX Rival Vertical Rise Rotation Slash 2_SFX_ Petals -- c7100_EXライバル\u3000垂直上昇回転斬り2_SFX_花弁"
+        "Inner Genichiro - Sakura Dance"
       ]
     },
     {
       "ID": 71000612,
       "Entries": [
-        "c7100_EX Rival Vertical Rise Rotation Slash 3_SFX_ Petals -- c7100_EXライバル\u3000垂直上昇回転斬り3_SFX_花弁"
+        "Inner Genichiro - Sakura Dance"
       ]
     },
     {
       "ID": 71000980,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign Lower breakthrough -- ダミー弾丸_危険な攻撃予兆\u3000下段切り抜け"
+        "Genichiro - Perilous Attack Warning"
       ]
     },
     {
       "ID": 71000981,
       "Entries": [
-        "Dummy Bullet_Dangerous Attack Prediction Throw Transition -- ダミー弾丸_危険な攻撃予兆\u3000投げ遷移"
+        "Genichiro - Perilous Attack Warning"
       ]
     },
     {
       "ID": 71000982,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign -- ダミー弾丸_危険な攻撃予兆\u3000八艘飛びからの突き"
+        "Genichiro - Perilous Attack Warning"
       ]
     },
     {
       "ID": 71000983,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign Backstep thrust -- ダミー弾丸_危険な攻撃予兆\u3000バックステップ突き"
+        "Genichiro - Perilous Attack Warning"
       ]
     },
     {
       "ID": 71000984,
       "Entries": [
-        "Dummy Bullet_Dangerous Attack Prediction Finish Lower Slash -- ダミー弾丸_危険な攻撃予兆\u3000フィニッシュ下段斬り"
+        "Genichiro - Perilous Attack Warning"
       ]
     },
     {
       "ID": 71000985,
       "Entries": [
-        "Dummy Bullet_Dangerous Attack Prediction Down Revenge -- ダミー弾丸_危険な攻撃予兆\u3000ダウン追い討ち"
+        "Genichiro - Perilous Attack Warning"
       ]
     },
     {
       "ID": 71100500,
       "Entries": [
-        "c7110_Rival Naked Bow_Short Distance 0 -- c7110_ライバル裸\u3000弓_近距離0"
+        "Genichiro, Way of Tomoe - Bow Short Distance"
       ]
     },
     {
       "ID": 71100501,
       "Entries": [
-        "c7110_Rival Naked Bow_Long Distance 0 -- c7110_ライバル裸\u3000弓_遠距離0"
+        "Genichiro, Way of Tomoe - Bow Long Distance"
       ]
     },
     {
       "ID": 71100502,
       "Entries": [
-        "c7110_Rival Naked Bow_Short Distance 1 -- c7110_ライバル裸\u3000弓_近距離1"
+        "Genichiro, Way of Tomoe - Bow Short Distance"
       ]
     },
     {
       "ID": 71100503,
       "Entries": [
-        "c7110_Rival Naked Bow_Long Distance 1 -- c7110_ライバル裸\u3000弓_遠距離1"
+        "Genichiro, Way of Tomoe - Bow Long Distance"
       ]
     },
     {
       "ID": 71100510,
       "Entries": [
-        "c7110_ Rival Naked Reservoir Bow -- c7110_ライバル裸\u3000溜め弓"
+        "Genichiro, Way of Tomoe - Charged Bow"
       ]
     },
     {
       "ID": 71100520,
       "Entries": [
-        "c7110_ rival naked thunder bow -- c7110_ライバル裸\u3000雷弓"
+        "Genichiro, Way of Tomoe - Lightning Arrow"
       ]
     },
     {
       "ID": 71100521,
       "Entries": [
-        "c7110_Rival naked thunder bow_thunder part -- c7110_ライバル裸\u3000雷弓_雷部分"
+        "Genichiro, Way of Tomoe - Lightning Arrow"
       ]
     },
     {
       "ID": 71100530,
       "Entries": [
-        "c7110_ Rival Naked Bow Four Fires 1 -- c7110_ライバル裸\u3000弓四連射1"
+        "Genichiro, Way of Tomoe - Quadruple Shot"
       ]
     },
     {
       "ID": 71100531,
       "Entries": [
-        "c7110_ Rival Naked Bow Four Fires 2 -- c7110_ライバル裸\u3000弓四連射2"
+        "Genichiro, Way of Tomoe - Quadruple Shot"
       ]
     },
     {
       "ID": 71100532,
       "Entries": [
-        "c7110_ Rival Naked Bow Four Fires 3 -- c7110_ライバル裸\u3000弓四連射3"
+        "Genichiro, Way of Tomoe - Quadruple Shot"
       ]
     },
     {
       "ID": 71100533,
       "Entries": [
-        "c7110_ Rival Naked Bow Four Fires 4 -- c7110_ライバル裸\u3000弓四連射4"
+        "Genichiro, Way of Tomoe - Quadruple Shot"
       ]
     },
     {
       "ID": 71100540,
       "Entries": [
-        "c7110_ Rival Naked Brake Bow Predictive Shooting Ali -- c7110_ライバル裸\u3000ブレーキ弓\u3000予測射撃アリ"
+        "Genichiro, Way of Tomoe - Bow"
       ]
     },
     {
       "ID": 71100600,
       "Entries": [
-        "c7110_EX Rival Naked Vertical Rise Rotation Slash 1_SFX -- c7110_EXライバル裸\u3000垂直上昇回転斬り1_SFX"
+        "Genichiro, Way of Tomoe - Sakura Dance"
       ]
     },
     {
       "ID": 71100601,
       "Entries": [
-        "c7110_EX Rival Naked Vertical Rise Rotation Slash 2_SFX -- c7110_EXライバル裸\u3000垂直上昇回転斬り2_SFX"
+        "Genichiro, Way of Tomoe - Sakura Dance"
       ]
     },
     {
       "ID": 71100602,
       "Entries": [
-        "c7110_EX Rival Naked Vertical Rise Rotation Slash 3_SFX -- c7110_EXライバル裸\u3000垂直上昇回転斬り3_SFX"
+        "Genichiro, Way of Tomoe - Sakura Dance"
       ]
     },
     {
       "ID": 71100610,
       "Entries": [
-        "c7110_EX Rival Naked Vertical Rise Rotation Slash 1_SFX_ Petals -- c7110_EXライバル裸\u3000垂直上昇回転斬り1_SFX_花弁"
+        "Genichiro, Way of Tomoe - Sakura Dance"
       ]
     },
     {
       "ID": 71100611,
       "Entries": [
-        "c7110_EX Rival Naked Vertical Rise Rotation Slash 2_SFX_ Petals -- c7110_EXライバル裸\u3000垂直上昇回転斬り2_SFX_花弁"
+        "Genichiro, Way of Tomoe - Sakura Dance"
       ]
     },
     {
       "ID": 71100612,
       "Entries": [
-        "c7110_EX Rival Naked Vertical Rise Rotation Slash 3_SFX_ Petals -- c7110_EXライバル裸\u3000垂直上昇回転斬り3_SFX_花弁"
+        "Genichiro, Way of Tomoe - Sakura Dance"
       ]
     },
     {
       "ID": 71100620,
       "Entries": [
-        "c7110_EX Rival Naked Vertical Rise Rotation Slash 1_SFX_ Lightning Return -- c7110_EXライバル裸\u3000垂直上昇回転斬り1_SFX_雷返し返し"
+        "Genichiro, Way of Tomoe - Sakura Dance Lightning Reversal"
       ]
     },
     {
       "ID": 71100621,
       "Entries": [
-        "c7110_EX Rival Naked Vertical Rise Rotation Slash 2_SFX_ Lightning Return -- c7110_EXライバル裸\u3000垂直上昇回転斬り2_SFX_雷返し返し"
+        "Genichiro, Way of Tomoe - Sakura Dance Lightning Reversal"
       ]
     },
     {
       "ID": 71100622,
       "Entries": [
-        "c7110_EX Rival Naked Vertical Rise Rotation Slash 3_SFX_ Lightning Return -- c7110_EXライバル裸\u3000垂直上昇回転斬り3_SFX_雷返し返し"
+        "Genichiro, Way of Tomoe - Sakura Dance Lightning Reversal"
       ]
     },
     {
       "ID": 71100980,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign Lower breakthrough -- ダミー弾丸_危険な攻撃予兆\u3000下段切り抜け"
+        "Genichiro, Way of Tomoe - Perilous Attack Warning"
       ]
     },
     {
       "ID": 71100981,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign Lariat neck grab and pull -- ダミー弾丸_危険な攻撃予兆\u3000ラリアット首掴み引き寄せ"
+        "Genichiro, Way of Tomoe - Perilous Attack Warning"
       ]
     },
     {
       "ID": 71100982,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign -- ダミー弾丸_危険な攻撃予兆\u3000八艘飛びからの突き"
+        "Genichiro, Way of Tomoe - Perilous Attack Warning"
       ]
     },
     {
       "ID": 71100983,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign Backstep thrust -- ダミー弾丸_危険な攻撃予兆\u3000バックステップ突き"
+        "Genichiro, Way of Tomoe - Perilous Attack Warning"
       ]
     },
     {
       "ID": 71100984,
       "Entries": [
-        "Dummy Bullet_Dangerous Attack Prediction Finish Lower Slash -- ダミー弾丸_危険な攻撃予兆\u3000フィニッシュ下段斬り"
+        "Genichiro, Way of Tomoe - Perilous Attack Warning"
       ]
     },
     {
       "ID": 71100985,
       "Entries": [
-        "Dummy Bullet_Dangerous Attack Prediction Thrust from Repartition -- ダミー弾丸_危険な攻撃予兆\u3000仕切り直しからの突き"
+        "Genichiro, Way of Tomoe - Perilous Attack Warning"
       ]
     },
     {
       "ID": 71100986,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign Jump slash before thunder -- ダミー弾丸_危険な攻撃予兆\u3000雷前ジャンプ斬り"
+        "Genichiro, Way of Tomoe - Perilous Attack Warning"
       ]
     },
     {
       "ID": 71100987,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign Lei Heng jump slash -- ダミー弾丸_危険な攻撃予兆\u3000雷横ジャンプ斬り"
+        "Genichiro, Way of Tomoe - Perilous Attack Warning"
       ]
     },
     {
       "ID": 71100988,
       "Entries": [
-        "Dummy Bullet_Dangerous Attack Predictor Thunder Bow -- ダミー弾丸_危険な攻撃予兆\u3000雷弓"
+        "Genichiro, Way of Tomoe - Perilous Attack Warning"
       ]
     },
     {
       "ID": 71100989,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign Dash Eight stabs -- ダミー弾丸_危険な攻撃予兆\u3000ダッシュ八艘飛び突き"
+        "Genichiro, Way of Tomoe - Perilous Attack Warning"
       ]
     },
     {
       "ID": 74000980,
       "Entries": [
-        "c7100_Daughter of Medical Holy_Dummy Bullet_Dangerous Attack Prediction -- c7100_医聖の娘_ダミー弾丸_危険な攻撃予兆"
+        "Emma - Perilous Attack Warning"
       ]
     },
     {
       "ID": 74000981,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Thrust from slashing -- ダミー弾丸_危険な攻撃予兆_斬り下がりからの突き"
+        "Emma - Perilous Attack Warning"
       ]
     },
     {
       "ID": 74000982,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Lower payment from slashing -- ダミー弾丸_危険な攻撃予兆_斬り下がりからの下段払い"
+        "Emma - Perilous Attack Warning"
       ]
     },
     {
       "ID": 74000983,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Swallow -- ダミー弾丸_危険な攻撃予兆_燕返し"
+        "Emma - Perilous Attack Warning"
       ]
     },
     {
       "ID": 74000984,
       "Entries": [
-        "Dummy bullet _ dangerous attack sign _ jumping technique -- ダミー弾丸_危険な攻撃予兆_飛び技"
+        "Emma - Perilous Attack Warning"
       ]
     },
     {
       "ID": 74000985,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Iai connected from repartitioning -- ダミー弾丸_危険な攻撃予兆_仕切り直しから繋がる居合"
+        "Emma - Perilous Attack Warning"
       ]
     },
     {
       "ID": 74000986,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Swallowing from right hit -- ダミー弾丸_危険な攻撃予兆_右弾かれからの燕返し"
+        "Emma - Perilous Attack Warning"
       ]
     },
     {
       "ID": 74000987,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Lower sword from left hit -- ダミー弾丸_危険な攻撃予兆_左弾かれからの下段薙ぎ"
+        "Emma - Perilous Attack Warning"
       ]
     }
   ]

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/Bullet.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/Bullet.json
@@ -82,19 +82,19 @@
     {
       "ID": 290,
       "Entries": [
-        "Anti-spirit force -- 対霊フォース"
+        "Anti-Apparition Force"
       ]
     },
     {
       "ID": 295,
       "Entries": [
-        "Depression Force_Parent -- 恐慌フォース_親"
+        "Red Eyes Scare Parent"
       ]
     },
     {
       "ID": 296,
       "Entries": [
-        "Depression Force_Child -- 恐慌フォース_子"
+        "Red Eyes Scare Child"
       ]
     },
     {
@@ -328,103 +328,103 @@
     {
       "ID": 999,
       "Entries": [
-        "Prosthetic hand ninja tool_form consumption dummy -- 義手忍具_形代消費ダミー"
+        "Prosthetic Tool - Spirit Emblem Consumption Dummy"
       ]
     },
     {
       "ID": 1000,
       "Entries": [
-        "Prosthetic Hand Ninja _ Finger Whistle _ Lock On _ From Enemy _ Parent A (Reservoir) -- 義手忍具_指笛_ロックオン_敵から_親A（溜め）"
+        "Finger Whistle Lock"
       ]
     },
     {
       "ID": 1001,
       "Entries": [
-        "Prosthetic Hand Ninja _ Finger Whistle _ Lock On _ From Enemy _ Parent B -- 義手忍具_指笛_ロックオン_敵から_親B"
+        "Finger Whistle Lock"
       ]
     },
     {
       "ID": 1002,
       "Entries": [
-        "Prosthetic hand ninja _ finger whistle _ lock-on _ from enemy _ child A (reservoir) -- 義手忍具_指笛_ロックオン_敵から_子A（溜め）"
+        "Finger Whistle Lock"
       ]
     },
     {
       "ID": 1003,
       "Entries": [
-        "Prosthetic Hand Ninja _ Finger Whistle _ Lock On _ From Enemy _ Child B -- 義手忍具_指笛_ロックオン_敵から_子B"
+        "Finger Whistle Lock"
       ]
     },
     {
       "ID": 1004,
       "Entries": [
-        "Prosthetic hand ninja _ finger whistle _ lock-on _ from enemy _ grandson A (reservoir) -- 義手忍具_指笛_ロックオン_敵から_孫A（溜め）"
+        "Finger Whistle Lock"
       ]
     },
     {
       "ID": 1010,
       "Entries": [
-        "Prosthetic hand ninja _ finger whistle LV3 _ lock on _ from enemy _ parent A (reservoir) -- 義手忍具_指笛LV3_ロックオン_敵から_親A（溜め）"
+        "Malcontent Lock"
       ]
     },
     {
       "ID": 1011,
       "Entries": [
-        "Prosthetic Hand Ninja _ Finger Whistle LV3 _ Lock On _ From Enemy _ Parent B -- 義手忍具_指笛LV3_ロックオン_敵から_親B"
+        "Malcontent Lock"
       ]
     },
     {
       "ID": 1012,
       "Entries": [
-        "Prosthetic hand ninja _ finger whistle LV3 _ lock on _ from enemy _ child A (reservoir) -- 義手忍具_指笛LV3_ロックオン_敵から_子A（溜め）"
+        "Malcontent Lock"
       ]
     },
     {
       "ID": 1013,
       "Entries": [
-        "Prosthetic hand ninja _ finger whistle LV3 _ lock on _ from enemy _ child B -- 義手忍具_指笛LV3_ロックオン_敵から_子B"
+        "Malcontent Lock"
       ]
     },
     {
       "ID": 1014,
       "Entries": [
-        "Prosthetic hand ninja _ finger whistle LV3 _ lock on _ from enemy _ grandson A (reservoir) -- 義手忍具_指笛LV3_ロックオン_敵から_孫A（溜め）"
+        "Malcontent Lock"
       ]
     },
     {
       "ID": 1020,
       "Entries": [
-        "Pottery _ Bullet to fly from the enemy -- 陶片_敵から飛ばす弾丸"
+        "Pottery - Bullet to fly from the enemy"
       ]
     },
     {
       "ID": 1700,
       "Entries": [
-        "Miasma_dummy_parent -- 瘴気_ダミー_親"
+        "Miasma Dummy Parent"
       ]
     },
     {
       "ID": 1701,
       "Entries": [
-        "Miasma_dummy_child -- 瘴気_ダミー_子"
+        "Miasma Dummy Child"
       ]
     },
     {
       "ID": 1702,
       "Entries": [
-        "Miasma_dummy_grandson -- 瘴気_ダミー_孫"
+        "Miasma Dummy Grandson"
       ]
     },
     {
       "ID": 1705,
       "Entries": [
-        "Miasma _ body _ parent -- 瘴気_本体_親"
+        "Miasma Body Parent"
       ]
     },
     {
       "ID": 1706,
       "Entries": [
-        "Miasma_body_child -- 瘴気_本体_子"
+        "Miasma Body Child"
       ]
     },
     {
@@ -1096,85 +1096,85 @@
     {
       "ID": 9900,
       "Entries": [
-        "DL confirmation 00_ None"
+        "Damage Level Confirmation - None (0)"
       ]
     },
     {
       "ID": 9901,
       "Entries": [
-        "DL confirmation 01_small"
+        "Damage Level Confirmation - Weak (1)"
       ]
     },
     {
       "ID": 9902,
       "Entries": [
-        "DL confirmation 02_ Medium"
+        "Damage Level Confirmation - Medium (2)"
       ]
     },
     {
       "ID": 9903,
       "Entries": [
-        "DL confirmation 03_large"
+        "Damage Level Confirmation - Large (3)"
       ]
     },
     {
       "ID": 9904,
       "Entries": [
-        "DL confirmation 04_ Blow-off size"
+        "Damage Level Confirmation - Blow back (4)"
       ]
     },
     {
       "ID": 9905,
       "Entries": [
-        "DL confirmation 05_ press"
+        "Damage Level Confirmation - Flatten (5)"
       ]
     },
     {
       "ID": 9906,
       "Entries": [
-        "DL confirmation 06_ slamming"
+        "Damage Level Confirmation - Slam (6)"
       ]
     },
     {
       "ID": 9907,
       "Entries": [
-        "DL confirmation 07_Blow-off small (PC kick only)"
+        "Damage Level Confirmation - Jump Kick (7)"
       ]
     },
     {
       "ID": 9908,
       "Entries": [
-        "DL confirmation 08_minimal addition"
+        "Damage Level Confirmation - Minimal (8)"
       ]
     },
     {
       "ID": 9909,
       "Entries": [
-        "DL confirmation 09_ lift up"
+        "Damage Level Confirmation - Launch Up (9)"
       ]
     },
     {
       "ID": 9910,
       "Entries": [
-        "DL confirmation 10_ Blow-off oversized"
+        "Damage Level Confirmation - Very Large Blow Back (10)"
       ]
     },
     {
       "ID": 9911,
       "Entries": [
-        "DL confirmation 11_ breath (unused)"
+        "Damage Level Confirmation - Unused (11)"
       ]
     },
     {
       "ID": 9915,
       "Entries": [
-        "DL confirmation 20_break"
+        "Damage Level Confirmation - Break (20)"
       ]
     },
     {
       "ID": 9920,
       "Entries": [
-        "DL confirmation 15_flame"
+        "Damage Level Confirmation - Flame (15)"
       ]
     },
     {
@@ -1258,1393 +1258,1393 @@
     {
       "ID": 500410,
       "Entries": [
-        "School Technique_Sword Holy Iai_Reserved Bullet 1 -- 流派技_剣聖居合い_溜め弾丸1"
+        "Dragon Flash - Charged - Bullet 1"
       ]
     },
     {
       "ID": 500415,
       "Entries": [
-        "School Technique_Sword Holy Iai_Reserved Bullet 2_Parent -- 流派技_剣聖居合い_溜め弾丸2_親"
+        "Dragon Flash - Charged - Bullet 2 - Dummy Parent"
       ]
     },
     {
       "ID": 500416,
       "Entries": [
-        "School Technique_Sword Holy Iai_Reserved Bullet 2_Child -- 流派技_剣聖居合い_溜め弾丸2_子"
+        "Dragon Flash - Charged - Bullet 2 - Dummy Parent"
       ]
     },
     {
       "ID": 500417,
       "Entries": [
-        "School Technique_Sword Holy Iai_Reservoir Bullet 2_Grandson -- 流派技_剣聖居合い_溜め弾丸2_孫"
+        "Dragon Flash - Charged - Bullet 2 - Dummy Parent"
       ]
     },
     {
       "ID": 500418,
       "Entries": [
-        "School Technique_Sword Holy Iai_Reservoir Bullet 2_Great-Grandson -- 流派技_剣聖居合い_溜め弾丸2_曾孫"
+        "Dragon Flash - Charged - Bullet 2"
       ]
     },
     {
       "ID": 500430,
       "Entries": [
-        "School Technique_Sword Holy Iai_Bullet -- 流派技_剣聖居合い_弾丸"
+        "Dragon Flash - Bullet"
       ]
     },
     {
       "ID": 500510,
       "Entries": [
-        "School technique_Invisible Iai continuous attack_Slashing 1 -- 流派技_見えない居合連撃_斬撃1"
+        "One Mind - Initial Attack"
       ]
     },
     {
       "ID": 500511,
       "Entries": [
-        "School Technique_Invisible Iai Strike _Slash 1_Red Blood Enchantment -- 流派技_見えない居合連撃_斬撃1_赤血エンチャント"
+        "One Mind - Initial Attack - Bestowal"
       ]
     },
     {
       "ID": 500512,
       "Entries": [
-        "School Technique_Invisible Iai Strike _Slash 1_Poison Blood Enchantment -- 流派技_見えない居合連撃_斬撃1_毒血エンチャント"
+        "One Mind - Initial Attack - Poison Bestowal"
       ]
     },
     {
       "ID": 500513,
       "Entries": [
-        "School technique_Invisible Iai continuous attack_Slashing 1_White blood enchantment -- 流派技_見えない居合連撃_斬撃1_白血エンチャント"
+        "One Mind - Initial Attack - Lifesteal Bestowal"
       ]
     },
     {
       "ID": 500514,
       "Entries": [
-        "School technique_Invisible Iai continuous attack_Slashing 1_Orange wind enchantment -- 流派技_見えない居合連撃_斬撃1_橙風エンチャント"
+        "One Mind - Initial Attack - Divine Abduction Living Force"
       ]
     },
     {
       "ID": 500515,
       "Entries": [
-        "School technique_Invisible Iai continuous attack_Slashing 1_Kinfu enchantment -- 流派技_見えない居合連撃_斬撃1_金風エンチャント"
+        "One Mind - Initial Attack - Golden Vortex Living Force"
       ]
     },
     {
       "ID": 500516,
       "Entries": [
-        "School technique_Invisible Iai continuous attack_Slashing 1_No form -- 流派技_見えない居合連撃_斬撃1_形代なし"
+        "One Mind - Initial Attack - No Spirit Emblems"
       ]
     },
     {
       "ID": 500520,
       "Entries": [
-        "School technique_Invisible Iai continuous attack_Delayed continuous attack 0 -- 流派技_見えない居合連撃_遅延連撃0"
+        "One Mind - Continuous Attack Parent"
       ]
     },
     {
       "ID": 500521,
       "Entries": [
-        "School technique_Invisible Iai continuous attack_Delayed continuous attack 1 -- 流派技_見えない居合連撃_遅延連撃1"
+        "One Mind - Continuous Attack 1"
       ]
     },
     {
       "ID": 500522,
       "Entries": [
-        "School technique_Invisible Iai continuous attack_Delayed continuous attack 2 -- 流派技_見えない居合連撃_遅延連撃2"
+        "One Mind - Continuous Attack 2"
       ]
     },
     {
       "ID": 500523,
       "Entries": [
-        "School technique_Invisible Iai continuous attack_Delayed continuous attack 3 -- 流派技_見えない居合連撃_遅延連撃3"
+        "One Mind - Continuous Attack 3"
       ]
     },
     {
       "ID": 500524,
       "Entries": [
-        "School technique_Invisible Iai continuous attack_Delayed continuous attack 4 -- 流派技_見えない居合連撃_遅延連撃4"
+        "One Mind - Continuous Attack 4"
       ]
     },
     {
       "ID": 500530,
       "Entries": [
-        "School technique_Invisible Iai continuous attack_Delayed continuous attack SFX0 -- 流派技_見えない居合連撃_遅延連撃SFX0"
+        "One Mind - Continuous Attack SFX"
       ]
     },
     {
       "ID": 500531,
       "Entries": [
-        "School technique_Invisible Iai continuous attack_Delayed continuous attack SFX1 -- 流派技_見えない居合連撃_遅延連撃SFX1"
+        "One Mind - Continuous Attack SFX"
       ]
     },
     {
       "ID": 500540,
       "Entries": [
-        "School technique_Invisible Iai continuous attack_Slashing 2 -- 流派技_見えない居合連撃_斬撃2"
+        "One Mind - Final Attack"
       ]
     },
     {
       "ID": 500541,
       "Entries": [
-        "School Technique_Invisible Iai Strike _Slash 2_Red Blood Enchantment -- 流派技_見えない居合連撃_斬撃2_赤血エンチャント"
+        "One Mind - Final Attack - Bestowal"
       ]
     },
     {
       "ID": 500542,
       "Entries": [
-        "School Technique_Invisible Iai Strike _Slash 2_Poison Blood Enchantment -- 流派技_見えない居合連撃_斬撃2_毒血エンチャント"
+        "One Mind - Final Attack - Poison Bestowal"
       ]
     },
     {
       "ID": 500543,
       "Entries": [
-        "School technique_Invisible Iai continuous attack_Slashing 2_White blood enchantment -- 流派技_見えない居合連撃_斬撃2_白血エンチャント"
+        "One Mind - Final Attack - Lifesteal Bestowal"
       ]
     },
     {
       "ID": 500544,
       "Entries": [
-        "School technique_Invisible Iai continuous attack_Slashing 2_Orange wind enchantment -- 流派技_見えない居合連撃_斬撃2_橙風エンチャント"
+        "One Mind - Final Attack - Divine Abduction Living Force"
       ]
     },
     {
       "ID": 500545,
       "Entries": [
-        "School technique_Invisible Iai continuous attack_Slashing 2_Kinfu enchantment -- 流派技_見えない居合連撃_斬撃2_金風エンチャント"
+        "One Mind - Final Attack - Golden Vortex Living Force"
       ]
     },
     {
       "ID": 500546,
       "Entries": [
-        "School technique_Invisible Iai continuous attack_Slashing 2_No form -- 流派技_見えない居合連撃_斬撃2_形代なし"
+        "One Mind - Final Attack - No Spirit Emblems"
       ]
     },
     {
       "ID": 503010,
       "Entries": [
-        "School technique_new technique 1_SFX -- 流派技_新技1_SFX"
+        "Sakura Dance"
       ]
     },
     {
       "ID": 503011,
       "Entries": [
-        "School technique_new technique 2_SFX -- 流派技_新技2_SFX"
+        "Sakura Dance"
       ]
     },
     {
       "ID": 503012,
       "Entries": [
-        "School technique_new technique 3_SFX -- 流派技_新技3_SFX"
+        "Sakura Dance"
       ]
     },
     {
       "ID": 503015,
       "Entries": [
-        "School technique_new technique 1_SFX_no form fee -- 流派技_新技1_SFX_形代なし"
+        "Sakura Dance - No Spirit Emblems"
       ]
     },
     {
       "ID": 503016,
       "Entries": [
-        "School technique_new technique 2_SFX_no form fee -- 流派技_新技2_SFX_形代なし"
+        "Sakura Dance - No Spirit Emblems"
       ]
     },
     {
       "ID": 503017,
       "Entries": [
-        "School technique_new technique 3_SFX_no form fee -- 流派技_新技3_SFX_形代なし"
+        "Sakura Dance - No Spirit Emblems"
       ]
     },
     {
       "ID": 503020,
       "Entries": [
-        "School Technique_New Technique 1_SFX_Flame Encha -- 流派技_新技1_SFX_炎エンチャ"
+        "Sakura Dance - Flame"
       ]
     },
     {
       "ID": 503021,
       "Entries": [
-        "School Technique_New Technique 2_SFX_Flame Encha -- 流派技_新技2_SFX_炎エンチャ"
+        "Sakura Dance - Flame"
       ]
     },
     {
       "ID": 503022,
       "Entries": [
-        "School Technique_New Technique 3_SFX_Flame Encha -- 流派技_新技3_SFX_炎エンチャ"
+        "Sakura Dance - Flame"
       ]
     },
     {
       "ID": 503025,
       "Entries": [
-        "School Technique_New Technique 1_SFX_Rei Encha -- 流派技_新技1_SFX_霊エンチャ"
+        "Sakura Dance - Anti-apparition"
       ]
     },
     {
       "ID": 503026,
       "Entries": [
-        "School Technique_New Technique 2_SFX_Rei Encha -- 流派技_新技2_SFX_霊エンチャ"
+        "Sakura Dance - Anti-apparition"
       ]
     },
     {
       "ID": 503027,
       "Entries": [
-        "School technique_new technique 3_SFX_spirit enchantment -- 流派技_新技3_SFX_霊エンチャ"
+        "Sakura Dance - Anti-apparition"
       ]
     },
     {
       "ID": 503030,
       "Entries": [
-        "School Technique_New Technique 1_SFX_Orange Wind Encha -- 流派技_新技1_SFX_橙風エンチャ"
+        "Sakura Dance - Divine Abduction Living Force"
       ]
     },
     {
       "ID": 503031,
       "Entries": [
-        "School Technique_New Technique 2_SFX_Orange Wind Encha -- 流派技_新技2_SFX_橙風エンチャ"
+        "Sakura Dance - Divine Abduction Living Force"
       ]
     },
     {
       "ID": 503032,
       "Entries": [
-        "School Technique_New Technique 3_SFX_Orange Wind Encha -- 流派技_新技3_SFX_橙風エンチャ"
+        "Sakura Dance - Divine Abduction Living Force"
       ]
     },
     {
       "ID": 503035,
       "Entries": [
-        "School Technique_New Technique 1_SFX_Kinfu Encha -- 流派技_新技1_SFX_金風エンチャ"
+        "Sakura Dance - Golden Vortex Living Force"
       ]
     },
     {
       "ID": 503036,
       "Entries": [
-        "School Technique_New Technique 2_SFX_Kinfu Encha -- 流派技_新技2_SFX_金風エンチャ"
+        "Sakura Dance - Golden Vortex Living Force"
       ]
     },
     {
       "ID": 503037,
       "Entries": [
-        "School Technique_New Technique 3_SFX_Kinfu Encha -- 流派技_新技3_SFX_金風エンチャ"
+        "Sakura Dance - Golden Vortex Living Force"
       ]
     },
     {
       "ID": 503040,
       "Entries": [
-        "School Technique_New Technique 1_SFX_Red Blood Encha -- 流派技_新技1_SFX_赤血エンチャ"
+        "Sakura Dance - Bestowal"
       ]
     },
     {
       "ID": 503041,
       "Entries": [
-        "School Technique_New Technique 2_SFX_Red Blood Encha -- 流派技_新技2_SFX_赤血エンチャ"
+        "Sakura Dance - Bestowal"
       ]
     },
     {
       "ID": 503042,
       "Entries": [
-        "School Technique_New Technique 3_SFX_Red Blood Encha -- 流派技_新技3_SFX_赤血エンチャ"
+        "Sakura Dance - Bestowal"
       ]
     },
     {
       "ID": 503045,
       "Entries": [
-        "School Technique_New Technique 1_SFX_Poisonous Blood Encha -- 流派技_新技1_SFX_毒血エンチャ"
+        "Sakura Dance - Poison Bestowal"
       ]
     },
     {
       "ID": 503046,
       "Entries": [
-        "School Technique_New Technique 2_SFX_Poisonous Blood Encha -- 流派技_新技2_SFX_毒血エンチャ"
+        "Sakura Dance - Poison Bestowal"
       ]
     },
     {
       "ID": 503047,
       "Entries": [
-        "School Technique_New Technique 3_SFX_Poisonous Blood Encha -- 流派技_新技3_SFX_毒血エンチャ"
+        "Sakura Dance - Poison Bestowal"
       ]
     },
     {
       "ID": 503050,
       "Entries": [
-        "School Technique_New Technique 1_SFX_White Blood Encha -- 流派技_新技1_SFX_白血エンチャ"
+        "Sakura Dance - Lifesteal Bestowal"
       ]
     },
     {
       "ID": 503051,
       "Entries": [
-        "School Technique_New Technique 2_SFX_White Blood Encha -- 流派技_新技2_SFX_白血エンチャ"
+        "Sakura Dance - Lifesteal Bestowal"
       ]
     },
     {
       "ID": 503052,
       "Entries": [
-        "School Technique_New Technique 3_SFX_White Blood Encha -- 流派技_新技3_SFX_白血エンチャ"
+        "Sakura Dance - Lifesteal Bestowal"
       ]
     },
     {
       "ID": 503055,
       "Entries": [
-        "School Technique_New Technique 1_SFX_Thunder Encha -- 流派技_新技1_SFX_雷エンチャ"
+        "Sakura Dance - Lightning"
       ]
     },
     {
       "ID": 503056,
       "Entries": [
-        "School Technique_New Technique 2_SFX_Thunder Encha -- 流派技_新技2_SFX_雷エンチャ"
+        "Sakura Dance - Lightning"
       ]
     },
     {
       "ID": 503057,
       "Entries": [
-        "School Technique_New Technique 3_SFX_Thunder Encha -- 流派技_新技3_SFX_雷エンチャ"
+        "Sakura Dance - Lightning"
       ]
     },
     {
       "ID": 503060,
       "Entries": [
-        "School technique_new technique 1_SFX_ petals -- 流派技_新技1_SFX_花弁"
+        "Sakura Dance - Petals"
       ]
     },
     {
       "ID": 503061,
       "Entries": [
-        "School technique_new technique 2_SFX_petals -- 流派技_新技2_SFX_花弁"
+        "Sakura Dance - Petals"
       ]
     },
     {
       "ID": 503062,
       "Entries": [
-        "School technique_new technique 3_SFX_petals -- 流派技_新技3_SFX_花弁"
+        "Sakura Dance - Petals"
       ]
     },
     {
       "ID": 700000,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken _ Reservoir 1/3 Throw _1 Hit -- 義手忍具_手裏剣_溜め1/3投目_1Hit"
+        "Shuriken Charge - Throw 1 - Hit 1"
       ]
     },
     {
       "ID": 700001,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken _ Reservoir 1/3 Throw _1 Wait -- 義手忍具_手裏剣_溜め1/3投目_1Wait"
+        "Shuriken Charge - Throw 1 - Wait 1"
       ]
     },
     {
       "ID": 700002,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken _ Reservoir 1/3 Throw _2 Hit -- 義手忍具_手裏剣_溜め1/3投目_2Hit"
+        "Shuriken Charge - Throw 1 - Hit 2"
       ]
     },
     {
       "ID": 700003,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken _ Reservoir 1/3 Throw _2 Wait -- 義手忍具_手裏剣_溜め1/3投目_2Wait"
+        "Shuriken Charge - Throw 1 - Wait 2"
       ]
     },
     {
       "ID": 700004,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken _ Reservoir 1/3 Throw _ 3 Hit -- 義手忍具_手裏剣_溜め1/3投目_3Hit"
+        "Shuriken Charge - Throw 1 - Hit 3"
       ]
     },
     {
       "ID": 700010,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken _ Reservoir 2nd Throw _1 Hit -- 義手忍具_手裏剣_溜め2投目_1Hit"
+        "Shuriken Charge - Throw 2 - Hit 1"
       ]
     },
     {
       "ID": 700011,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken _ Reservoir 2nd Throw _1 Wait -- 義手忍具_手裏剣_溜め2投目_1Wait"
+        "Shuriken Charge - Throw 2 - Wait 1"
       ]
     },
     {
       "ID": 700012,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken _ Reservoir 2nd Throw_2 Hit -- 義手忍具_手裏剣_溜め2投目_2Hit"
+        "Shuriken Charge - Throw 2 - Hit 2"
       ]
     },
     {
       "ID": 700013,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken _ Reservoir 2nd Throw_2Wait -- 義手忍具_手裏剣_溜め2投目_2Wait"
+        "Shuriken Charge - Throw 2 - Wait 2"
       ]
     },
     {
       "ID": 700014,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken _ Reservoir 2nd Throw _ 3 Hit -- 義手忍具_手裏剣_溜め2投目_3Hit"
+        "Shuriken Charge - Throw 2 - Hit 3"
       ]
     },
     {
       "ID": 700050,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken _1 / 3rd throw -- 義手忍具_手裏剣_1/3投目"
+        "Shuriken Throw 1"
       ]
     },
     {
       "ID": 700060,
       "Entries": [
-        "Prosthetic Hand Ninja _ Shuriken_2 Eyes -- 義手忍具_手裏剣_2投目"
+        "Shuriken Throw 2"
       ]
     },
     {
       "ID": 700200,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV3-A_ Reservoir 1/3 Throw _1 Hit -- 義手忍具_手裏剣LV3-A_溜め1/3投目_1Hit"
+        "Gouging Top Charge - Throw 1 - Hit 1"
       ]
     },
     {
       "ID": 700201,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV3-A_ Reservoir 1/3 Throw _1 Wait -- 義手忍具_手裏剣LV3-A_溜め1/3投目_1Wait"
+        "Gouging Top Charge - Throw 1 - Wait 1"
       ]
     },
     {
       "ID": 700202,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV3-A_ Reservoir 1/3 Throw _2 Hit -- 義手忍具_手裏剣LV3-A_溜め1/3投目_2Hit"
+        "Gouging Top Charge - Throw 1 - Hit 2"
       ]
     },
     {
       "ID": 700203,
       "Entries": [
-        "Prosthetic Hand Ninja _ Shuriken LV3-A_ Reservoir 1/3 Throw _2 Wait -- 義手忍具_手裏剣LV3-A_溜め1/3投目_2Wait"
+        "Gouging Top Charge - Throw 1 - Wait 2"
       ]
     },
     {
       "ID": 700204,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV3-A_ Reservoir 1/3 Throw _ 3 Hit -- 義手忍具_手裏剣LV3-A_溜め1/3投目_3Hit"
+        "Gouging Top Charge - Throw 1 - Hit 3"
       ]
     },
     {
       "ID": 700210,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV3-A_ Reservoir 2nd Throw _1 Hit -- 義手忍具_手裏剣LV3-A_溜め2投目_1Hit"
+        "Gouging Top Charge - Throw 2 - Hit 1"
       ]
     },
     {
       "ID": 700211,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV3-A_ Reservoir 2nd Throw _1 Wait -- 義手忍具_手裏剣LV3-A_溜め2投目_1Wait"
+        "Gouging Top Charge - Throw 2 - Wait 1 "
       ]
     },
     {
       "ID": 700212,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV3-A_ Reservoir 2nd Throw_2 Hit -- 義手忍具_手裏剣LV3-A_溜め2投目_2Hit"
+        "Gouging Top Charge - Throw 2 - Hit 2"
       ]
     },
     {
       "ID": 700213,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV3-A_ Reservoir 2nd Throw_2Wait -- 義手忍具_手裏剣LV3-A_溜め2投目_2Wait"
+        "Gouging Top Charge - Throw 2 - Wait 2"
       ]
     },
     {
       "ID": 700214,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV3-A_ Reservoir 2nd Throw _ 3 Hit -- 義手忍具_手裏剣LV3-A_溜め2投目_3Hit"
+        "Gouging Top Charge - Throw 2 - Hit 3"
       ]
     },
     {
       "ID": 700250,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV3-A_1 / 3 -- 義手忍具_手裏剣LV3-A_1/3投目"
+        "Gouging Top - Throw 1"
       ]
     },
     {
       "ID": 700260,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV3-A_2 Throw -- 義手忍具_手裏剣LV3-A_2投目"
+        "Gouging Top - Throw 2"
       ]
     },
     {
       "ID": 700300,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV3-B_ Reservoir 1/3 throw -- 義手忍具_手裏剣LV3-B_溜め1/3投目"
+        "Phantom Kunai Charge - Throw 1"
       ]
     },
     {
       "ID": 700310,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV3-B_ 2nd throw -- 義手忍具_手裏剣LV3-B_溜め2投目"
+        "Phantom Kunai Charge - Throw 2"
       ]
     },
     {
       "ID": 700320,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV3-B_ Reservoir Guide Bullet _ Parent -- 義手忍具_手裏剣LV3-B_溜め誘導弾丸_親"
+        "Phantom Kunai Charge - Butterfly - Parent"
       ]
     },
     {
       "ID": 700321,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV3-B_ Reservoir Guide Bullet _ Child -- 義手忍具_手裏剣LV3-B_溜め誘導弾丸_子"
+        "Phantom Kunai Charge - Butterfly"
       ]
     },
     {
       "ID": 700350,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV3-B_1 / 3 Throw -- 義手忍具_手裏剣LV3-B_1/3投目"
+        "Phantom Kunai - Throw 1"
       ]
     },
     {
       "ID": 700360,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV3-B_2 Throw -- 義手忍具_手裏剣LV3-B_2投目"
+        "Phantom Kunai - Throw 2"
       ]
     },
     {
       "ID": 700370,
       "Entries": [
-        "Prosthetic Hand Ninja _ Shuriken LV3-B_ Guided Bullet _ Parent -- 義手忍具_手裏剣LV3-B_誘導弾丸_親"
+        "Phantom Kunai - Butterfly Parent"
       ]
     },
     {
       "ID": 700371,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV3-B_ Guided Bullet _ Child -- 義手忍具_手裏剣LV3-B_誘導弾丸_子"
+        "Phantom Kunai - Butterfly"
       ]
     },
     {
       "ID": 700400,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV3-C_ Reservoir 1/3 Throw _ LV0 -- 義手忍具_手裏剣LV3-C_溜め1/3投目_LV0"
+        "Sen Throw Charge - No Money"
       ]
     },
     {
       "ID": 700401,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV3-C_ Reservoir 1/3 Throw _ LV1 -- 義手忍具_手裏剣LV3-C_溜め1/3投目_LV1"
+        "Sen Throw Charge - Little Money"
       ]
     },
     {
       "ID": 700402,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV3-C_ Reservoir 1/3 Throw _ LV2 -- 義手忍具_手裏剣LV3-C_溜め1/3投目_LV2"
+        "Sen Throw Charge - Some Money"
       ]
     },
     {
       "ID": 700403,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV3-C_ Reservoir 1/3 Throw _ LV3 -- 義手忍具_手裏剣LV3-C_溜め1/3投目_LV3"
+        "Sen Throw Charge - A Lot of Money"
       ]
     },
     {
       "ID": 700410,
       "Entries": [
-        "Prosthetic Hand Ninja _ Shuriken LV3-C_ Reservoir 2nd Throw _ LV0 -- 義手忍具_手裏剣LV3-C_溜め2投目_LV0"
+        "Sen Throw - No Money"
       ]
     },
     {
       "ID": 700411,
       "Entries": [
-        "Prosthetic Hand Ninja _ Shuriken LV3-C_ Reservoir 2nd Throw _ LV1 -- 義手忍具_手裏剣LV3-C_溜め2投目_LV1"
+        "Sen Throw - Little Money"
       ]
     },
     {
       "ID": 700412,
       "Entries": [
-        "Prosthetic Hand Ninja _ Shuriken LV3-C_ Reservoir 2nd Throw _ LV2 -- 義手忍具_手裏剣LV3-C_溜め2投目_LV2"
+        "Sen Throw - Some Money"
       ]
     },
     {
       "ID": 700413,
       "Entries": [
-        "Prosthetic Hand Ninja _ Shuriken LV3-C_ Reservoir 2nd Throw _ LV3 -- 義手忍具_手裏剣LV3-C_溜め2投目_LV3"
+        "Sen Throw - A Lot of Money"
       ]
     },
     {
       "ID": 700450,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV3-C_1 / 3 Throw _LV0 -- 義手忍具_手裏剣LV3-C_1/3投目_LV0"
+        "Sen Throw Charge - No Money"
       ]
     },
     {
       "ID": 700451,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV3-C_1 / 3 Throw _LV1 -- 義手忍具_手裏剣LV3-C_1/3投目_LV1"
+        "Sen Throw Charge - Little Money"
       ]
     },
     {
       "ID": 700452,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV3-C_1 / 3 Throw _LV2 -- 義手忍具_手裏剣LV3-C_1/3投目_LV2"
+        "Sen Throw Charge - Some Money"
       ]
     },
     {
       "ID": 700453,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV3-C_1 / 3 Throw _LV3 -- 義手忍具_手裏剣LV3-C_1/3投目_LV3"
+        "Sen Throw Charge - A Lot of Money"
       ]
     },
     {
       "ID": 700460,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV3-C_2 Throw _LV0 -- 義手忍具_手裏剣LV3-C_2投目_LV0"
+        "Sen Throw - No Money"
       ]
     },
     {
       "ID": 700461,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV3-C_2 Throw _LV1 -- 義手忍具_手裏剣LV3-C_2投目_LV1"
+        "Sen Throw - Little Money"
       ]
     },
     {
       "ID": 700462,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV3-C_2 Throw _LV2 -- 義手忍具_手裏剣LV3-C_2投目_LV2"
+        "Sen Throw - Some Money"
       ]
     },
     {
       "ID": 700463,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV3-C_2 Throw _LV3 -- 義手忍具_手裏剣LV3-C_2投目_LV3"
+        "Sen Throw - A Lot of Money"
       ]
     },
     {
       "ID": 700500,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV4_ Reservoir 1/3 Throw _1 Hit -- 義手忍具_手裏剣LV4_溜め1/3投目_1Hit"
+        "Lazulite Shuriken Charge - Throw 1 - Hit 1"
       ]
     },
     {
       "ID": 700501,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV4_ Reservoir 1/3 Throw _1 Wait -- 義手忍具_手裏剣LV4_溜め1/3投目_1Wait"
+        "Lazulite Shuriken Charge - Throw 1 - Wait 1"
       ]
     },
     {
       "ID": 700502,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV4_ Reservoir 1/3 Throw _2 Hit -- 義手忍具_手裏剣LV4_溜め1/3投目_2Hit"
+        "Lazulite Shuriken Charge - Throw 1 - Hit 2"
       ]
     },
     {
       "ID": 700503,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV4_ Reservoir 1/3 Throw _2 Wait -- 義手忍具_手裏剣LV4_溜め1/3投目_2Wait"
+        "Lazulite Shuriken Charge - Throw 1 - Wait 2"
       ]
     },
     {
       "ID": 700504,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV4 _ Reservoir 1/3 Throw _ 3 Hit -- 義手忍具_手裏剣LV4_溜め1/3投目_3Hit"
+        "Lazulite Shuriken Charge - Throw 1 - Hit 3"
       ]
     },
     {
       "ID": 700510,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV4_ Reservoir 2nd Throw _1 Hit -- 義手忍具_手裏剣LV4_溜め2投目_1Hit"
+        "Lazulite Shuriken Charge - Throw 2 - Hit 1"
       ]
     },
     {
       "ID": 700511,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV4_ Reservoir 2nd Throw _1 Wait -- 義手忍具_手裏剣LV4_溜め2投目_1Wait"
+        "Lazulite Shuriken Charge - Throw 2 - Wait 1"
       ]
     },
     {
       "ID": 700512,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV4_ Reservoir 2nd Throw_2Hit -- 義手忍具_手裏剣LV4_溜め2投目_2Hit"
+        "Lazulite Shuriken Charge - Throw 2 - Hit 2"
       ]
     },
     {
       "ID": 700513,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV4_ Reservoir 2nd Throw_2Wait -- 義手忍具_手裏剣LV4_溜め2投目_2Wait"
+        "Lazulite Shuriken Charge - Throw 2 - Wait 2"
       ]
     },
     {
       "ID": 700514,
       "Entries": [
-        "Prosthetic hand ninja _ Shuriken LV4 _ Reservoir 2nd throw _ 3 Hit -- 義手忍具_手裏剣LV4_溜め2投目_3Hit"
+        "Lazulite Shuriken Charge - Throw 2 - Hit 3"
       ]
     },
     {
       "ID": 700550,
       "Entries": [
-        "Prosthetic hand ninja _ Shuriken LV4_1 / 3 throw -- 義手忍具_手裏剣LV4_1/3投目"
+        "Lazulite Shuriken - Throw 1"
       ]
     },
     {
       "ID": 700560,
       "Entries": [
-        "Prosthesis Ninja _ Shuriken LV4_2 Throw -- 義手忍具_手裏剣LV4_2投目"
+        "Lazulite Shuriken - Throw 2"
       ]
     },
     {
       "ID": 710000,
       "Entries": [
-        "Prosthesis Ninja _ Firecracker _ Reservoir _ Parent -- 義手忍具_爆竹_溜め_親"
+        "Firecracker - Charge Parent"
       ]
     },
     {
       "ID": 710001,
       "Entries": [
-        "Prosthetic hand ninja _ firecracker _ child -- 義手忍具_爆竹_子"
+        "Firecracker - Child 1"
       ]
     },
     {
       "ID": 710002,
       "Entries": [
-        "Prosthetic hand ninja _ firecracker _ grandson -- 義手忍具_爆竹_孫"
+        "Firecracker - Child 2"
       ]
     },
     {
       "ID": 710003,
       "Entries": [
-        "Prosthetic hand ninja _ firecracker _ great-grandson -- 義手忍具_爆竹_曾孫"
+        "Firecracker - Child 3"
       ]
     },
     {
       "ID": 710010,
       "Entries": [
-        "Prosthetic Hand Ninja _ Firecracker _ Reservoir _ Parent _ Anti-Special Attack Character -- 義手忍具_爆竹_溜め_親_対特攻キャラ"
+        "Firecracker Against Beast - Charge Parent"
       ]
     },
     {
       "ID": 710011,
       "Entries": [
-        "Prosthetic hand ninja _ firecracker _ child _ anti-special attack character -- 義手忍具_爆竹_子_対特攻キャラ"
+        "Firecracker Against Beast - Child 1"
       ]
     },
     {
       "ID": 710012,
       "Entries": [
-        "Prosthetic hand ninja _ firecracker _ grandson _ anti-special attack character -- 義手忍具_爆竹_孫_対特攻キャラ"
+        "Firecracker Against Beast - Child 2"
       ]
     },
     {
       "ID": 710013,
       "Entries": [
-        "Prosthetic hand ninja _ firecracker _ great-grandson _ vs. special attack character -- 義手忍具_爆竹_曾孫_対特攻キャラ"
+        "Firecracker Against Beast - Child 3"
       ]
     },
     {
       "ID": 710020,
       "Entries": [
-        "Prosthetic hand ninja _ firecracker _ aerial _ parent -- 義手忍具_爆竹_空中_親"
+        "Firecracker - Aerial Parent"
       ]
     },
     {
       "ID": 710030,
       "Entries": [
-        "Prosthetic hand ninja _ firecracker _ aerial _ parent _ anti-special attack character -- 義手忍具_爆竹_空中_親_対特攻キャラ"
+        "Firecracker Against Beast - Aerial Parent"
       ]
     },
     {
       "ID": 710050,
       "Entries": [
-        "Prosthetic hand ninja _ firecracker _ parent -- 義手忍具_爆竹_親"
+        "Firecracker - Parent"
       ]
     },
     {
       "ID": 710060,
       "Entries": [
-        "Prosthetic hand ninja _ firecracker _ parent _ anti-special attack character -- 義手忍具_爆竹_親_対特攻キャラ"
+        "Firecracker Against Beast - Parent"
       ]
     },
     {
       "ID": 710200,
       "Entries": [
-        "Prosthetic Hand Ninja _ Firecracker LV3-A_ Reservoir _ Parent -- 義手忍具_爆竹LV3-A_溜め_親"
+        "Long Spark - Charge Parent"
       ]
     },
     {
       "ID": 710201,
       "Entries": [
-        "Prosthetic hand ninja _ firecracker LV3-A_ child -- 義手忍具_爆竹LV3-A_子"
+        "Long Spark - Child 1"
       ]
     },
     {
       "ID": 710202,
       "Entries": [
-        "Prosthetic hand ninja _ firecracker LV3-A_ grandson -- 義手忍具_爆竹LV3-A_孫"
+        "Long Spark - Child 2"
       ]
     },
     {
       "ID": 710203,
       "Entries": [
-        "Prosthetic hand ninja _ firecracker LV3-A_ great-grandson -- 義手忍具_爆竹LV3-A_曾孫"
+        "Long Spark - Child 3"
       ]
     },
     {
       "ID": 710210,
       "Entries": [
-        "Prosthetic Hand Ninja _ Firecracker LV3-A_ Reservoir _ Parent _ Anti-Special Attack Character -- 義手忍具_爆竹LV3-A_溜め_親_対特攻キャラ"
+        "Long Spark Against Beast - Charge Parent"
       ]
     },
     {
       "ID": 710211,
       "Entries": [
-        "Prosthetic hand ninja _ firecracker LV3-A_ child _ anti-special attack character -- 義手忍具_爆竹LV3-A_子_対特攻キャラ"
+        "Long Spark Against Beast - Child 1"
       ]
     },
     {
       "ID": 710212,
       "Entries": [
-        "Prosthetic hand ninja _ firecracker LV3-A_ grandson _ vs. special attack character -- 義手忍具_爆竹LV3-A_孫_対特攻キャラ"
+        "Long Spark Against Beast - Child 2"
       ]
     },
     {
       "ID": 710213,
       "Entries": [
-        "Prosthetic hand ninja _ firecracker LV3-A_ great-grandson _ vs. special attack character -- 義手忍具_爆竹LV3-A_曾孫_対特攻キャラ"
+        "Long Spark Against Beast - Child 3"
       ]
     },
     {
       "ID": 710220,
       "Entries": [
-        "Prosthetic hand ninja _ firecracker LV3-A_ aerial _ parent -- 義手忍具_爆竹LV3-A_空中_親"
+        "Long Spark - Aerial Parent"
       ]
     },
     {
       "ID": 710230,
       "Entries": [
-        "Prosthesis Ninja _ Firecracker LV3-A_Aerial_Parent_Vs. Special Attack Character -- 義手忍具_爆竹LV3-A_空中_親_対特攻キャラ"
+        "Long Spark Against Beast - Aerial Parent"
       ]
     },
     {
       "ID": 710250,
       "Entries": [
-        "Prosthetic hand ninja _ firecracker LV3-A_ parent -- 義手忍具_爆竹LV3-A_親"
+        "Long Spark - Parent"
       ]
     },
     {
       "ID": 710260,
       "Entries": [
-        "Prosthetic Hand Ninja _ Firecracker LV3-A_ Parent _ Anti-Special Attack Character -- 義手忍具_爆竹LV3-A_親_対特攻キャラ"
+        "Long Spark Against Beast - Parent"
       ]
     },
     {
       "ID": 710300,
       "Entries": [
-        "Prosthesis Ninja _ Firecracker LV3-B_ Reservoir _ Parent -- 義手忍具_爆竹LV3-B_溜め_親"
+        "Purple Fume Spark - Charge Parent"
       ]
     },
     {
       "ID": 710301,
       "Entries": [
-        "Prosthetic hand ninja _ firecracker LV3-B_ child -- 義手忍具_爆竹LV3-B_子"
+        "Purple Fume Spark - Child 1"
       ]
     },
     {
       "ID": 710302,
       "Entries": [
-        "Prosthetic hand ninja _ firecracker LV3-B_ grandson -- 義手忍具_爆竹LV3-B_孫"
+        "Purple Fume Spark - Child 2"
       ]
     },
     {
       "ID": 710303,
       "Entries": [
-        "Prosthetic hand ninja _ firecracker LV3-B_ great-grandson -- 義手忍具_爆竹LV3-B_曾孫"
+        "Purple Fume Spark - Child 3"
       ]
     },
     {
       "ID": 710310,
       "Entries": [
-        "Prosthetic Hand Ninja _ Firecracker LV3-B_ Reservoir _ Parent _ Anti-Special Attack Character -- 義手忍具_爆竹LV3-B_溜め_親_対特攻キャラ"
+        "Purple Fume Spark Against Beast - Charge Parent"
       ]
     },
     {
       "ID": 710311,
       "Entries": [
-        "Prosthetic hand ninja _ firecracker LV3-B_ child _ anti-special attack character -- 義手忍具_爆竹LV3-B_子_対特攻キャラ"
+        "Purple Fume Spark Against Beast - Child 1"
       ]
     },
     {
       "ID": 710312,
       "Entries": [
-        "Prosthetic hand ninja _ firecracker LV3-B_ grandson _ vs. special attack character -- 義手忍具_爆竹LV3-B_孫_対特攻キャラ"
+        "Purple Fume Spark Against Beast - Child 2"
       ]
     },
     {
       "ID": 710313,
       "Entries": [
-        "Prosthetic hand ninja _ firecracker LV3-B _ great-grandson _ vs. special attack character -- 義手忍具_爆竹LV3-B_曾孫_対特攻キャラ"
+        "Purple Fume Spark Against Beast - Child 3"
       ]
     },
     {
       "ID": 710320,
       "Entries": [
-        "Prosthetic hand ninja _ firecracker LV3-B_ aerial _ parent -- 義手忍具_爆竹LV3-B_空中_親"
+        "Purple Fume Spark - Aerial Parent"
       ]
     },
     {
       "ID": 710330,
       "Entries": [
-        "Prosthetic Hand Ninja _ Firecracker LV3-B_Aerial_Parent_Vs. -- 義手忍具_爆竹LV3-B_空中_親_対特攻キャラ"
+        "Purple Fume Spark Against Beast - Aerial Parent"
       ]
     },
     {
       "ID": 710350,
       "Entries": [
-        "Prosthetic hand ninja _ firecracker LV3-B_ parent -- 義手忍具_爆竹LV3-B_親"
+        "Purple Fume Spark - Parent"
       ]
     },
     {
       "ID": 710360,
       "Entries": [
-        "Prosthetic Hand Ninja _ Firecracker LV3-B_ Parent _ Against Special Attack Character -- 義手忍具_爆竹LV3-B_親_対特攻キャラ"
+        "Purple Fume Spark Against Beast - Parent"
       ]
     },
     {
       "ID": 720000,
       "Entries": [
-        "Prosthesis Ninja _ Ignition _ Accumulation Shooting 1 -- 義手忍具_発火_溜め撃ち1"
+        "Flame Vent Charge - Hit 1"
       ]
     },
     {
       "ID": 720001,
       "Entries": [
-        "Prosthesis Ninja _ Ignition _ Accumulation Shooting 2 -- 義手忍具_発火_溜め撃ち2"
+        "Flame Vent Charge - Hit 2"
       ]
     },
     {
       "ID": 720010,
       "Entries": [
-        "Prosthesis Ninja _ Ignition _ Normal shooting -- 義手忍具_発火_通常撃ち"
+        "Flame Vent - Normal"
       ]
     },
     {
       "ID": 720020,
       "Entries": [
-        "Prosthesis Ninja _ Ignition _ Shoot in the air -- 義手忍具_発火_空中撃ち"
+        "Flame Vent - Aerial"
       ]
     },
     {
       "ID": 720030,
       "Entries": [
-        "Prosthesis Ninja _ Ignition _ Flamethrower _ Start -- 義手忍具_発火_火炎放射_開始"
+        "Flame Vent - Flamethrower Start"
       ]
     },
     {
       "ID": 720031,
       "Entries": [
-        "Prosthetic Hand Ninja _ Ignition _ Flame Thrower _ Loop -- 義手忍具_発火_火炎放射_ループ"
+        "Flame Vent - Flamethrower Loop"
       ]
     },
     {
       "ID": 720040,
       "Entries": [
-        "Prosthetic Hand Ninja _ Ignition _ Derived Attack Dummy for Enchantment -- 義手忍具_発火_派生攻撃エンチャント用ダミー"
+        "Flame Vent - Dummy for Living Force"
       ]
     },
     {
       "ID": 720300,
       "Entries": [
-        "Prosthesis Ninja _ Ignition LV4 _ Accumulation Shooting 1 -- 義手忍具_発火LV4_溜め撃ち1"
+        "Lazulite Sacred Flame - Charge - Hit 1"
       ]
     },
     {
       "ID": 720301,
       "Entries": [
-        "Prosthesis Ninja _ Ignition LV4 _ Accumulation Shooting 2 -- 義手忍具_発火LV4_溜め撃ち2"
+        "Lazulite Sacred Flame - Charge - Hit 2"
       ]
     },
     {
       "ID": 720310,
       "Entries": [
-        "Prosthetic hand ninja _ firing LV4 _ normal shooting -- 義手忍具_発火LV4_通常撃ち"
+        "Lazulite Sacred Flame - Normal"
       ]
     },
     {
       "ID": 720320,
       "Entries": [
-        "Prosthesis Ninja _Ignition LV4_Aerial Shooting -- 義手忍具_発火LV4_空中撃ち"
+        "Lazulite Sacred Flame - Aerial"
       ]
     },
     {
       "ID": 720330,
       "Entries": [
-        "Prosthesis Ninja _ Ignition LV4 _ Flamethrower _ Start -- 義手忍具_発火LV4_火炎放射_開始"
+        "Lazulite Sacred Flame - Flamethrower Start"
       ]
     },
     {
       "ID": 720331,
       "Entries": [
-        "Prosthesis Ninja _ Ignition LV4 _ Flamethrower _ Loop -- 義手忍具_発火LV4_火炎放射_ループ"
+        "Lazulite Sacred Flame - Flamethrower Loop"
       ]
     },
     {
       "ID": 720340,
       "Entries": [
-        "Prosthetic Hand Ninja_Ignition LV4_Dummy for Derived Attack Enchantment -- 義手忍具_発火LV4_派生攻撃エンチャント用ダミー"
+        "Lazulite Sacred Flame - Dummy for Living Force"
       ]
     },
     {
       "ID": 720350,
       "Entries": [
-        "Prosthetic Hand Ninja _ Ignition LV4 _ Anti-spirit Force _ Reach far -- 義手忍具_発火LV4_対霊フォース_遠くまで届く"
+        "Lazulite Sacred Flame - Far reaching Anti-apparition"
       ]
     },
     {
       "ID": 730200,
       "Entries": [
-        "Prosthetic Hand Ninja _Ax LV3_Crisis Force_Parent -- 義手忍具_斧LV3_恐慌フォース_親"
+        "Sparking Axe - Red Eyes Scare Parent"
       ]
     },
     {
       "ID": 730201,
       "Entries": [
-        "Prosthesis Ninja _Ax LV3_Crisis Force_Child -- 義手忍具_斧LV3_恐慌フォース_子"
+        "Sparking Axe - Red Eyes Scare Child"
       ]
     },
     {
       "ID": 740200,
       "Entries": [
-        "Prosthetic hand ninja _ transformation LV3 _ activation shock _ parent -- 義手忍具_変わり身LV3_発動衝撃_親"
+        "Great Feather Mist Raven - Activation Parent"
       ]
     },
     {
       "ID": 740201,
       "Entries": [
-        "Prosthetic hand ninja _ transformation LV3 _ activation shock _ child -- 義手忍具_変わり身LV3_発動衝撃_子"
+        "Great Feather Mist Raven - Explosion"
       ]
     },
     {
       "ID": 740210,
       "Entries": [
-        "Prosthetic Hand Ninja _ Transformation LV3 _ Depression Force _ Parent -- 義手忍具_変わり身LV3_恐慌フォース_親"
+        "Great Feather Mist Raven - Red Eyes Scare Parent"
       ]
     },
     {
       "ID": 740211,
       "Entries": [
-        "Prosthetic Hand Ninja _ Transformation LV3 _ Depression Force _ Child -- 義手忍具_変わり身LV3_恐慌フォース_子"
+        "Great Feather Mist Raven - Red Eyes Scare Child"
       ]
     },
     {
       "ID": 750300,
       "Entries": [
-        "Prosthetic hand ninja _ Kodachi LV3-B _ poison fog _ to the front -- 義手忍具_小太刀LV3-B_毒霧_正面へ"
+        "Lazulite Sabimaru - Poison Mist"
       ]
     },
     {
       "ID": 750301,
       "Entries": [
-        "Prosthetic hand Ninja _ Kodachi LV3-B_ Poison fog _ Left front -- 義手忍具_小太刀LV3-B_毒霧_左前へ"
+        "Lazulite Sabimaru - Poison Mist"
       ]
     },
     {
       "ID": 750302,
       "Entries": [
-        "Prosthesis Ninja _ Kodachi LV3-B_ Poison fog _ Right front -- 義手忍具_小太刀LV3-B_毒霧_右前へ"
+        "Lazulite Sabimaru - Poison Mist"
       ]
     },
     {
       "ID": 760000,
       "Entries": [
-        "Prosthesis Ninja _ Iron Fan _ Iron Fan Bullet LV1 -- 義手忍具_鉄扇_鉄扇弾丸LV1"
+        "Projected Force - Loaded Umbrella - Level 1"
       ]
     },
     {
       "ID": 760010,
       "Entries": [
-        "Prosthesis Ninja _ Iron Fan _ Iron Fan Bullet LV2 -- 義手忍具_鉄扇_鉄扇弾丸LV2"
+        "Projected Force - Loaded Umbrella - Level 2"
       ]
     },
     {
       "ID": 760011,
       "Entries": [
-        "Prosthetic hand ninja _ iron fan _ iron fan bullet LV2_SFX only -- 義手忍具_鉄扇_鉄扇弾丸LV2_SFXのみ"
+        "Projected Force - Loaded Umbrella - Level 2 SFX"
       ]
     },
     {
       "ID": 760020,
       "Entries": [
-        "Prosthesis Ninja _ Iron Fan _ Iron Fan Bullet LV3 -- 義手忍具_鉄扇_鉄扇弾丸LV3"
+        "Projected Force - Loaded Umbrella - Level 3"
       ]
     },
     {
       "ID": 760021,
       "Entries": [
-        "Prosthetic hand ninja _ iron fan _ iron fan bullet LV3_SFX only -- 義手忍具_鉄扇_鉄扇弾丸LV3_SFXのみ"
+        "Projected Force - Loaded Umbrella - Level 3 SFX"
       ]
     },
     {
       "ID": 760070,
       "Entries": [
-        "Prosthetic hand Ninja _ Iron fan _ Anti-flame iron fan / Anti-spirit iron fan Momentary enchantment by slashing -- 義手忍具_鉄扇_対炎鉄扇/対霊鉄扇派放ち斬りによる瞬間エンチャ"
+        "Suzaku's Lotus Umbrella Weapon Effect"
       ]
     },
     {
       "ID": 760071,
       "Entries": [
-        "Prosthetic hand Ninja _ Iron fan _ Anti-ghost iron fan / Anti-spirit iron fan Momentary enchantment by slashing -- 義手忍具_鉄扇_対霊鉄扇/対霊鉄扇派放ち斬りによる瞬間エンチャ"
+        "Phoenix's Lilac Umbrella Weapon Effect"
       ]
     },
     {
       "ID": 760200,
       "Entries": [
-        "Prosthetic Hand Ninja _ Iron Fan LV3-A_ Depression Force _ Parent -- 義手忍具_鉄扇LV3-A_恐慌フォース_親"
+        "Suzaku's Lotus Umbrella - Red Eyes Scare Parent"
       ]
     },
     {
       "ID": 760201,
       "Entries": [
-        "Prosthetic Hand Ninja _ Iron Fan LV3-A_ Depression Force _ Child -- 義手忍具_鉄扇LV3-A_恐慌フォース_子"
+        "Suzaku's Lotus Umbrella - Red Eyes Scare Child"
       ]
     },
     {
       "ID": 760300,
       "Entries": [
-        "Prosthetic hand Ninja _ Iron fan LV3-B_ Anti-spirit force _ Jasuga / Turn receiving -- 義手忍具_鉄扇LV3-B_対霊フォース_ジャスガ/回し受け"
+        "Phoenix's Lilac Umbrella - Anti-apparition"
       ]
     },
     {
       "ID": 760301,
       "Entries": [
-        "Prosthetic hand ninja _ Iron fan LV3-B _ Anti-spirit force _ Reach far -- 義手忍具_鉄扇LV3-B_対霊フォース_遠くまで届く"
+        "Phoenix's Lilac Umbrella - Anti-apparition far reach"
       ]
     },
     {
       "ID": 770000,
       "Entries": [
-        "Prosthesis Ninja _ Enemy Turn (1 remaining) -- 義手忍具_敵回し（残り1）"
+        "Divine Abduction - Turn"
       ]
     },
     {
       "ID": 770020,
       "Entries": [
-        "Prosthesis Ninja _ Enemy Turn _ Wind Collection Extension (1 remaining) -- 義手忍具_敵回し_風集め延長（残り1）"
+        "Divine Abduction - Wind Gather"
       ]
     },
     {
       "ID": 770040,
       "Entries": [
-        "Prosthetic Hand Ninja _ Enemy Turn _ Derived Attack Enchantment Dummy -- 義手忍具_敵回し_派生攻撃エンチャント用ダミー"
+        "Divine Abduction - Living Force Dummy"
       ]
     },
     {
       "ID": 770100,
       "Entries": [
-        "Prosthesis Ninja _ Enemy Turn LV2 (1 remaining) -- 義手忍具_敵回しLV2（残り1）"
+        "Double Divine Abduction - Turn"
       ]
     },
     {
       "ID": 770101,
       "Entries": [
-        "Prosthesis Ninja _ Enemy Turn LV2 (2 remaining) -- 義手忍具_敵回しLV2（残り2）"
+        "Double Divine Abduction - Turn"
       ]
     },
     {
       "ID": 770120,
       "Entries": [
-        "Prosthesis Ninja _ Enemy Turn LV2_ Wind Collection Extension (1 remaining) -- 義手忍具_敵回しLV2_風集め延長（残り1）"
+        "Double Divine Abduction - Wind Gather"
       ]
     },
     {
       "ID": 770121,
       "Entries": [
-        "Prosthesis Ninja _ Enemy Turn LV2_ Wind Collection Extension (2 remaining) -- 義手忍具_敵回しLV2_風集め延長（残り2）"
+        "Double Divine Abduction - Wind Gather"
       ]
     },
     {
       "ID": 770200,
       "Entries": [
-        "Prosthesis Ninja _ Enemy Turn LV3 (1 remaining) -- 義手忍具_敵回しLV3（残り1）"
+        "Golden Vortex - Turn"
       ]
     },
     {
       "ID": 770201,
       "Entries": [
-        "Prosthesis Ninja _ Enemy Turn LV3 (2 remaining) -- 義手忍具_敵回しLV3（残り2）"
+        "Golden Vortex - Turn"
       ]
     },
     {
       "ID": 770220,
       "Entries": [
-        "Prosthesis Ninja _ Enemy Turn LV3_ Wind Collection Extension (1 remaining) -- 義手忍具_敵回しLV3_風集め延長（残り1）"
+        "Golden Vortex - Wind Gather"
       ]
     },
     {
       "ID": 770221,
       "Entries": [
-        "Prosthesis Ninja _ Enemy Turn LV3_ Wind Collection Extension (2 remaining) -- 義手忍具_敵回しLV3_風集め延長（残り2）"
+        "Golden Vortex - Wind Gather"
       ]
     },
     {
       "ID": 770240,
       "Entries": [
-        "Prosthetic Hand Ninja _ Enemy Turn LV3_ Derived Attack Enchantment Dummy -- 義手忍具_敵回しLV3_派生攻撃エンチャント用ダミー"
+        "Golden Vortex - Living Force Dummy"
       ]
     },
     {
       "ID": 780400,
       "Entries": [
-        "Prosthetic Hand Ninja _ Spear LV3-B_ Crisis Force _ Parent -- 義手忍具_槍LV3-B_恐慌フォース_親"
+        "Leaping Flame - Red Eyes Scare Parent"
       ]
     },
     {
       "ID": 780401,
       "Entries": [
-        "Prosthetic Hand Ninja _ Spear LV3-B_ Crisis Force _ Child -- 義手忍具_槍LV3-B_恐慌フォース_子"
+        "Leaping Flame - Red Eyes Scare Child"
       ]
     },
     {
       "ID": 790000,
       "Entries": [
-        "Prosthetic hand ninja _ finger whistle _ no lock _ parent A (reservoir) -- 義手忍具_指笛_ノーロック_親A（溜め）"
+        "Finger Whistle No Lock - Charge Parent"
       ]
     },
     {
       "ID": 790001,
       "Entries": [
-        "Prosthetic Hand Ninja _ Finger Whistle _ No Lock _ Parent B -- 義手忍具_指笛_ノーロック_親B"
+        "Finger Whistle No Lock - Parent"
       ]
     },
     {
       "ID": 790002,
       "Entries": [
-        "Prosthetic hand ninja _ finger whistle _ no lock _ child (reservoir) -- 義手忍具_指笛_ノーロック_子（溜め）"
+        "Finger Whistle No Lock - Charge Child"
       ]
     },
     {
       "ID": 790003,
       "Entries": [
-        "Prosthetic hand ninja _ finger whistle _ no lock _ grandson -- 義手忍具_指笛_ノーロック_孫"
+        "Finger Whistle No Lock - Child 1"
       ]
     },
     {
       "ID": 790004,
       "Entries": [
-        "Prosthetic hand ninja _ finger whistle _ no lock _ great-grandson -- 義手忍具_指笛_ノーロック_曾孫"
+        "Finger Whistle No Lock - Child 2"
       ]
     },
     {
       "ID": 790005,
       "Entries": [
-        "Prosthesis Ninja _ Finger Whistle _ Sound Feed Slash _ Reservoir Bullet -- 義手忍具_指笛_音送り斬り_溜め弾丸"
+        "Finger Whistle - Living Force - Charge Bullet"
       ]
     },
     {
       "ID": 790006,
       "Entries": [
-        "Prosthetic hand ninja _ finger whistle _ sound feed slash _ bullet -- 義手忍具_指笛_音送り斬り_弾丸"
+        "Finger Whistle - Living Force - Bullet"
       ]
     },
     {
       "ID": 790010,
       "Entries": [
-        "Prosthetic hand ninja _ finger whistle _ lock-on _ PC to A (reservoir) -- 義手忍具_指笛_ロックオン_PCからA（溜め）"
+        "Finger Whistle Lock - Charge"
       ]
     },
     {
       "ID": 790011,
       "Entries": [
-        "Prosthetic hand ninja _ finger whistle _ lock-on _ B from PC (release) -- 義手忍具_指笛_ロックオン_PCからB（リリース）"
+        "Finger Whistle Lock - Charge Release"
       ]
     },
     {
       "ID": 790012,
       "Entries": [
-        "Prosthesis Ninja _ Finger Whistle _ Lock-on _ B from PC (hanging) -- 義手忍具_指笛_ロックオン_PCからB（ぶら下がり）"
+        "Finger Whistle Lock - Hanging"
       ]
     },
     {
       "ID": 790014,
       "Entries": [
-        "Prosthetic hand ninja _ finger whistle _ lock-on _ PC to B (peeping _ left) -- 義手忍具_指笛_ロックオン_PCからB（覗き込み_左）"
+        "Finger Whistle Lock - Peeping Left"
       ]
     },
     {
       "ID": 790015,
       "Entries": [
-        "Prosthetic hand ninja _ finger whistle _ lock-on _ PC to B (peeping _ right) -- 義手忍具_指笛_ロックオン_PCからB（覗き込み_右）"
+        "Finger Whistle Lock - Peeping Right"
       ]
     },
     {
       "ID": 790200,
       "Entries": [
-        "Prosthetic Hand Ninja _ Finger Whistle LV3 _ No Lock _ Parent A (Reservoir) -- 義手忍具_指笛LV3_ノーロック_親A（溜め）"
+        "Malcontent No Lock - Charge Parent"
       ]
     },
     {
       "ID": 790201,
       "Entries": [
-        "Prosthetic hand ninja _ finger whistle LV3 _ no lock _ parent B -- 義手忍具_指笛LV3_ノーロック_親B"
+        "Malcontent No Lock - Parent"
       ]
     },
     {
       "ID": 790202,
       "Entries": [
-        "Prosthetic hand ninja _ finger whistle LV3 _ no lock _ child (reservoir) -- 義手忍具_指笛LV3_ノーロック_子（溜め）"
+        "Malcontent No Lock - Charge Child"
       ]
     },
     {
       "ID": 790203,
       "Entries": [
-        "Prosthetic hand ninja _ finger whistle LV3 _ no lock _ grandson -- 義手忍具_指笛LV3_ノーロック_孫"
+        "Malcontent No Lock - Child 1"
       ]
     },
     {
       "ID": 790204,
       "Entries": [
-        "Prosthetic hand ninja _ finger whistle LV3 _ no lock _ great-grandson -- 義手忍具_指笛LV3_ノーロック_曾孫"
+        "Malcontent No Lock - Child 2"
       ]
     },
     {
       "ID": 790205,
       "Entries": [
-        "Prosthetic Hand Ninja _ Finger Whistle LV3 _ Sound Feed Slash _ Reservoir Bullet -- 義手忍具_指笛LV3_音送り斬り_溜め弾丸"
+        "Malcontent - Living Force - Charge Bullet"
       ]
     },
     {
       "ID": 790206,
       "Entries": [
-        "Prosthetic hand ninja _ finger whistle LV3 _ sound feed slash _ bullet -- 義手忍具_指笛LV3_音送り斬り_弾丸"
+        "Malcontent - Living Force - Bullet"
       ]
     },
     {
       "ID": 790210,
       "Entries": [
-        "Prosthetic hand ninja _ finger whistle LV3 _ lock-on _ PC to A (reservoir) -- 義手忍具_指笛LV3_ロックオン_PCからA（溜め）"
+        "Malcontent Lock - Charge"
       ]
     },
     {
       "ID": 790211,
       "Entries": [
-        "Prosthetic Hand Ninja _ Finger Whistle LV3 _ Lock On _ B from PC (Release) -- 義手忍具_指笛LV3_ロックオン_PCからB（リリース）"
+        "Malcontent Lock - Charge Release"
       ]
     },
     {
       "ID": 790212,
       "Entries": [
-        "Prosthetic hand ninja _ finger whistle LV3 _ lock on _ PC to B (hanging) -- 義手忍具_指笛LV3_ロックオン_PCからB（ぶら下がり）"
+        "Malcontent Lock - Hanging"
       ]
     },
     {
       "ID": 790214,
       "Entries": [
-        "Prosthetic hand ninja _ finger whistle LV3 _ lock-on _ PC to B (peeping _ left) -- 義手忍具_指笛LV3_ロックオン_PCからB（覗き込み_左）"
+        "Malcontent Lock - Peeping Left"
       ]
     },
     {
       "ID": 790215,
       "Entries": [
-        "Prosthetic hand ninja _ finger whistle LV3 _ lock-on _ PC to B (peeping _ right) -- 義手忍具_指笛LV3_ロックオン_PCからB（覗き込み_右）"
+        "Malcontent Lock - Peeping Right"
       ]
     },
     {
       "ID": 1000000,
       "Entries": [
-        "Map placement Mario coin _ white -- マップ配置マリオコイン_白"
+        "Spirit Emblem Placed On Map"
       ]
     },
     {
       "ID": 1000010,
       "Entries": [
-        "Map placement Mario coin _ red -- マップ配置マリオコイン_赤"
+        "Red Spirit Emblem Placed On Map (Unused)"
       ]
     },
     {
       "ID": 1000020,
       "Entries": [
-        "Map placement Mario coin _ blue -- マップ配置マリオコイン_青"
+        "Blue Spirit Emblem Placed On Map (Unused)"
       ]
     },
     {
@@ -2674,13 +2674,13 @@
     {
       "ID": 1001200,
       "Entries": [
-        "Ashina Outskirts Lightning Strikes (during Sword Saint fight)"
+        "Ashina Reservoir Lightning Strikes (during Sword Saint fight)"
       ]
     },
     {
       "ID": 1001201,
       "Entries": [
-        "Ashina Outskirts Lightning Strikes (during Sword Saint fight)"
+        "Ashina Reservoir Lightning Strikes (during Sword Saint fight)"
       ]
     },
     {
@@ -2704,2569 +2704,2569 @@
     {
       "ID": 10001500,
       "Entries": [
-        "Dummy bullet_pseudo platoon AI sound -- ダミー弾丸_疑似小隊AI音"
+        "Dummy Bullet Pseudo Platoon AI Sound"
       ]
     },
     {
       "ID": 10001600,
       "Entries": [
-        "Dummy bullet_dangerous attack -- ダミー弾丸_危険な攻撃"
+        "Perilous Attack Earning"
       ]
     },
     {
       "ID": 10002100,
       "Entries": [
-        "Dummy bullet _ find judgment -- ダミー弾丸_見つけ判定"
+        "Dummy Bullet Find Judgment"
       ]
     },
     {
       "ID": 10002200,
       "Entries": [
-        "Dummy bullet _ kick jump back circumference judgment -- ダミー弾丸_蹴りジャンプ裏周り判定"
+        "Dummy Bullet Jump Kick Back Circumference Judgment"
       ]
     },
     {
       "ID": 10002300,
       "Entries": [
-        "Dummy bullet _ enemy turning AI sound bullet -- ダミー弾丸_敵回しAI音弾丸"
+        "Dummy Bullet - Divine Abduction AI Sound Bullet"
       ]
     },
     {
       "ID": 10002400,
       "Entries": [
-        "Dummy bullet _ resurrection detection AI sound bullet -- ダミー弾丸_復活感知AI音弾丸"
+        "Dummy Bullet - Resurrection AI Sound"
       ]
     },
     {
       "ID": 10002500,
       "Entries": [
-        "[GC version provisional] Dummy bullet _ Continue to make sound from PC during battle -- 【GC版暫定】ダミー弾丸_戦闘時PCから音を出し続ける"
+        ""
       ]
     },
     {
       "ID": 10100190,
       "Entries": [
-        "c1010_Ochimusha_One-handed_Stone throwing -- c1010_落武者_片手_石投げ"
+        "Ashina Soldier - Stone Throw"
       ]
     },
     {
       "ID": 10100910,
       "Entries": [
-        "c1010_Ochimusha_One-handed_AI sound at the start of battle -- c1010_落武者_片手_戦闘開始時AI音"
+        "Ashina Solider One Handed - AI Sound at start of battle"
       ]
     },
     {
       "ID": 10101910,
       "Entries": [
-        "c1010_Ochimusha_Eight Phases_AI sound at the start of battle -- c1010_落武者_八相_戦闘開始時AI音"
+        "Ashina Solider Two Handed - AI Sound at start of battle"
       ]
     },
     {
       "ID": 10102910,
       "Entries": [
-        "c1010_Ochimusha_Spear_AI sound at the start of battle -- c1010_落武者_槍_戦闘開始時AI音"
+        "Ashina Solider Spear - AI Sound at start of battle"
       ]
     },
     {
       "ID": 10102980,
       "Entries": [
-        "Dummy Bullet_Dangerous Attack_Push Combo 1 -- ダミー弾丸_危険な攻撃_突きコンボ1"
+        "Perilous Attack Warning"
       ]
     },
     {
       "ID": 10102981,
       "Entries": [
-        "Dummy Bullet_Dangerous Attack_-Push Combo 2 -- ダミー弾丸_危険な攻撃_-突きコンボ2"
+        "Perilous Attack Warning"
       ]
     },
     {
       "ID": 10102982,
       "Entries": [
-        "Dummy bullet _ dangerous attack _ stepping on -- ダミー弾丸_危険な攻撃_踏み込み突き"
+        "Perilous Attack Warning"
       ]
     },
     {
       "ID": 10102983,
       "Entries": [
-        "Dummy bullets_dangerous attack_checking thrust -- ダミー弾丸_危険な攻撃_牽制突き"
+        "Perilous Attack Warning"
       ]
     },
     {
       "ID": 10102984,
       "Entries": [
-        "Dummy Bullet_Dangerous Attack_Pump Thrust -- ダミー弾丸_危険な攻撃_溜め突き"
+        "Perilous Attack Warning"
       ]
     },
     {
       "ID": 10102985,
       "Entries": [
-        "Dummy Bullet_Dangerous Attack_Push Retreat -- ダミー弾丸_危険な攻撃_突き後退"
+        "Perilous Attack Warning"
       ]
     },
     {
       "ID": 10102986,
       "Entries": [
-        "Dummy Bullet_Dangerous Attack_Treading Thrust (Short Range) -- ダミー弾丸_危険な攻撃_踏み込み突き（近距離）"
+        "Perilous Attack Warning"
       ]
     },
     {
       "ID": 10102987,
       "Entries": [
-        "Dummy bullet _ dangerous attack _ stepping on (long range) -- ダミー弾丸_危険な攻撃_踏み込み突き（遠距離）"
+        "Perilous Attack Warning"
       ]
     },
     {
       "ID": 10102988,
       "Entries": [
-        "Dummy bullets_dangerous attack_bottom -- ダミー弾丸_危険な攻撃_下段"
+        "Perilous Attack Warning"
       ]
     },
     {
       "ID": 10102989,
       "Entries": [
-        "Dummy bullets_dangerous attacks_other thrusts -- ダミー弾丸_危険な攻撃_その他突き"
+        "Perilous Attack Warning"
       ]
     },
     {
       "ID": 10103100,
       "Entries": [
-        "c1010_Ochimusha_Matchlock_Shoot -- c1010_落武者_火縄銃_撃つ"
+        "Ashina Solider Matchlock - Shoot"
       ]
     },
     {
       "ID": 10103130,
       "Entries": [
-        "c1010_Ochimusha_Matchlock_Shoot_Not accurate -- c1010_落武者_火縄銃_撃つ_正確じゃない"
+        "Ashina Solider Matchlock - Shoot Not Accurate"
       ]
     },
     {
       "ID": 10103140,
       "Entries": [
-        "c1010_Ochimusha_Matchlock_Shoot_Underwater -- c1010_落武者_火縄銃_撃つ_水中用"
+        "Ashina Solider Matchlock - Shoot Underwater"
       ]
     },
     {
       "ID": 10103141,
       "Entries": [
-        "c1010_Ochimusha_Matchlock_Shoot_Underwater_Advance a little underwater -- c1010_落武者_火縄銃_撃つ_水中用_水中でちょっと進む"
+        "Ashina Solider Matchlock - Shoot Underwater"
       ]
     },
     {
       "ID": 10103910,
       "Entries": [
-        "c1010_Ochimusha_Matchlock_AI sound at the start of battle -- c1010_落武者_火縄銃_戦闘開始時AI音"
+        "Ashina Solider Matchlock - AI Sound at start of battle"
       ]
     },
     {
       "ID": 10103920,
       "Entries": [
-        "c1010_Ochimusha_Matchlock_AI sound -- c1010_落武者_火縄銃_AI音"
+        "Ashina Solider Matchlock - AI Sound"
       ]
     },
     {
       "ID": 10200980,
       "Entries": [
-        "Dummy Bullet_Dangerous Attack_Lower Combo 1 -- ダミー弾丸_危険な攻撃_下段薙ぎ払いコンボ1"
+        "Perilous Attack Warning"
       ]
     },
     {
       "ID": 10200981,
       "Entries": [
-        "Dummy bullet _ Dangerous attack _ Lower sword-fighting combo 2 -- ダミー弾丸_危険な攻撃_下段薙ぎ払いコンボ2"
+        "Perilous Attack Warning"
       ]
     },
     {
       "ID": 10200982,
       "Entries": [
-        "Dummy bullet _ dangerous attack _ forward thrust -- ダミー弾丸_危険な攻撃_前進突き"
+        "Perilous Attack Warning"
       ]
     },
     {
       "ID": 10200983,
       "Entries": [
-        "Dummy bullet _ dangerous attack _ neck grab -- ダミー弾丸_危険な攻撃_首つかみ"
+        "Perilous Attack Warning"
       ]
     },
     {
       "ID": 10200984,
       "Entries": [
-        "Dummy bullet _ Dangerous attack _ Right strong shot from the eight-shaped cut → thrust -- ダミー弾丸_危険な攻撃_右強弾かれからの八の字切り→突き"
+        "Perilous Attack Warning"
       ]
     },
     {
       "ID": 10200985,
       "Entries": [
-        "Dummy bullet _ Dangerous attack _ Strong lower tier from being hit hard on the left -- ダミー弾丸_危険な攻撃_左強弾かれからの強下段薙ぎ払い"
+        "Perilous Attack Warning"
       ]
     },
     {
       "ID": 10201980,
       "Entries": [
-        "Dummy Bullet_Dangerous Attack 6m -- ダミー弾丸_危険な攻撃\u30006m"
+        "Perilous Attack Warning"
       ]
     },
     {
       "ID": 10201981,
       "Entries": [
-        "Dummy bullet_dangerous attack 12m -- ダミー弾丸_危険な攻撃\u300012m"
+        "Perilous Attack Warning"
       ]
     },
     {
       "ID": 10300200,
       "Entries": [
-        "c1030_centipede (small) _self-destruct -- c1030_ムカデ（小）_自爆"
+        "Small Centipede - Explode"
       ]
     },
     {
       "ID": 10300210,
       "Entries": [
-        "c1030_Centipede (Small) _Burning ball sprinkling -- c1030_ムカデ（小）_炮烙玉ばらまき"
+        "Small Centipede - Burning Ball"
       ]
     },
     {
       "ID": 10300220,
       "Entries": [
-        "c1030_Centipede (small) _Burning ball sprinkling 2 consecutive-1 -- c1030_ムカデ（小）_炮烙玉ばらまき2連-1"
+        "Small Centipede - Burning Ball"
       ]
     },
     {
       "ID": 10300221,
       "Entries": [
-        "c1030_Centipede (Small) _Burning ball sprinkling 2 consecutive-2 -- c1030_ムカデ（小）_炮烙玉ばらまき2連-2"
+        "Small Centipede - Burning Ball"
       ]
     },
     {
       "ID": 10300230,
       "Entries": [
-        "c1030_ Centipede (Small) _ Right-handed smashing ball sprinkling 2 consecutive -1 -- c1030_ムカデ（小）_右強弾かれからの炮烙玉ばらまき2連-1"
+        "Small Centipede - Burning Ball"
       ]
     },
     {
       "ID": 10300231,
       "Entries": [
-        "c1030_Centipede (Small) _Right-handed smashing ball sprinkling 2 consecutive-2 -- c1030_ムカデ（小）_右強弾かれからの炮烙玉ばらまき2連-2"
+        "Small Centipede - Burning Ball"
       ]
     },
     {
       "ID": 10300240,
       "Entries": [
-        "c1030_Centipede (Small) _Burning Ball_Impacting Flame Floor -- c1030_ムカデ（小）_炮烙玉_着弾炎床"
+        "Small Centipede - Burning Ball"
       ]
     },
     {
       "ID": 10400210,
       "Entries": [
-        "c1040_Centipede (Large) _Burning ball sprinkling -- c1040_ムカデ（大）_炮烙玉ばらまき"
+        "Long-arm Centipede - Burning Ball"
       ]
     },
     {
       "ID": 10400220,
       "Entries": [
-        "c1040_Centipede (Large) _Burning ball sprinkling 2 consecutive -1 -- c1040_ムカデ（大）_炮烙玉ばらまき2連-1"
+        "Long-arm Centipede - Burning Ball"
       ]
     },
     {
       "ID": 10400221,
       "Entries": [
-        "c1040_Centipede (Large) _Burning ball sprinkling 2 consecutive-2 -- c1040_ムカデ（大）_炮烙玉ばらまき2連-2"
+        "Long-arm Centipede - Burning Ball"
       ]
     },
     {
       "ID": 10400230,
       "Entries": [
-        "c1040_ Centipede (Large) _ Right-handed smashing ball sprinkling 2 consecutive -1 -- c1040_ムカデ（大）_右強弾かれからの炮烙玉ばらまき2連-1"
+        "Long-arm Centipede - Burning Ball"
       ]
     },
     {
       "ID": 10400231,
       "Entries": [
-        "c1040_Centipede (Large) _Right-handed smashing ball sprinkling 2 consecutive-2 -- c1040_ムカデ（大）_右強弾かれからの炮烙玉ばらまき2連-2"
+        "Long-arm Centipede - Burning Ball"
       ]
     },
     {
       "ID": 10400240,
       "Entries": [
-        "c1040_Centipede (Large) _Burning ball_Impacting flame floor -- c1040_ムカデ（大）_炮烙玉_着弾炎床"
+        "Long-arm Centipede - Burning Ball"
       ]
     },
     {
       "ID": 10400981,
       "Entries": [
-        "c1040_Centipede (Large) _Dummy Bullet_Dangerous Attack -- c1040_ムカデ（大）_ダミー弾丸_危険な攻撃"
+        "Long-arm Centipede - Perilous Attack Warning"
       ]
     },
     {
       "ID": 10500980,
       "Entries": [
-        "c1050_Spear Monk_Dummy Bullet_Dangerous Attack -- c1050_槍僧兵_ダミー弾丸_危険な攻撃"
+        "Shinobi Hunter - Perilous Attack Warning"
       ]
     },
     {
       "ID": 10600500,
       "Entries": [
-        "c1060_Rotating spearman_Shuriken_Common -- c1060_回転槍術師_手裏剣_共通"
+        "Spear Adept - Throwing Knife"
       ]
     },
     {
       "ID": 10600510,
       "Entries": [
-        "c1060_Rotating spearman_Shuriken_Navimesh For when not connected -- c1060_回転槍術師_手裏剣_ナビメッシュ繋がってない時用"
+        "Spear Adept - Throwing Knife"
       ]
     },
     {
       "ID": 10600980,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Lower slash from 4 rotations -- ダミー弾丸_危険な攻撃予兆_回転4連撃からの下段斬り"
+        "Spear Adept - Perilous Attack Warning"
       ]
     },
     {
       "ID": 10600981,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Pole vault lower step -- ダミー弾丸_危険な攻撃予兆_棒高跳び回り込みからの踏み込み下段"
+        "Spear Adept - Perilous Attack Warning"
       ]
     },
     {
       "ID": 10700360,
       "Entries": [
-        "Poison fog_parent -- 毒霧_親"
+        "Shura Samurai - Poison Spit"
       ]
     },
     {
       "ID": 10700361,
       "Entries": [
-        "Poison fog _ child -- 毒霧_子"
+        "Shura Samurai - Poison Spit"
       ]
     },
     {
       "ID": 10700362,
       "Entries": [
-        "Poison fog _ grandson -- 毒霧_孫"
+        "Shura Samurai - Poison Spit"
       ]
     },
     {
       "ID": 10700363,
       "Entries": [
-        "Poisonous fog_great-grandson -- 毒霧_曾孫"
+        "Shura Samurai - Poison Spit"
       ]
     },
     {
       "ID": 10700364,
       "Entries": [
-        "Poison fog _ body _ small -- 毒霧_本体_小"
+        "Shura Samurai - Poison Spit"
       ]
     },
     {
       "ID": 10700365,
       "Entries": [
-        "Poison fog _ body _ inside -- 毒霧_本体_中"
+        "Shura Samurai - Poison Spit"
       ]
     },
     {
       "ID": 10700366,
       "Entries": [
-        "Poison fog _ body _ large -- 毒霧_本体_大"
+        "Shura Samurai - Poison Spit"
       ]
     },
     {
       "ID": 10700367,
       "Entries": [
-        "Poison fog _ body _ oversized -- 毒霧_本体_特大"
+        "Shura Samurai - Poison Spit"
       ]
     },
     {
       "ID": 10700369,
       "Entries": [
-        "Poison fog _ dizziness dummy -- 毒霧_目眩ましダミー"
+        "Shura Samurai - Poison Spit"
       ]
     },
     {
       "ID": 10700380,
       "Entries": [
-        "Flame fog_parent -- 炎霧_親"
+        "Shura Samurai - Flame Spit"
       ]
     },
     {
       "ID": 10700381,
       "Entries": [
-        "Flame fog _ child -- 炎霧_子"
+        "Shura Samurai - Flame Spit"
       ]
     },
     {
       "ID": 10700382,
       "Entries": [
-        "Flame fog _ grandson -- 炎霧_孫"
+        "Shura Samurai - Flame Spit"
       ]
     },
     {
       "ID": 10700383,
       "Entries": [
-        "Flame fog _ body _ small -- 炎霧_本体_小"
+        "Shura Samurai - Flame Spit"
       ]
     },
     {
       "ID": 10700384,
       "Entries": [
-        "Flame fog _ body _ inside -- 炎霧_本体_中"
+        "Shura Samurai - Flame Spit"
       ]
     },
     {
       "ID": 10700385,
       "Entries": [
-        "Flame fog _ body _ large -- 炎霧_本体_大"
+        "Shura Samurai - Flame Spit"
       ]
     },
     {
       "ID": 10700386,
       "Entries": [
-        "Flame fog _ dizziness dummy -- 炎霧_目眩ましダミー"
+        "Shura Samurai - Flame Spit"
       ]
     },
     {
       "ID": 10700387,
       "Entries": [
-        "Flame fog _ great-grandson -- 炎霧_曾孫"
+        "Shura Samurai - Flame Spit"
       ]
     },
     {
       "ID": 10700910,
       "Entries": [
-        "Sake bottle throwing bullet (cancellation of special standby) -- 酒瓶投げ弾丸（特殊待機の解除）"
+        "Shura Samurai - Sake Bottle Throw"
       ]
     },
     {
       "ID": 10700920,
       "Entries": [
-        "Dummy bullet _ armor generation _ black armor -- ダミー弾丸_鎧生成_黒い鎧"
+        "Shura Samurai - Armor"
       ]
     },
     {
       "ID": 10700921,
       "Entries": [
-        "Dummy bullet _ armor generation _ red armor -- ダミー弾丸_鎧生成_赤い鎧"
+        "Shura Samurai - Armor"
       ]
     },
     {
       "ID": 10700930,
       "Entries": [
-        "Dummy Bullet_Dummy Attack_Armor Destruction -- ダミー弾丸_ダミー攻撃_鎧破壊"
+        "Shura Samurai - Armor Destruction"
       ]
     },
     {
       "ID": 10700980,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ One-handed lower sword from poison fog -- ダミー弾丸_危険な攻撃予兆_毒霧からの片手下段薙ぎ払い"
+        "Shura Samurai - Perilous Attack Warning"
       ]
     },
     {
       "ID": 10700981,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Shikona trampling throw -- ダミー弾丸_危険な攻撃予兆_四股踏みつけ投げ"
+        "Shura Samurai - Perilous Attack Warning"
       ]
     },
     {
       "ID": 10700982,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ One-handed lower sword -- ダミー弾丸_危険な攻撃予兆_片手下段薙ぎ払い"
+        "Shura Samurai - Perilous Attack Warning"
       ]
     },
     {
       "ID": 10800500,
       "Entries": [
-        "c1080: Seven-sided warrior_burst -- c1080：七面武者_連射弾"
+        "Shichimen Warrior - Burst"
       ]
     },
     {
       "ID": 10800501,
       "Entries": [
-        "c1080: Seven-sided warrior_burst _for short range -- c1080：七面武者_連射弾_近距離用"
+        "Shichimen Warrior - Burst"
       ]
     },
     {
       "ID": 10800510,
       "Entries": [
-        "c1080: Seven-sided warrior_guided bullet_small reservoir -- c1080：七面武者_誘導弾_溜め小"
+        "Shichimen Warrior - Bullet"
       ]
     },
     {
       "ID": 10800511,
       "Entries": [
-        "c1080: Seven-sided warrior_guided bullets_reserving -- c1080：七面武者_誘導弾_溜め中"
+        "Shichimen Warrior - Bullet"
       ]
     },
     {
       "ID": 10800512,
       "Entries": [
-        "c1080: Seven-sided warrior_guided bullet_large reservoir -- c1080：七面武者_誘導弾_溜め大"
+        "Shichimen Warrior - Bullet"
       ]
     },
     {
       "ID": 10800520,
       "Entries": [
-        "c1080: Seven-sided warrior_giant bullet_accumulation_launch -- c1080：七面武者_巨大弾_溜め中_打ち上げ"
+        "Shichimen Warrior - Bullet"
       ]
     },
     {
       "ID": 10800521,
       "Entries": [
-        "c1080: Seven-sided warrior_giant bullet_reserving_created -- c1080：七面武者_巨大弾_溜め中_作成"
+        "Shichimen Warrior - Bullet"
       ]
     },
     {
       "ID": 10800522,
       "Entries": [
-        "c1080: Seven-sided warrior_giant bullet_reservoir_injection -- c1080：七面武者_巨大弾_溜め中_射出"
+        "Shichimen Warrior - Bullet"
       ]
     },
     {
       "ID": 10800530,
       "Entries": [
-        "c1080: Seven-sided warrior_giant bullet_reservoir small_launch -- c1080：七面武者_巨大弾_溜め小_打ち上げ"
+        "Shichimen Warrior - Bullet"
       ]
     },
     {
       "ID": 10800531,
       "Entries": [
-        "c1080: Seven-sided warrior_giant bullet_reservoir small_create -- c1080：七面武者_巨大弾_溜め小_作成"
+        "Shichimen Warrior - Bullet"
       ]
     },
     {
       "ID": 10800532,
       "Entries": [
-        "c1080: Seven-sided warrior_giant bullet_reservoir small_injection -- c1080：七面武者_巨大弾_溜め小_射出"
+        "Shichimen Warrior - Bullet"
       ]
     },
     {
       "ID": 10800600,
       "Entries": [
-        "c1080: Seven-sided warrior_guided bullet_launch -- c1080：七面武者_誘導弾_発射"
+        "Shichimen Warrior - Bullet"
       ]
     },
     {
       "ID": 10800601,
       "Entries": [
-        "c1080: Seven-sided warrior_guided bullet_scattering 1 -- c1080：七面武者_誘導弾_ばら撒き1"
+        "Shichimen Warrior - Bullet"
       ]
     },
     {
       "ID": 10800602,
       "Entries": [
-        "c1080: Seven-sided warrior_guided bullet_scatter 2 -- c1080：七面武者_誘導弾_ばら撒き2"
+        "Shichimen Warrior - Bullet"
       ]
     },
     {
       "ID": 10800603,
       "Entries": [
-        "c1080: Seven-sided warrior_guided bullet_scattering 3 -- c1080：七面武者_誘導弾_ばら撒き3"
+        "Shichimen Warrior - Bullet"
       ]
     },
     {
       "ID": 10800604,
       "Entries": [
-        "c1080: Seven-sided warrior_guided bullet_scattering 4 -- c1080：七面武者_誘導弾_ばら撒き4"
+        "Shichimen Warrior - Bullet"
       ]
     },
     {
       "ID": 10800605,
       "Entries": [
-        "c1080: Seven-sided warrior_guided bullet_scattering 5 -- c1080：七面武者_誘導弾_ばら撒き5"
+        "Shichimen Warrior - Bullet"
       ]
     },
     {
       "ID": 10800610,
       "Entries": [
-        "c1080: Seven-sided warrior_Rapid fire _Grief mass summon _Position movement -- c1080：七面武者_連射弾_怨霊大量召喚_位置移動"
+        "Shichimen Warrior - Bullet"
       ]
     },
     {
       "ID": 10800611,
       "Entries": [
-        "c1080: Seven-sided warrior _ rapid fire _ mass summoning ghosts _ summoning -- c1080：七面武者_連射弾_怨霊大量召喚_召喚"
+        "Shichimen Warrior - Rapid Fire"
       ]
     },
     {
       "ID": 10800612,
       "Entries": [
-        "c1080: Seven-sided warrior_Rapid fire _Grief mass summon _Launch -- c1080：七面武者_連射弾_怨霊大量召喚_発射"
+        "Shichimen Warrior - Rapid Fire"
       ]
     },
     {
       "ID": 10800620,
       "Entries": [
-        "c1080: Seven-sided warrior_guided bullets_mass summons of grudges_position movement -- c1080：七面武者_誘導弾_怨霊大量召喚_位置移動"
+        "Shichimen Warrior - Large Bullet"
       ]
     },
     {
       "ID": 10800621,
       "Entries": [
-        "c1080: Seven-sided warrior_guided bullet_mass summoning ghosts_summoning -- c1080：七面武者_誘導弾_怨霊大量召喚_召喚"
+        "Shichimen Warrior - Large Bullet"
       ]
     },
     {
       "ID": 10800622,
       "Entries": [
-        "c1080: Seven-sided warrior_guided bullet_mass summoning ghosts_launch -- c1080：七面武者_誘導弾_怨霊大量召喚_発射"
+        "Shichimen Warrior - Large Bullet"
       ]
     },
     {
       "ID": 10800630,
       "Entries": [
-        "c1080: Seven-sided warrior_Large bullets_Mass summoning grudges_Position movement 1 -- c1080：七面武者_大型弾_怨霊大量召喚_位置移動1"
+        "Shichimen Warrior - Large Bullet"
       ]
     },
     {
       "ID": 10800631,
       "Entries": [
-        "c1080: Seven-sided warrior_Large bullets_Mass summoning grudges_Position movement 2 -- c1080：七面武者_大型弾_怨霊大量召喚_位置移動2"
+        "Shichimen Warrior - Large Bullet"
       ]
     },
     {
       "ID": 10800632,
       "Entries": [
-        "c1080: Seven-sided warrior_Large bullets_Mass summoning grudges_Position movement 3 -- c1080：七面武者_大型弾_怨霊大量召喚_位置移動3"
+        "Shichimen Warrior - Large Bullet"
       ]
     },
     {
       "ID": 10800633,
       "Entries": [
-        "c1080: Seven-sided warrior_Large bullets_Accumulating_Launch 1 -- c1080：七面武者_大型弾_溜め中_打ち上げ1"
+        "Shichimen Warrior - Large Bullet"
       ]
     },
     {
       "ID": 10800634,
       "Entries": [
-        "c1080: Seven-sided warrior_Large bullets_Accumulating_Launch 2 -- c1080：七面武者_大型弾_溜め中_打ち上げ2"
+        "Shichimen Warrior - Large Bullet"
       ]
     },
     {
       "ID": 10800635,
       "Entries": [
-        "c1080: Seven-sided warrior_Large bullets_Accumulating_Launch 3 -- c1080：七面武者_大型弾_溜め中_打ち上げ3"
+        "Shichimen Warrior - Large Bullet"
       ]
     },
     {
       "ID": 10800636,
       "Entries": [
-        "c1080: Seven-sided warrior_Large bullet_Grief mass summon_Summon 1 -- c1080：七面武者_大型弾_怨霊大量召喚_召喚1"
+        "Shichimen Warrior - Large Bullet"
       ]
     },
     {
       "ID": 10800637,
       "Entries": [
-        "c1080: Seven-sided warrior_Large bullet_Grief mass summon_Summon 2 -- c1080：七面武者_大型弾_怨霊大量召喚_召喚2"
+        "Shichimen Warrior - Large Bullet"
       ]
     },
     {
       "ID": 10800638,
       "Entries": [
-        "c1080: Seven-sided warrior_Large bullets_Mass summons of grudges_Summon 3 -- c1080：七面武者_大型弾_怨霊大量召喚_召喚3"
+        "Shichimen Warrior - Large Bullet"
       ]
     },
     {
       "ID": 10800639,
       "Entries": [
-        "c1080: Seven-sided warrior_Large bullets_Mass summoning ghosts_Launch -- c1080：七面武者_大型弾_怨霊大量召喚_発射"
+        "Shichimen Warrior - Large Bullet"
       ]
     },
     {
       "ID": 10800640,
       "Entries": [
-        "c1080: Seven-sided warrior_guided bullet_event summoning_position movement -- c1080：七面武者_誘導弾_イベント召喚_位置移動"
+        "Shichimen Warrior - Guided Bullet"
       ]
     },
     {
       "ID": 10800641,
       "Entries": [
-        "c1080: Seven-sided warrior_guided bullet_event summon_summon -- c1080：七面武者_誘導弾_イベント召喚_召喚"
+        "Shichimen Warrior - Guided Bullet"
       ]
     },
     {
       "ID": 10800642,
       "Entries": [
-        "c1080: Seven-sided warrior_guided bullet_event summoning_launch -- c1080：七面武者_誘導弾_イベント召喚_発射"
+        "Shichimen Warrior - Guided Bullet"
       ]
     },
     {
       "ID": 10800650,
       "Entries": [
-        "c1080: Seven-sided warrior_special standby grudge_position movement -- c1080：七面武者_特殊待機怨霊_位置移動"
+        "Shichimen Warrior"
       ]
     },
     {
       "ID": 10800651,
       "Entries": [
-        "c1080: Seven-sided warrior_special standby grudge_summon -- c1080：七面武者_特殊待機怨霊_召喚"
+        "Shichimen Warrior"
       ]
     },
     {
       "ID": 10800660,
       "Entries": [
-        "c1080: Seven-sided warrior_torrent -- c1080：七面武者_奔流"
+        "Shichimen Warrior - Terror Beam"
       ]
     },
     {
       "ID": 10800700,
       "Entries": [
-        "c1080: Seven-sided warrior_when mass summoned_self-centered horror bullet -- c1080：七面武者_大量召喚時_自己中心恐怖弾丸"
+        "Shichimen Warrior"
       ]
     },
     {
       "ID": 10800800,
       "Entries": [
-        "c1080: Seven-sided warrior_at death_remove ghost bullets -- c1080：七面武者_死亡時_怨霊弾削除"
+        "Shichimen Warrior - Remove Bullets on Death"
       ]
     },
     {
       "ID": 10900110,
       "Entries": [
-        "c1090: Dog_Basic_Barking (AI sound bullet shooting at the PC) -- c1090：イヌ_基本_吠える（PCに向かって撃つAI音弾丸）"
+        ""
       ]
     },
     {
       "ID": 10900900,
       "Entries": [
-        "c1090: Dog_Special effects_Jump and bite -- c1090：イヌ_特殊効果_飛びかかり噛みつき"
+        ""
       ]
     },
     {
       "ID": 11000010,
       "Entries": [
-        "c1100: Gecko_poison sprinkling -- c1100：ヤモリ_毒ばらまき"
+        "Gecko - Poison Spit"
       ]
     },
     {
       "ID": 11000011,
       "Entries": [
-        "c1100: Gecko_poison sprinkling_at the time of landing -- c1100：ヤモリ_毒ばらまき_着弾時"
+        "Gecko - Poison Spit"
       ]
     },
     {
       "ID": 11000020,
       "Entries": [
-        "c1100: Gull _ Poison spitting from the ceiling -- c1100：ヤモリ_天井から毒吐き"
+        "Gecko - Poison Spit"
       ]
     },
     {
       "ID": 11000021,
       "Entries": [
-        "c1100: Gecko _ Poison spitting from the ceiling _ At the time of landing -- c1100：ヤモリ_天井から毒吐き_着弾時"
+        "Gecko - Poison Spit"
       ]
     },
     {
       "ID": 11000030,
       "Entries": [
-        "c1100: Poison vomiting from the gecko _ wall -- c1100：ヤモリ_壁から毒吐き"
+        "Gecko - Poison Spit"
       ]
     },
     {
       "ID": 11000031,
       "Entries": [
-        "c1100: Gull _ Poison spit from the wall _ At the time of landing -- c1100：ヤモリ_壁から毒吐き_着弾時"
+        "Gecko - Poison Spit"
       ]
     },
     {
       "ID": 11000040,
       "Entries": [
-        "c1100: Gecko _ frontal poison _ -- c1100：ヤモリ_正面毒_"
+        "Gecko - Poison Spit"
       ]
     },
     {
       "ID": 11000041,
       "Entries": [
-        "c1100: Gecko_front poison_landing -- c1100：ヤモリ_正面毒_着弾"
+        "Gecko - Poison Spit"
       ]
     },
     {
       "ID": 11000050,
       "Entries": [
-        "c1100: Gecko_poison sprinkling -- c1100：ヤモリ_毒ばらまき"
+        "Gecko - Poison Spit"
       ]
     },
     {
       "ID": 11000051,
       "Entries": [
-        "c1100: Gecko_poison sprinkling_at the time of landing -- c1100：ヤモリ_毒ばらまき_着弾時"
+        "Gecko - Poison Spit"
       ]
     },
     {
       "ID": 11000100,
       "Entries": [
-        "c1100: Gecko _ stepped on poison _ -- c1100：ヤモリ_踏まれ毒_"
+        "Gecko - Poison Spit"
       ]
     },
     {
       "ID": 11000101,
       "Entries": [
-        "c1100: Gecko_stepped poison_landing -- c1100：ヤモリ_踏まれ毒_着弾"
+        "Gecko - Poison Spit"
       ]
     },
     {
       "ID": 11000110,
       "Entries": [
-        "c1100: White gecko_front poison_aging -- c1100：白ヤモリ_正面毒_老化"
+        "White Gecko - Spit"
       ]
     },
     {
       "ID": 11000111,
       "Entries": [
-        "c1100: White gecko_front poison_aging_landing -- c1100：白ヤモリ_正面毒_老化_着弾"
+        "White Gecko - Spit"
       ]
     },
     {
       "ID": 11000300,
       "Entries": [
-        "c1100: White gecko_poison spit from the ceiling -- c1100：白ヤモリ_天井から毒吐き"
+        "White Gecko - Spit"
       ]
     },
     {
       "ID": 11000310,
       "Entries": [
-        "c1100: White gecko_poisoning from the wall -- c1100：白ヤモリ_壁から毒吐き"
+        "White Gecko - Spit"
       ]
     },
     {
       "ID": 11100010,
       "Entries": [
-        "c1110: Aunt Samurai_Call a Friend_For AI Sound -- c1110：侍女おば_仲間を呼ぶ_AI音用"
+        "Old Maid - AI Sound"
       ]
     },
     {
       "ID": 11200120,
       "Entries": [
-        "c1120: Watchman_Basic_Gong ringing A -- c1120：見張り爺_基本_銅鑼を鳴らすA"
+        "Sentry - Gong"
       ]
     },
     {
       "ID": 11200130,
       "Entries": [
-        "c1120: Watchman_Basic_Gong ringing B -- c1120：見張り爺_基本_銅鑼を鳴らすB"
+        "Sentry - Gong"
       ]
     },
     {
       "ID": 11300900,
       "Entries": [
-        "c1130_Nanban Armor_Collision Detection Sonar -- c1130_南蛮甲冑_衝突検出ソナー"
+        "Armored Warrior - Collision Detection"
       ]
     },
     {
       "ID": 11300901,
       "Entries": [
-        "c1130_Southern armor_Collision detection sonar_Reflection -- c1130_南蛮甲冑_衝突検出ソナー_反射"
+        "Armored Warrior - Collision Detection"
       ]
     },
     {
       "ID": 11300980,
       "Entries": [
-        "c1130_Nanban Armor_Dummy Bullet_Dangerous Attack -- c1130_南蛮甲冑_ダミー弾丸_危険な攻撃"
+        "Armored Warrior - Perilous Attack Warning"
       ]
     },
     {
       "ID": 11400980,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Surprise attack A -- ダミー弾丸_危険な攻撃予兆_奇襲突きA"
+        "Rock Diver - Perilous Attack Warning"
       ]
     },
     {
       "ID": 11400981,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Surprise attack B -- ダミー弾丸_危険な攻撃予兆_奇襲突きB"
+        "Rock Diver - Perilous Attack Warning"
       ]
     },
     {
       "ID": 11400982,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Two-handed thrust from shaving -- ダミー弾丸_危険な攻撃予兆_薙ぎ払いからの両手突き"
+        "Rock Diver - Perilous Attack Warning"
       ]
     },
     {
       "ID": 11400983,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ One-handed thrust -- ダミー弾丸_危険な攻撃予兆_片手突き"
+        "Rock Diver - Perilous Attack Warning"
       ]
     },
     {
       "ID": 11400984,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Surprise attack _ Sideways _ Left -- ダミー弾丸_危険な攻撃予兆_奇襲_横薙ぎ_左"
+        "Rock Diver - Perilous Attack Warning"
       ]
     },
     {
       "ID": 11400985,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Surprise attack _ Sideways _ Right -- ダミー弾丸_危険な攻撃予兆_奇襲_横薙ぎ_右"
+        "Rock Diver - Perilous Attack Warning"
       ]
     },
     {
       "ID": 11500120,
       "Entries": [
-        "c1150: Dog_Basic_Barking (AI sound bullet shooting at the PC) -- c1150：イヌ_基本_吠える（PCに向かって撃つAI音弾丸）"
+        "Hound - Barking AI Sound"
       ]
     },
     {
       "ID": 11510110,
       "Entries": [
-        "c1151_Innsmouth dog_Thunder bullet spitting -- c1151_インスマス犬_雷弾丸吐き"
+        "Palace Hound - Lightning"
       ]
     },
     {
       "ID": 11510111,
       "Entries": [
-        "c1151_Innsmouth dog_spread on the ground -- c1151_インスマス犬_地面に広がる"
+        "Palace Hound - Lightning"
       ]
     },
     {
       "ID": 11510500,
       "Entries": [
-        "c1151_Innsmouth dog_Thunder bullet spitting -- c1151_インスマス犬_雷弾丸吐き"
+        "Palace Hound - Lightning"
       ]
     },
     {
       "ID": 11510501,
       "Entries": [
-        "c1151_Innsmouth dog_spread on the ground 1 -- c1151_インスマス犬_地面に広がる1"
+        "Palace Hound - Lightning"
       ]
     },
     {
       "ID": 11510980,
       "Entries": [
-        "Dummy bullets_dangerous attack precursors_thunder bullets -- ダミー弾丸_危険な攻撃予兆_雷弾丸"
+        "Palace Hound - Perilous Attack Warning"
       ]
     },
     {
       "ID": 11800910,
       "Entries": [
-        "c1180_Lower man_Mallet_Dummy bullet_Armor generation -- c1180_下男_木槌_ダミー弾丸_鎧生成"
+        "Taro Troop - Armor"
       ]
     },
     {
       "ID": 11800911,
       "Entries": [
-        "c1180_Lower man_Mallet_Dummy bullet_Dummy attack_Armor destruction -- c1180_下男_木槌_ダミー弾丸_ダミー攻撃_鎧破壊"
+        "Taro Troop - Armor"
       ]
     },
     {
       "ID": 11800980,
       "Entries": [
-        "c1180_Lower man_Mallet_Dummy bullet_Dangerous attack sign_Rampage 1 -- c1180_下男_木槌_ダミー弾丸_危険な攻撃予兆_暴れる1"
+        "Taro Troop - Perilous Attack Warning"
       ]
     },
     {
       "ID": 11800981,
       "Entries": [
-        "c1180_Lower man_Mallet_Dummy bullet_Dangerous attack sign_Rampage 2 -- c1180_下男_木槌_ダミー弾丸_危険な攻撃予兆_暴れる2"
+        "Taro Troop - Perilous Attack Warning"
       ]
     },
     {
       "ID": 11801910,
       "Entries": [
-        "c1180_Lower man_Kanabo_Dummy bullet_Armor generation -- c1180_下男_金砕棒_ダミー弾丸_鎧生成"
+        "Taro Troop - Armor"
       ]
     },
     {
       "ID": 11801911,
       "Entries": [
-        "c1180_Lower man_Kanabo_Dummy bullet_Dummy attack_Armor destruction -- c1180_下男_金砕棒_ダミー弾丸_ダミー攻撃_鎧破壊"
+        "Taro Troop - Armor"
       ]
     },
     {
       "ID": 11801980,
       "Entries": [
-        "c1180_Lower man_Kanabo_Dummy bullet_Dangerous attack sign_Yokosagi combo 2 -- c1180_下男_金砕棒_ダミー弾丸_危険な攻撃予兆_横薙ぎコンボ2"
+        "Taro Troop - Perilous Attack Warning"
       ]
     },
     {
       "ID": 11802910,
       "Entries": [
-        "c1180_Lower man_Bell with string_Dummy bullet_Armor generation -- c1180_下男_紐付き鐘_ダミー弾丸_鎧生成"
+        "Taro Troop Bell - Armor"
       ]
     },
     {
       "ID": 11802911,
       "Entries": [
-        "c1180_Lower man_Bell with string_Dummy bullet_Dummy attack_Armor destruction -- c1180_下男_紐付き鐘_ダミー弾丸_ダミー攻撃_鎧破壊"
+        "Taro Troop Bell - Armor"
       ]
     },
     {
       "ID": 11802980,
       "Entries": [
-        "c1180_Lower man_Bell with string_Dummy bullet_Dangerous attack sign_Bell-covered throw_First stage -- c1180_下男_紐付き鐘_ダミー弾丸_危険な攻撃予兆_鐘被せ投げ_初段"
+        "Taro Troop Bell - Perilous Attack Warning"
       ]
     },
     {
       "ID": 11802981,
       "Entries": [
-        "c1180_Lower man_Bell with string_Dummy bullet_Dangerous attack sign_Bell-covered throw_Loop -- c1180_下男_紐付き鐘_ダミー弾丸_危険な攻撃予兆_鐘被せ投げ_ループ"
+        "Taro Troop Bell - Perilous Attack Warning"
       ]
     },
     {
       "ID": 11804500,
       "Entries": [
-        "c1180_lower man_shield mud hanging -- c1180_下男_盾泥掛け"
+        "Taro Troop Shield"
       ]
     },
     {
       "ID": 11804910,
       "Entries": [
-        "c1180_Lower man_Shield_Dummy bullet_Shield generation -- c1180_下男_盾_ダミー弾丸_盾生成"
+        "Taro Troop Shield"
       ]
     },
     {
       "ID": 11804911,
       "Entries": [
-        "c1180_Lower man_Shield_Dummy bullet_Dummy attack_Shield destruction -- c1180_下男_盾_ダミー弾丸_ダミー攻撃_盾破壊"
+        "Taro Troop Shield"
       ]
     },
     {
       "ID": 11900100,
       "Entries": [
-        "c1190_Valley enemy_Stone fire arrow_Shooting -- c1190_谷敵_石火矢_射撃"
+        "Sunken Valley Clan Rifle"
       ]
     },
     {
       "ID": 11900101,
       "Entries": [
-        "c1190_Valley enemy_Stone fire arrow_Shooting_Not accurate -- c1190_谷敵_石火矢_射撃_正確じゃない"
+        "Sunken Valley Clan Rifle"
       ]
     },
     {
       "ID": 11900980,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Bayonet thrust _ Standing -- ダミー弾丸_危険な攻撃予兆_銃剣突き_立ち"
+        "Sunken Valley Clan Rifle - Perilous Attack Warning"
       ]
     },
     {
       "ID": 11900981,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Double thrust -- ダミー弾丸_危険な攻撃予兆_二段突き"
+        "Sunken Valley Clan Rifle - Perilous Attack Warning"
       ]
     },
     {
       "ID": 11900982,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Thrust from left and right weak bullets -- ダミー弾丸_危険な攻撃予兆_左右弱弾きからの突き"
+        "Sunken Valley Clan Rifle - Perilous Attack Warning"
       ]
     },
     {
       "ID": 11901100,
       "Entries": [
-        "c1190_Valley enemy_Sniper_Stone fire arrow_Shooting -- c1190_谷敵_狙撃_石火矢_射撃"
+        "Snake Eyes - Shoot"
       ]
     },
     {
       "ID": 11901101,
       "Entries": [
-        "c1190_Valley enemy_Sniper_Stone fire arrow_Rapid fire -- c1190_谷敵_狙撃_石火矢_速射"
+        "Snake Eyes - Shoot"
       ]
     },
     {
       "ID": 11901102,
       "Entries": [
-        "c1190_Valley enemy_Sniper_Stone fire arrow_Foot shooting -- c1190_谷敵_狙撃_石火矢_足元射撃"
+        "Snake Eyes - Shoot"
       ]
     },
     {
       "ID": 11901103,
       "Entries": [
-        "c1190_Valley enemy_Sniper_Stone fire arrow_Sniper bullet -- c1190_谷敵_狙撃_石火矢_狙撃弾丸"
+        "Snake Eyes - Shoot"
       ]
     },
     {
       "ID": 11901980,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Anchor hook -- ダミー弾丸_危険な攻撃予兆_アンカー引っ掛け"
+        "Snake Eyes - Perilous Attack Warning"
       ]
     },
     {
       "ID": 11901981,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Anchor hook from weakly hit -- ダミー弾丸_危険な攻撃予兆_弱弾かれからのアンカー引っ掛け"
+        "Snake Eyes - Perilous Attack Warning"
       ]
     },
     {
       "ID": 11902100,
       "Entries": [
-        "c1190_Valley enemy_Shotgun_Side shooting_Parent -- c1190_谷敵_散弾_横射撃_親"
+        "Sunken Valley Clan Shotgun"
       ]
     },
     {
       "ID": 11902101,
       "Entries": [
-        "c1190_Valley enemy_Shotgun_Vertical shooting_Parent -- c1190_谷敵_散弾_縦射撃_親"
+        "Sunken Valley Clan Shotgun"
       ]
     },
     {
       "ID": 11902102,
       "Entries": [
-        "c1190_Valley enemy_Shotgun_Side shooting_Child -- c1190_谷敵_散弾_横射撃_子"
+        "Sunken Valley Clan Shotgun"
       ]
     },
     {
       "ID": 11902103,
       "Entries": [
-        "c1190_Valley enemy_Shotgun_Vertical shooting_Child -- c1190_谷敵_散弾_縦射撃_子"
+        "Sunken Valley Clan Shotgun"
       ]
     },
     {
       "ID": 11903100,
       "Entries": [
-        "c1190_Valley enemy_Cannon_Indirect fire_Distant -- c1190_谷敵_大砲_曲射_遠"
+        "Sunken Valley Clan Cannon"
       ]
     },
     {
       "ID": 11903101,
       "Entries": [
-        "c1190_Valley enemy_Cannon_Indirect fire_Medium -- c1190_谷敵_大砲_曲射_中"
+        "Sunken Valley Clan Cannon"
       ]
     },
     {
       "ID": 11903102,
       "Entries": [
-        "c1190_Valley enemy_Cannon_Indirect fire_Near -- c1190_谷敵_大砲_曲射_近"
+        "Sunken Valley Clan Cannon"
       ]
     },
     {
       "ID": 11903103,
       "Entries": [
-        "c1190_Valley enemy_Cannon_Horizontal fire_Distant -- c1190_谷敵_大砲_水平射_遠"
+        "Sunken Valley Clan Cannon"
       ]
     },
     {
       "ID": 11903104,
       "Entries": [
-        "c1190_Valley enemy_Cannon_Horizontal fire_Near -- c1190_谷敵_大砲_水平射_近"
+        "Sunken Valley Clan Cannon"
       ]
     },
     {
       "ID": 11903105,
       "Entries": [
-        "c1190_Valley enemy_Cannon_Shoot down_Far -- c1190_谷敵_大砲_撃ち下ろし_遠"
+        "Sunken Valley Clan Cannon"
       ]
     },
     {
       "ID": 11903106,
       "Entries": [
-        "c1190_Valley enemy_Cannon_Shoot down_Medium -- c1190_谷敵_大砲_撃ち下ろし_中"
+        "Sunken Valley Clan Cannon"
       ]
     },
     {
       "ID": 11903107,
       "Entries": [
-        "c1190_Valley enemy_Cannon_Shoot down_Near -- c1190_谷敵_大砲_撃ち下ろし_近"
+        "Sunken Valley Clan Cannon"
       ]
     },
     {
       "ID": 11903108,
       "Entries": [
-        "c1190_Valley enemy_Cannon_Indirect fire_Close -- c1190_谷敵_大砲_曲射_至近"
+        "Sunken Valley Clan Cannon"
       ]
     },
     {
       "ID": 11903109,
       "Entries": [
-        "c1190_Valley enemy_Cannon_Indirect fire_Nearby -- c1190_谷敵_大砲_曲射_至々近"
+        "Sunken Valley Clan Cannon"
       ]
     },
     {
       "ID": 11903120,
       "Entries": [
-        "c1190_Valley enemy_Cannon_Shoot down_Close -- c1190_谷敵_大砲_撃ち下ろし_至近"
+        "Sunken Valley Clan Cannon"
       ]
     },
     {
       "ID": 11903130,
       "Entries": [
-        "c1190_Valley enemy_Cannon_Shoot down_Far_Dummy -- c1190_谷敵_大砲_撃ち下ろし_遠_ダミー"
+        "Sunken Valley Clan Cannon"
       ]
     },
     {
       "ID": 11903131,
       "Entries": [
-        "c1190_Valley enemy_Cannon_Shoot down_Medium_Dummy -- c1190_谷敵_大砲_撃ち下ろし_中_ダミー"
+        "Sunken Valley Clan Cannon"
       ]
     },
     {
       "ID": 11903132,
       "Entries": [
-        "c1190_Valley enemy_Cannon_Shoot down_Near_Dummy -- c1190_谷敵_大砲_撃ち下ろし_近_ダミー"
+        "Sunken Valley Clan Cannon"
       ]
     },
     {
       "ID": 11903190,
       "Entries": [
-        "c1190_valley enemy_cannon_explosion -- c1190_谷敵_大砲_爆発"
+        "Sunken Valley Clan Cannon"
       ]
     },
     {
       "ID": 11903191,
       "Entries": [
-        "c1190_valley enemy_cannon_shock wave -- c1190_谷敵_大砲_衝撃波"
+        "Sunken Valley Clan Cannon"
       ]
     },
     {
       "ID": 11903192,
       "Entries": [
-        "c1190_Valley enemy_Cannon_Shoot down_Dummy -- c1190_谷敵_大砲_撃ち下ろし_ダミー"
+        "Sunken Valley Clan Cannon"
       ]
     },
     {
       "ID": 11903193,
       "Entries": [
-        "c1190_Valley enemy_Cannon_Horizontal shooting_Far_Dummy -- c1190_谷敵_大砲_水平射撃_遠_ダミー"
+        "Sunken Valley Clan Cannon"
       ]
     },
     {
       "ID": 11903194,
       "Entries": [
-        "c1190_Valley enemy_Cannon_Horizontal shooting_Near_Dummy -- c1190_谷敵_大砲_水平射撃_近_ダミー"
+        "Sunken Valley Clan Cannon"
       ]
     },
     {
       "ID": 11903300,
       "Entries": [
-        "c1190_Valley enemy_Cannon_Indirect fire -- c1190_谷敵_大砲_曲射"
+        "Sunken Valley Clan Cannon"
       ]
     },
     {
       "ID": 11903310,
       "Entries": [
-        "c1190_valley enemy_cannon_explosion -- c1190_谷敵_大砲_爆発"
+        "Sunken Valley Clan Cannon"
       ]
     },
     {
       "ID": 11903311,
       "Entries": [
-        "c1190_valley enemy_cannon_shock wave -- c1190_谷敵_大砲_衝撃波"
+        "Sunken Valley Clan Cannon"
       ]
     },
     {
       "ID": 12000980,
       "Entries": [
-        "Dummy bullet _ dangerous attack sign _ clinging -- ダミー弾丸_危険な攻撃予兆_すがりつき"
+        "Infested Seeker Parasite - Perilous Attack Warning"
       ]
     },
     {
       "ID": 12000981,
       "Entries": [
-        "Dummy bullets_dangerous attack precursors_cling from attraction -- ダミー弾丸_危険な攻撃予兆_引き寄せからのすがりつき"
+        "Infested Seeker Parasite - Perilous Attack Warning"
       ]
     },
     {
       "ID": 12100100,
       "Entries": [
-        "c1210: Immediate Buddha (without centipede) _ vomit _ medium range _ with bullet SFX -- c1210：即身仏（ムカデなし）_ゲロ_中距離_弾丸SFXあり"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100101,
       "Entries": [
-        "c1210: Immediate Buddha (without centipede) _ vomit _ medium range _ with bullet SFX -- c1210：即身仏（ムカデなし）_ゲロ_中距離_弾丸SFXあり"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100105,
       "Entries": [
-        "c1210: Immediate Buddha (without centipede) _ vomit _ medium range _ without bullet SFX -- c1210：即身仏（ムカデなし）_ゲロ_中距離_弾丸SFXなし"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100110,
       "Entries": [
-        "c1210: Immediate Buddha (without centipede) _ vomit _ short distance _ left single shot _ with bullet SFX -- c1210：即身仏（ムカデなし）_ゲロ_近距離_左単発_弾丸SFXあり"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100111,
       "Entries": [
-        "c1210: Immediate Buddha (without centipede) _ vomit _ short distance _ right single shot _ with bullet SFX -- c1210：即身仏（ムカデなし）_ゲロ_近距離_右単発_弾丸SFXあり"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100120,
       "Entries": [
-        "c1210: Immediate Buddha (without centipede) _ vomit _ short distance _ left single shot _ with bullet SFX -- c1210：即身仏（ムカデなし）_ゲロ_近距離_左単発_弾丸SFXあり"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100121,
       "Entries": [
-        "c1210: Immediate Buddha (without centipede) _ vomit _ short distance _ right single shot _ with bullet SFX -- c1210：即身仏（ムカデなし）_ゲロ_近距離_右単発_弾丸SFXあり"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100130,
       "Entries": [
-        "c1210_Sokushinbutsu (without centipede) _Vomiting_Short distance_Front_Bullet SFX available -- c1210_即身仏（ムカデなし）_ゲロ_近距離_正面_弾丸SFXあり"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100131,
       "Entries": [
-        "c1210_Sokushinbutsu (without centipede) _Vomiting_Short distance_Side_No bullet SFX -- c1210_即身仏（ムカデなし）_ゲロ_近距離_側面_弾丸SFXなし"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100140,
       "Entries": [
-        "c1210: Immediate Buddha (without centipede) _ spitting _ small _ medium distance _ vomit body 3 -- c1210：即身仏（ムカデなし）_蟲吐き_小_中距離_ゲロ本体3"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100141,
       "Entries": [
-        "c1210_Sokushinbutsu (without centipede) _Vomiting landing_Parent_Grandchildren -- c1210_即身仏（ムカデなし）_ゲロ着弾_親_孫を産む子を産む"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100142,
       "Entries": [
-        "c1210_Sokushinbutsu (without centipede) _Vomiting landing_Child_Grandchild -- c1210_即身仏（ムカデなし）_ゲロ着弾_子_孫を産む"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100143,
       "Entries": [
-        "c1210_Sokushinbutsu (without centipede) _Vomiting landing_Child_Grandchild_Remaining -- c1210_即身仏（ムカデなし）_ゲロ着弾_子_孫_残る"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100147,
       "Entries": [
-        "c1210_Sokushinbutsu (without centipede) _Global Y-axis -- c1210_即身仏（ムカデなし）_グローバルY軸"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100148,
       "Entries": [
-        "c1210_Sokushinbutsu (without centipede) _Vertical fall -- c1210_即身仏（ムカデなし）_垂直落下"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100149,
       "Entries": [
-        "c1210_Sokushinbutsu (without centipede) _Vomiting floor -- c1210_即身仏（ムカデなし）_ゲロ床"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100150,
       "Entries": [
-        "c1210_Sokushinbutsu (without centipede) _Poltergeist_Khakkhara_Right_Leave the statue&#39;s hand (parent) -- c1210_即身仏（ムカデなし）_ポルターガイスト_錫杖_右_像の手から離れる（親）"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100151,
       "Entries": [
-        "c1210_Sokushinbutsu (without centipede) _Poltergeist_Khakkhara_Right_Burbul sign (child) -- c1210_即身仏（ムカデなし）_ポルターガイスト_錫杖_右_ブルブル予兆（子）"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100152,
       "Entries": [
-        "c1210_Sokushinbutsu (without centipede) _Poltergeist_Khakkhara_Right_Fly toward PC (grandchild) -- c1210_即身仏（ムカデなし）_ポルターガイスト_錫杖_右_ＰＣに向かって飛ぶ（孫）"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100160,
       "Entries": [
-        "c1210_Sokushinbutsu (without centipede) _Poltergeist_Khakkhara_Left_Leave the statue&#39;s hand (parent) -- c1210_即身仏（ムカデなし）_ポルターガイスト_錫杖_左_像の手から離れる（親）"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100161,
       "Entries": [
-        "c1210_Sokushinbutsu (without centipede) _Poltergeist_Khakkhara_Left_Bull Bull sign (child) -- c1210_即身仏（ムカデなし）_ポルターガイスト_錫杖_左_ブルブル予兆（子）"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100162,
       "Entries": [
-        "c1210_Sokushinbutsu (without centipede) _Poltergeist_Khakkhara_Left_Fly toward PC (grandchild) -- c1210_即身仏（ムカデなし）_ポルターガイスト_錫杖_左_ＰＣに向かって飛ぶ（孫）"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100170,
       "Entries": [
-        "c1210_Sokushinbutsu (without centipede) _Poltergeist_Hanging lantern_Right_Floating (parent) -- c1210_即身仏（ムカデなし）_ポルターガイスト_吊り灯篭_右_浮遊（親）"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100171,
       "Entries": [
-        "c1210_Sokushinbutsu (without centipede) _Poltergeist_Hanging lantern_Right_Bull Bull sign (child) -- c1210_即身仏（ムカデなし）_ポルターガイスト_吊り灯篭_右_ブルブル予兆（子）"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100172,
       "Entries": [
-        "c1210_Sokushinbutsu (without centipede) _Poltergeist_Hanging lantern_Right_Launch (grandchild) -- c1210_即身仏（ムカデなし）_ポルターガイスト_吊り灯篭_右_発射（孫）"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100175,
       "Entries": [
-        "c1210_Sokushinbutsu (without centipede) _Poltergeist_Hanging lantern_Left_Floating (parent) -- c1210_即身仏（ムカデなし）_ポルターガイスト_吊り灯篭_左_浮遊（親）"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100176,
       "Entries": [
-        "c1210_Sokushinbutsu (without centipede) _Poltergeist_Hanging lantern_Left_Bull Bull (child) -- c1210_即身仏（ムカデなし）_ポルターガイスト_吊り灯篭_左_ブルブル（子）"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100177,
       "Entries": [
-        "c1210_Sokushinbutsu (without centipede) _Poltergeist_Hanging lantern_Left_Launch (grandchild) -- c1210_即身仏（ムカデなし）_ポルターガイスト_吊り灯篭_左_発射（孫）"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100180,
       "Entries": [
-        "c1210_Sokushinbutsu (without centipede) _Poltergeist_Vase_Right_Floating (parent) -- c1210_即身仏（ムカデなし）_ポルターガイスト_壺_右_浮遊（親）"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100181,
       "Entries": [
-        "c1210_Sokushinbutsu (without centipede) _Poltergeist_Vase_Right_Bull Bull_ (child) -- c1210_即身仏（ムカデなし）_ポルターガイスト_壺_右_ブルブル_（子）"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100182,
       "Entries": [
-        "c1210_Sokushinbutsu (without centipede) _Poltergeist_Vase_Right_Launch (grandchild) -- c1210_即身仏（ムカデなし）_ポルターガイスト_壺_右_発射（孫）"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100185,
       "Entries": [
-        "c1210_Sokushinbutsu (without centipede) _Poltergeist_Vase_Left_Floating (parent) -- c1210_即身仏（ムカデなし）_ポルターガイスト_壺_左_浮遊（親）"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100186,
       "Entries": [
-        "c1210_Sokushinbutsu (without centipede) _Poltergeist_Vase_Left_Bull Bull (child) -- c1210_即身仏（ムカデなし）_ポルターガイスト_壺_左_ブルブル（子）"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100187,
       "Entries": [
-        "c1210_Sokushinbutsu (without centipede) _Poltergeist_Vase_Left_Launch (grandchild) -- c1210_即身仏（ムカデなし）_ポルターガイスト_壺_左_発射（孫）"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100190,
       "Entries": [
-        "c1210_Sokushinbutsu (without centipede) _Poltergeist_Buddha statue (right) _Floating -- c1210_即身仏（ムカデなし）_ポルターガイスト_仏像（右）_浮遊"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100191,
       "Entries": [
-        "c1210_Sokushinbutsu (without centipede) _Poltergeist_Buddha statue (right) _Appear in front -- c1210_即身仏（ムカデなし）_ポルターガイスト_仏像（右）_前に出る"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100192,
       "Entries": [
-        "c1210_Sokushinbutsu (without centipede) _Poltergeist_Buddha statue (right) _Approach -- c1210_即身仏（ムカデなし）_ポルターガイスト_仏像（右）_接近"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100193,
       "Entries": [
-        "c1210_Sokushinbutsu (without centipede) _Poltergeist_Buddha statue (right) _Bull Bull sign -- c1210_即身仏（ムカデなし）_ポルターガイスト_仏像（右）_ブルブル予兆"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100194,
       "Entries": [
-        "c1210_Sokushinbutsu (without centipede) _Poltergeist_Buddha statue (right) _Fall -- c1210_即身仏（ムカデなし）_ポルターガイスト_仏像（右）_落下"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100210,
       "Entries": [
-        "c1210_Sokushinbutsu (without centipede) _Poltergeist_Hanging lantern_Bottom_Floating (parent) -- c1210_即身仏（ムカデなし）_ポルターガイスト_吊り灯篭_下_浮遊（親）"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12120100,
       "Entries": [
-        "c1212_Poltergeist dummy character_Poltergeist (floats a little) -- c1212_ポルターガイスト用ダミーキャラ_ポルターガイスト（少し浮く）"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12120101,
       "Entries": [
-        "c1212_Poltergeist dummy character_Poltergeist (turns toward the PC) -- c1212_ポルターガイスト用ダミーキャラ_ポルターガイスト（PCの方へ旋回する）"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12120102,
       "Entries": [
-        "c1212_Poltergeist dummy character_Poltergeist (coming to the PC) -- c1212_ポルターガイスト用ダミーキャラ_ポルターガイスト（ＰＣに向かってくる）"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12200120,
       "Entries": [
-        "c1220: Temple foundation Zako_Rin treasure throwing -- c1220：寺基礎ザコ_輪宝投げ"
+        "Seeker - Throwing"
       ]
     },
     {
       "ID": 12200860,
       "Entries": [
-        "c1220: Temple foundation Zako_projectile_fly straight -- c1220：寺基礎ザコ_飛び道具_まっすぐ飛んでくる"
+        "Seeker - Bomb Throwing"
       ]
     },
     {
       "ID": 12200861,
       "Entries": [
-        "c1220: Temple foundation Zako_fly on a missile -- c1220：寺基礎ザコ_飛び道具上に飛ぶ"
+        "Seeker - Bomb Throwing"
       ]
     },
     {
       "ID": 12200862,
       "Entries": [
-        "c1220: Temple foundation Zako_ projectile slowly facing down -- c1220：寺基礎ザコ_飛び道具ゆっくり下に向く"
+        "Seeker - Bomb Throwing"
       ]
     },
     {
       "ID": 12200863,
       "Entries": [
-        "c1220: Temple foundation Zako_falls under missiles -- c1220：寺基礎ザコ_飛び道具下に落ちる"
+        "Seeker - Bomb Throwing"
       ]
     },
     {
       "ID": 12200864,
       "Entries": [
-        "c1220: Temple foundation Zako_projectile (stops on the ground) -- c1220：寺基礎ザコ_飛び道具（地面で止まる）"
+        "Seeker - Bomb Throwing"
       ]
     },
     {
       "ID": 12200865,
       "Entries": [
-        "c1220: Temple foundation Zako_projectile (explosion damage) -- c1220：寺基礎ザコ_飛び道具（爆発ダメージ）"
+        "Seeker - Bomb Throwing"
       ]
     },
     {
       "ID": 12200980,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Double thrust _ Elbow strike -- ダミー弾丸_危険な攻撃予兆_二段突き_肘打ち"
+        "Seeker - Perilous Attack Warning"
       ]
     },
     {
       "ID": 12201980,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Double thrust -- ダミー弾丸_危険な攻撃予兆_二段突き"
+        "Seeker - Perilous Attack Warning"
       ]
     },
     {
       "ID": 12201981,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Thrust from payback back -- ダミー弾丸_危険な攻撃予兆_払い上げバックからの突き"
+        "Seeker - Perilous Attack Warning"
       ]
     },
     {
       "ID": 12201990,
       "Entries": [
-        "Lure bullet -- おびき寄せ弾丸"
+        "Lure Bullet"
       ]
     },
     {
       "ID": 12500100,
       "Entries": [
-        "c1250_Yaksha Monkey genus_Sanding -- c1250_夜叉猿の眷属_砂かけ"
+        "Monkey - Sand Throw"
       ]
     },
     {
       "ID": 12500120,
       "Entries": [
-        "c1250_Yaksha Monkey Genus_Poisoning -- c1250_夜叉猿の眷属_毒かけ"
+        "Monkey - Poison Claw"
       ]
     },
     {
       "ID": 12500121,
       "Entries": [
-        "c1250_Yaksha Monkey genus_Poisoning_Child bullet -- c1250_夜叉猿の眷属_毒かけ_子弾丸"
+        "Monkey - Poison Claw"
       ]
     },
     {
       "ID": 12500122,
       "Entries": [
-        "c1250_Yaksha Monkey genus_Poisoning_Child bullet -- c1250_夜叉猿の眷属_毒かけ_子弾丸"
+        "Monkey - Poison Claw"
       ]
     },
     {
       "ID": 12500300,
       "Entries": [
-        "c1250_Yaksha Monkey Family_Shooting -- c1250_夜叉猿の眷属_射撃"
+        "Monkey - Rifle Shot"
       ]
     },
     {
       "ID": 12500350,
       "Entries": [
-        "c1250_Yaksha Monkey Genus_Sniper -- c1250_夜叉猿の眷属_狙撃"
+        "Monkey - Rifle Shot"
       ]
     },
     {
       "ID": 12500650,
       "Entries": [
-        "c1250_Yaksha Monkey genus_Throw a sword -- c1250_夜叉猿の眷属_刀を投げる"
+        "Monkey - Sword Throw"
       ]
     },
     {
       "ID": 12500850,
       "Entries": [
-        "c1250_Yaksha Monkey genus_Throwing a sword_Poison -- c1250_夜叉猿の眷属_刀を投げる_毒"
+        "Monkey - Sword Throw Poison"
       ]
     },
     {
       "ID": 12503980,
       "Entries": [
-        "c1250_Yaksha Monkey&#39;s genus_Dual wield_Dummy bullet_Dangerous attack -- c1250_夜叉猿の眷属_二刀_ダミー弾丸_危険な攻撃"
+        "Dual Sword Monkey - Perilous Attack Warning"
       ]
     },
     {
       "ID": 12504100,
       "Entries": [
-        "c1260 Chigo monkey _ shout like howling -- ｃ1260稚児猿_遠吠えのように叫ぶ"
+        "Folding Screen Monkey - AI Sound"
       ]
     },
     {
       "ID": 13000120,
       "Entries": [
-        "c1300_Japanese style Innsmouth_Call Genpei warrior -- c1300_和風インスマス_源平武者を呼ぶ"
+        "Palace Noble - Call Okami"
       ]
     },
     {
       "ID": 13000200,
       "Entries": [
-        "c1300_Japanese-style Innsmouth_A character that sucks life, hits the map -- c1300_和風インスマス_生気を吸い取る\u3000キャラ、マップにヒットする"
+        "Palace Noble - Enfeeble Bullet"
       ]
     },
     {
       "ID": 13000201,
       "Entries": [
-        "c1300_Japanese-style Innsmouth_Sucking life_When hitting a character, landing SFX is activated -- c1300_和風インスマス_生気を吸い取る_キャラにヒットしたら着弾SFX発動"
+        "Palace Noble - Enfeeble Bullet"
       ]
     },
     {
       "ID": 13000900,
       "Entries": [
-        "Dummy Bullet_Revives on Death -- ダミー弾丸_死亡時に生気を返す"
+        "Palace Noble"
       ]
     },
     {
       "ID": 13000980,
       "Entries": [
-        "Dummy bullets _ dangerous attack precursors _ leaning throws _ moving -- ダミー弾丸_危険な攻撃予兆_のしかかり投げ_移動"
+        "Palace Noble - Perilous Attack Warning"
       ]
     },
     {
       "ID": 13000981,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Trigger throw _ On the spot -- ダミー弾丸_危険な攻撃予兆_のしかかり投げ_その場"
+        "Palace Noble - Perilous Attack Warning"
       ]
     },
     {
       "ID": 13100520,
       "Entries": [
-        "c1310_ Genpei Samurai Bow Common -- c1310_源平武者\u3000弓共通"
+        "Okami Warrior - Bow Shot"
       ]
     },
     {
       "ID": 13100521,
       "Entries": [
-        "c1310_Genpei Samurai Bow Common_ Water surface landing bullet -- c1310_源平武者\u3000弓共通_水面着弾用子弾丸"
+        "Okami Warrior - Bow Shot"
       ]
     },
     {
       "ID": 13100980,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign thrust -- ダミー弾丸_危険な攻撃予兆\u3000突き"
+        "Okami Warrior - Perilous Attack Warning"
       ]
     },
     {
       "ID": 13100981,
       "Entries": [
-        "Dummy bullet _ Dangerous attack precursor Lightning attack -- ダミー弾丸_危険な攻撃予兆\u3000雷攻撃"
+        "Okami Warrior - Perilous Attack Warning"
       ]
     },
     {
       "ID": 13101980,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign thrust -- ダミー弾丸_危険な攻撃予兆\u3000突き"
+        "Okami Warrior - Perilous Attack Warning"
       ]
     },
     {
       "ID": 13101981,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign Lower -- ダミー弾丸_危険な攻撃予兆\u3000下段"
+        "Okami Warrior - Perilous Attack Warning"
       ]
     },
     {
       "ID": 13101982,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign Flying rotation slash -- ダミー弾丸_危険な攻撃予兆\u3000飛び回転斬り"
+        "Okami Warrior - Perilous Attack Warning"
       ]
     },
     {
       "ID": 13101983,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign -- ダミー弾丸_危険な攻撃予兆\u3000破戒僧コマ回し"
+        "Okami Warrior - Perilous Attack Warning"
       ]
     },
     {
       "ID": 13101985,
       "Entries": [
-        "Dummy bullet _ Dangerous attack precursor Lightning attack -- ダミー弾丸_危険な攻撃予兆\u3000雷攻撃"
+        "Okami Warrior - Perilous Attack Warning"
       ]
     },
     {
       "ID": 13102500,
       "Entries": [
-        "c1310_ Genpei Samurai Bow Common -- c1310_源平武者\u3000弓共通"
+        "Okami Warrior - Bow Shot"
       ]
     },
     {
       "ID": 13102501,
       "Entries": [
-        "c1310_Genpei Samurai Bow Common_ Water surface landing bullet -- c1310_源平武者\u3000弓共通_水面着弾用子弾丸"
+        "Okami Warrior - Bow Shot"
       ]
     },
     {
       "ID": 13103100,
       "Entries": [
-        "c1310_Genpei Warrior_Kemari_Overhead Shoot -- c1310_源平武者_蹴鞠_オーバーヘッドシュート"
+        "Okami Warrior - Ball"
       ]
     },
     {
       "ID": 13103101,
       "Entries": [
-        "c1310_Genpei Samurai_Kemari_Overhead shoot (after landing) -- c1310_源平武者_蹴鞠_オーバーヘッドシュート(着弾後)"
+        "Okami Warrior - Ball"
       ]
     },
     {
       "ID": 13103110,
       "Entries": [
-        "c1310_Genpei Samurai_Kemari_Ject Shoot 1 (Over 15m) -- c1310_源平武者_蹴鞠_ジェクトシュート1(Over 15m)"
+        "Okami Warrior - Ball"
       ]
     },
     {
       "ID": 13103111,
       "Entries": [
-        "c1310_Genpei Samurai_Kemari_Ject Shoot 2 (Over 15m) -- c1310_源平武者_蹴鞠_ジェクトシュート2(Over 15m)"
+        "Okami Warrior - Ball"
       ]
     },
     {
       "ID": 13103112,
       "Entries": [
-        "c1310_Genpei Samurai_Kemari_Ject Shoot 3 -- c1310_源平武者_蹴鞠_ジェクトシュート3"
+        "Okami Warrior - Ball"
       ]
     },
     {
       "ID": 13103120,
       "Entries": [
-        "c1310_Genpei Samurai_Kemari_Ject Shoot 1 (Under 15m) -- c1310_源平武者_蹴鞠_ジェクトシュート1(Under 15m)"
+        "Okami Warrior - Ball"
       ]
     },
     {
       "ID": 13103121,
       "Entries": [
-        "c1310_Genpei Samurai_Kemari_Ject Shoot 2 (Under 15m) -- c1310_源平武者_蹴鞠_ジェクトシュート2(Under 15m)"
+        "Okami Warrior - Ball"
       ]
     },
     {
       "ID": 13103140,
       "Entries": [
-        "c1310_Genpei Samurai_Kemari_Volley Shoot -- c1310_源平武者_蹴鞠_ボレーシュート"
+        "Okami Warrior - Ball"
       ]
     },
     {
       "ID": 13103160,
       "Entries": [
-        "c1310_Genpei Samurai_Kemari_Heading ⇒ Heel Lifting ⇒ Left Foot Rotation Shoot 1 (Over15m) -- c1310_源平武者_蹴鞠_ヘディング⇒かかとリフティング⇒左足回転シュート1(Over15m)"
+        "Okami Warrior - Ball"
       ]
     },
     {
       "ID": 13103161,
       "Entries": [
-        "c1310_Genpei Samurai_Kemari_Heading ⇒ Heel Lifting ⇒ Left Foot Rotation Shoot 2 (Over15m) -- c1310_源平武者_蹴鞠_ヘディング⇒かかとリフティング⇒左足回転シュート2(Over15m)"
+        "Okami Warrior - Ball"
       ]
     },
     {
       "ID": 13103180,
       "Entries": [
-        "c1310_Genpei Samurai_Kemari_Lightning Overhead Shoot -- c1310_源平武者_蹴鞠_雷オーバーヘッドシュート"
+        "Okami Warrior - Lightning"
       ]
     },
     {
       "ID": 13103190,
       "Entries": [
-        "c1310_Genpei Warrior_Kemari_Thunder Overhead Shoot_For Map Gimmick -- c1310_源平武者_蹴鞠_雷オーバーヘッドシュート_マップギミック用"
+        "Okami Warrior - Lightning"
       ]
     },
     {
       "ID": 13103191,
       "Entries": [
-        "c1310_Genpei Samurai_Kemari_Lightning Overhead Shoot_Large bullet after landing on the water -- c1310_源平武者_蹴鞠_雷オーバーヘッドシュート_水面着弾後の大きい弾丸"
+        "Okami Warrior - Lightning"
       ]
     },
     {
       "ID": 13103192,
       "Entries": [
-        "c1310_Genpei Samurai_Kemari_Lightning Overhead Shoot_Residual bullets generated when a large bullet approaches a certain distance -- c1310_源平武者_蹴鞠_雷オーバーヘッドシュート_大きい弾丸が一定距離まで接近したときに生じる残留弾丸"
+        "Okami Warrior - Lightning"
       ]
     },
     {
       "ID": 13103980,
       "Entries": [
-        "Dummy Bullet_Dangerous Attack Predictor Lightning Kemari -- ダミー弾丸_危険な攻撃予兆\u3000雷蹴鞠"
+        "Okami Warrior - Perilous Attack Warning"
       ]
     },
     {
       "ID": 13200900,
       "Entries": [
-        "c1320_Treasure carp_Collision detection sonar -- c1320_宝鯉_衝突検出ソナー"
+        "Treasure Carp - Collision Detection"
       ]
     },
     {
       "ID": 13200901,
       "Entries": [
-        "c1320_Treasure carp_Collision detection sonar_Reflection -- c1320_宝鯉_衝突検出ソナー_反射"
+        "Treasure Carp - Collision Detection"
       ]
     },
     {
       "ID": 13200902,
       "Entries": [
-        "c1320_Treasure carp_Collision detection sonar_Reflection_Dummy bullet for life -- c1320_宝鯉_衝突検出ソナー_反射_寿命用ダミー弾"
+        "Treasure Carp - Collision Detection"
       ]
     },
     {
       "ID": 13200903,
       "Entries": [
-        "c1320_Treasure carp_Collision detection sonar_Disappearing bullet -- c1320_宝鯉_衝突検出ソナー_消失弾"
+        "Treasure Carp - Collision Detection"
       ]
     },
     {
       "ID": 13400600,
       "Entries": [
-        "c1340: Underwater neckless_Slashing light wave -- c1340：水中首なし_斬撃光波"
+        "Underwater Headless - Light Wave"
       ]
     },
     {
       "ID": 13400601,
       "Entries": [
-        "c1340: No underwater neck_Slashing light wave_Reverse -- c1340：水中首なし_斬撃光波_逆"
+        "Underwater Headless - Light Wave"
       ]
     },
     {
       "ID": 13400610,
       "Entries": [
-        "c1340: Underwater neckless_Slashing light wave For illusion -- c1340：水中首なし_斬撃光波\u3000幻影用"
+        "Underwater Headless Illusion - Light Wave"
       ]
     },
     {
       "ID": 13400640,
       "Entries": [
-        "c1340: No underwater neck_Hair bullet 1 -- c1340：水中首なし_髪の毛弾丸1"
+        "Underwater Headless - Hair"
       ]
     },
     {
       "ID": 13400641,
       "Entries": [
-        "c1340: No underwater neck_Hair bullet 2 -- c1340：水中首なし_髪の毛弾丸2"
+        "Underwater Headless - Hair"
       ]
     },
     {
       "ID": 13400642,
       "Entries": [
-        "c1340: No underwater neck_Hair bullet 3 -- c1340：水中首なし_髪の毛弾丸3"
+        "Underwater Headless - Hair"
       ]
     },
     {
       "ID": 13400643,
       "Entries": [
-        "c1340: No underwater neck_Hair bullet 4 -- c1340：水中首なし_髪の毛弾丸4"
+        "Underwater Headless - Hair"
       ]
     },
     {
       "ID": 13400644,
       "Entries": [
-        "c1340: No underwater neck_Hair bullet 5 -- c1340：水中首なし_髪の毛弾丸5"
+        "Underwater Headless - Hair"
       ]
     },
     {
       "ID": 13400645,
       "Entries": [
-        "c1340: No underwater neck_Hair bullet 6 -- c1340：水中首なし_髪の毛弾丸6"
+        "Underwater Headless - Hair"
       ]
     },
     {
       "ID": 13400646,
       "Entries": [
-        "c1340: No underwater neck_Hair bullet 7 -- c1340：水中首なし_髪の毛弾丸7"
+        "Underwater Headless - Hair"
       ]
     },
     {
       "ID": 13400647,
       "Entries": [
-        "c1340: No underwater neck_Hair bullet 8 -- c1340：水中首なし_髪の毛弾丸8"
+        "Underwater Headless - Hair"
       ]
     },
     {
       "ID": 13400648,
       "Entries": [
-        "c1340: No underwater neck_Hair bullet 9 -- c1340：水中首なし_髪の毛弾丸9"
+        "Underwater Headless - Hair"
       ]
     },
     {
       "ID": 13400649,
       "Entries": [
-        "c1340: No underwater neck_Hair bullet 10 -- c1340：水中首なし_髪の毛弾丸10"
+        "Underwater Headless - Hair"
       ]
     },
     {
       "ID": 13400650,
       "Entries": [
-        "c1340: Underwater neckless_hair bullet_to PC -- c1340：水中首なし_髪の毛弾丸_PCに向かう"
+        "Underwater Headless"
       ]
     },
     {
       "ID": 13400980,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign -- ダミー弾丸_危険な攻撃予兆\u3000尻子玉抜き"
+        "Underwater Headless - Perilous Attack Warning"
       ]
     },
     {
       "ID": 13500300,
       "Entries": [
-        "c1350_neckless_self-harm bullet -- c1350_首なし_自傷弾丸"
+        "Headless"
       ]
     },
     {
       "ID": 13500310,
       "Entries": [
-        "c1350_neckless_miasma-erasing bullet -- c1350_首なし_瘴気掻き消し弾丸"
+        "Headless"
       ]
     },
     {
       "ID": 13500640,
       "Entries": [
-        "c1350: Neckless_Hair Bullet 1 -- c1350：首なし_髪の毛弾丸1"
+        "Headless - Hair"
       ]
     },
     {
       "ID": 13500641,
       "Entries": [
-        "c1350: Neckless_Hair Bullet 2 -- c1350：首なし_髪の毛弾丸2"
+        "Headless - Hair"
       ]
     },
     {
       "ID": 13500642,
       "Entries": [
-        "c1350: Neckless_Hair Bullet 3 -- c1350：首なし_髪の毛弾丸3"
+        "Headless - Hair"
       ]
     },
     {
       "ID": 13500643,
       "Entries": [
-        "c1350: Neckless_Hair Bullet 4 -- c1350：首なし_髪の毛弾丸4"
+        "Headless - Hair"
       ]
     },
     {
       "ID": 13500644,
       "Entries": [
-        "c1350: Neckless_Hair Bullet 5 -- c1350：首なし_髪の毛弾丸5"
+        "Headless - Hair"
       ]
     },
     {
       "ID": 13500645,
       "Entries": [
-        "c1350: Neckless_Hair Bullet 6 -- c1350：首なし_髪の毛弾丸6"
+        "Headless - Hair"
       ]
     },
     {
       "ID": 13500646,
       "Entries": [
-        "c1350: Neckless_Hair Bullet 7 -- c1350：首なし_髪の毛弾丸7"
+        "Headless - Hair"
       ]
     },
     {
       "ID": 13500647,
       "Entries": [
-        "c1350: Neckless_Hair Bullet 8 -- c1350：首なし_髪の毛弾丸8"
+        "Headless - Hair"
       ]
     },
     {
       "ID": 13500648,
       "Entries": [
-        "c1350: Neckless_Hair Bullet 9 -- c1350：首なし_髪の毛弾丸9"
+        "Headless - Hair"
       ]
     },
     {
       "ID": 13500649,
       "Entries": [
-        "c1350: Neckless_Hair Bullet 10 -- c1350：首なし_髪の毛弾丸10"
+        "Headless - Hair"
       ]
     },
     {
       "ID": 13500650,
       "Entries": [
-        "c1350: Neckless_Hair Bullet_Go to PC -- c1350：首なし_髪の毛弾丸_PCに向かう"
+        "Headless - Hair"
       ]
     },
     {
       "ID": 13500980,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign -- ダミー弾丸_危険な攻撃予兆\u3000尻子玉抜き"
+        "Headless - Perilous Attack Warning"
       ]
     },
     {
       "ID": 13600130,
       "Entries": [
-        "c1360_Rappa_Poisonous Mucus_Front Dummy -- c1360_らっぱ_毒粘液_正面ダミー"
+        "Senpou Assassin - Poison"
       ]
     },
     {
       "ID": 13600131,
       "Entries": [
-        "c1360_Rappa_Poisonous Mucus_Right Dummy -- c1360_らっぱ_毒粘液_右ダミー"
+        "Senpou Assassin - Poison"
       ]
     },
     {
       "ID": 13600132,
       "Entries": [
-        "c1360_Rappa_Poisonous Mucus_Left Dummy -- c1360_らっぱ_毒粘液_左ダミー"
+        "Senpou Assassin - Poison"
       ]
     },
     {
       "ID": 13600136,
       "Entries": [
-        "c1360_Rappa_Poisonous mucus_Impact -- c1360_らっぱ_毒粘液_着弾"
+        "Senpou Assassin - Poison"
       ]
     },
     {
       "ID": 13600141,
       "Entries": [
-        "c1360_Rappa_Jumping blindfold -- c1360_らっぱ_跳躍目潰し"
+        "Senpou Assassin"
       ]
     },
     {
       "ID": 13600160,
       "Entries": [
-        "c1360_Rappa_Reeds skipped -- c1360_らっぱ_葦飛ばし"
+        "Senpou Assassin"
       ]
     },
     {
       "ID": 13600161,
       "Entries": [
-        "c1360_Rappa_Reeds_No poison -- c1360_らっぱ_葦飛ばし_毒なし"
+        "Senpou Assassin"
       ]
     },
     {
       "ID": 13600170,
       "Entries": [
-        "c1360_Rappa_Blind -- c1360_らっぱ_目潰し"
+        "Senpou Assassin"
       ]
     },
     {
       "ID": 13600171,
       "Entries": [
-        "c1360_Rappa_For blinding judgment -- c1360_らっぱ_目潰し判定用"
+        "Senpou Assassin"
       ]
     },
     {
       "ID": 13600800,
       "Entries": [
-        "c1360_Rappa_Dummy bullet_Kasa destruction -- c1360_らっぱ_ダミー弾丸_笠破壊"
+        "Senpou Assassin - Hat Destruction"
       ]
     },
     {
       "ID": 13600910,
       "Entries": [
-        "c1360_Rappa_Dummy bullet_Kasa generation -- c1360_らっぱ_ダミー弾丸_笠生成"
+        "Senpou Assassin - Hat Destruction"
       ]
     },
     {
       "ID": 13600980,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Jumping from behind -- ダミー弾丸_危険な攻撃予兆_背後からの飛び掛かり投げ"
+        "Senpou Assassin - Perilous Attack Warning"
       ]
     },
     {
       "ID": 13700920,
       "Entries": [
-        "c1370_Fire cow_Collision detection bullet 1 while driving -- c1370_火牛_走行中衝突判定用弾丸１"
+        "Bull - Collision Detection"
       ]
     },
     {
       "ID": 13700921,
       "Entries": [
-        "c1370_Fire cow_Bullet for collision detection while driving 2 -- c1370_火牛_走行中衝突判定用弾丸２"
+        "Bull - Collision Detection"
       ]
     },
     {
       "ID": 13700922,
       "Entries": [
-        "c1370_Fire cow_Angry_Collision detection bullet 1 -- c1370_火牛_怒り中_衝突判定用弾丸１"
+        "Bull - Collision Detection"
       ]
     },
     {
       "ID": 13700923,
       "Entries": [
-        "c1370_Fire cow_Angry_Collision detection bullet 2 -- c1370_火牛_怒り中_衝突判定用弾丸２"
+        "Bull - Collision Detection"
       ]
     },
     {
       "ID": 14000980,
       "Entries": [
-        "c1400_Swordsman_Pushing sign -- c1400_剣客_突き予兆"
+        "Fencer - Perilous Attack Warning"
       ]
     },
     {
       "ID": 14500100,
       "Entries": [
-        "c1450_Nightjars_Self-destruction_Center -- c1450_夜鷹衆_自爆_中心"
+        "Nightjar - Explode"
       ]
     },
     {
       "ID": 14500102,
       "Entries": [
-        "c1450_Nightjars_Self-destruction_Around -- c1450_夜鷹衆_自爆_周辺"
+        "Nightjar - Explode"
       ]
     },
     {
       "ID": 14500150,
       "Entries": [
-        "c1450_Nightjars_Weapon Ignition Effect -- c1450_夜鷹衆_武器着火エフェクト"
+        "Nightjar - Weapon Ignition"
       ]
     },
     {
       "ID": 14500151,
       "Entries": [
-        "c1450_Nightjars_Weapon Ignition Effect_Child -- c1450_夜鷹衆_武器着火エフェクト_子"
+        "Nightjar - Weapon Ignition"
       ]
     },
     {
       "ID": 14500250,
       "Entries": [
-        "c1450_Nightjars_Left hand throwing for proximity_1 -- c1450_夜鷹衆_左手投擲近接用_1"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14500251,
       "Entries": [
-        "c1450_Nightjars_Left hand throwing for proximity_1_2 -- c1450_夜鷹衆_左手投擲近接用_1_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14500701,
       "Entries": [
-        "c1450_Nightjars_Self-destruct activation -- c1450_夜鷹衆_自爆起動"
+        "Nightjar - Explosion Activation"
       ]
     },
     {
       "ID": 14501000,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 1_1 -- c1450_夜鷹衆_連続投擲1_1"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501001,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 1_2 -- c1450_夜鷹衆_連続投擲1_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501002,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 1_1_2 -- c1450_夜鷹衆_連続投擲1_1_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501003,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 1_2_2 -- c1450_夜鷹衆_連続投擲1_2_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501010,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 2_1 -- c1450_夜鷹衆_連続投擲2_1"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501011,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 2_2 -- c1450_夜鷹衆_連続投擲2_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501012,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 2_1_2 -- c1450_夜鷹衆_連続投擲2_1_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501013,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 2_2_2 -- c1450_夜鷹衆_連続投擲2_2_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501020,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 3_1 -- c1450_夜鷹衆_連続投擲3_1"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501021,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 3_3 -- c1450_夜鷹衆_連続投擲3_3"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501022,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 3_1_2 -- c1450_夜鷹衆_連続投擲3_1_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501023,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 3_3_2 -- c1450_夜鷹衆_連続投擲3_3_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501030,
       "Entries": [
-        "c1450_Nightjars_Simultaneous throwing 1 -- c1450_夜鷹衆_同時投擲1"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501031,
       "Entries": [
-        "c1450_Nightjars_Simultaneous throwing 2 -- c1450_夜鷹衆_同時投擲2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501032,
       "Entries": [
-        "c1450_Nightjars_Simultaneous throwing 1_2 -- c1450_夜鷹衆_同時投擲1_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501033,
       "Entries": [
-        "c1450_Nightjars_Simultaneous throwing 2_2 -- c1450_夜鷹衆_同時投擲2_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501040,
       "Entries": [
-        "c1450_Nightjars_Jumping and throwing 1 -- c1450_夜鷹衆_跳び下がり投擲1"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501041,
       "Entries": [
-        "c1450_Nightjars_Jumping and throwing 2 -- c1450_夜鷹衆_跳び下がり投擲2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501042,
       "Entries": [
-        "c1450_Nightjars_Jumping and throwing 1_2 -- c1450_夜鷹衆_跳び下がり投擲1_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501043,
       "Entries": [
-        "c1450_Nightjars_Jumping and throwing 2_2 -- c1450_夜鷹衆_跳び下がり投擲2_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501044,
       "Entries": [
-        "c1450_Nightjars_Jumping and throwing 1_3 -- c1450_夜鷹衆_跳び下がり投擲1_3"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501045,
       "Entries": [
-        "c1450_Nightjars_Jumping and throwing 2_3 -- c1450_夜鷹衆_跳び下がり投擲2_3"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501046,
       "Entries": [
-        "c1450_Nightjars_Jumping and throwing 1_4 -- c1450_夜鷹衆_跳び下がり投擲1_4"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501047,
       "Entries": [
-        "c1450_Nightjars_Jumping and throwing 2_4 -- c1450_夜鷹衆_跳び下がり投擲2_4"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501051,
       "Entries": [
-        "c1450_Nightjars_Step slash throwing_Left -- c1450_夜鷹衆_ステップ斬り投擲_左"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501061,
       "Entries": [
-        "c1450_Nightjars_Step slash throwing_Right -- c1450_夜鷹衆_ステップ斬り投擲_右"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501100,
       "Entries": [
-        "c1450_Nightjars_Left simultaneous throwing 1 -- c1450_夜鷹衆_左同時投擲1"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501101,
       "Entries": [
-        "c1450_Nightjars_Left simultaneous throwing 2 -- c1450_夜鷹衆_左同時投擲2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501120,
       "Entries": [
-        "c1450_Nightjars_Sidestep throwing_Left_1 -- c1450_夜鷹衆_サイドステップ投擲_左_1"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501121,
       "Entries": [
-        "c1450_Nightjars_Side step throwing_Left_2 -- c1450_夜鷹衆_サイドステップ投擲_左_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501130,
       "Entries": [
-        "c1450_Nightjars_Sidestep throwing_Right_1 -- c1450_夜鷹衆_サイドステップ投擲_右_1"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501131,
       "Entries": [
-        "c1450_Nightjars_Sidestep throwing_Right_2 -- c1450_夜鷹衆_サイドステップ投擲_右_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501140,
       "Entries": [
-        "c1450_Nightjars_Backward throwing_1 -- c1450_夜鷹衆_後方投擲_1"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501141,
       "Entries": [
-        "c1450_Nightjars_Backward throwing_2 -- c1450_夜鷹衆_後方投擲_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501300,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 1_1 -- c1450_夜鷹衆_連続投擲1_1"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501301,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 1_2 -- c1450_夜鷹衆_連続投擲1_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501302,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 1_1_2 -- c1450_夜鷹衆_連続投擲1_1_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501303,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 1_2_2 -- c1450_夜鷹衆_連続投擲1_2_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501310,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 2_1 -- c1450_夜鷹衆_連続投擲2_1"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501311,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 2_2 -- c1450_夜鷹衆_連続投擲2_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501312,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 2_1_2 -- c1450_夜鷹衆_連続投擲2_1_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501313,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 2_2_2 -- c1450_夜鷹衆_連続投擲2_2_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501320,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 3_1 -- c1450_夜鷹衆_連続投擲3_1"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501321,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 3_3 -- c1450_夜鷹衆_連続投擲3_3"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501322,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 3_1_2 -- c1450_夜鷹衆_連続投擲3_1_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501323,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 3_3_2 -- c1450_夜鷹衆_連続投擲3_3_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501330,
       "Entries": [
-        "c1450_Nightjars_Simultaneous throwing 1 -- c1450_夜鷹衆_同時投擲1"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501331,
       "Entries": [
-        "c1450_Nightjars_Simultaneous throwing 2 -- c1450_夜鷹衆_同時投擲2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501332,
       "Entries": [
-        "c1450_Nightjars_Simultaneous throwing 1_2 -- c1450_夜鷹衆_同時投擲1_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501333,
       "Entries": [
-        "c1450_Nightjars_Simultaneous throwing 2_2 -- c1450_夜鷹衆_同時投擲2_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501340,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 3_1 -- c1450_夜鷹衆_連続投擲3_1"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501341,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 3_3 -- c1450_夜鷹衆_連続投擲3_3"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501342,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 3_1_2 -- c1450_夜鷹衆_連続投擲3_1_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501343,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 3_3_2 -- c1450_夜鷹衆_連続投擲3_3_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501750,
       "Entries": [
-        "c1450_Nightjars_Retreat throwing from left weak throw_1 -- c1450_夜鷹衆_左弱弾きからの後退投擲_1"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501751,
       "Entries": [
-        "c1450_Nightjars_Retreat throwing from left weak throw_2 -- c1450_夜鷹衆_左弱弾きからの後退投擲_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501752,
       "Entries": [
-        "c1450_Nightjars_Retreat throwing from left weak playing_3 -- c1450_夜鷹衆_左弱弾きからの後退投擲_3"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501753,
       "Entries": [
-        "c1450_Nightjars_Retreat throwing from left weak play_4 -- c1450_夜鷹衆_左弱弾きからの後退投擲_4"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501754,
       "Entries": [
-        "c1450_Nightjars_Retreat throwing from left weak playing_5 -- c1450_夜鷹衆_左弱弾きからの後退投擲_5"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501755,
       "Entries": [
-        "c1450_Nightjars_Left throwing backwards from weak playing_6 -- c1450_夜鷹衆_左弱弾きからの後退投擲_6"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501756,
       "Entries": [
-        "c1450_Nightjars_Left throwing backwards from weak playing_7 -- c1450_夜鷹衆_左弱弾きからの後退投擲_7"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501757,
       "Entries": [
-        "c1450_Nightjars_Left throwing backwards from weak playing_8 -- c1450_夜鷹衆_左弱弾きからの後退投擲_8"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501758,
       "Entries": [
-        "c1450_Nightjars_Left throwing backwards from weak playing_9 -- c1450_夜鷹衆_左弱弾きからの後退投擲_9"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501759,
       "Entries": [
-        "c1450_Nightjars_Left throwing backwards from weak playing_10 -- c1450_夜鷹衆_左弱弾きからの後退投擲_10"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501760,
       "Entries": [
-        "c1450_Nightjars_Left throwing backwards from weak playing_11 -- c1450_夜鷹衆_左弱弾きからの後退投擲_11"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501761,
       "Entries": [
-        "c1450_Nightjars_Left throwing backwards from weak playing_12 -- c1450_夜鷹衆_左弱弾きからの後退投擲_12"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14501762,
       "Entries": [
-        "c1450_Nightjars_Left throwing backwards from weak playing_13 -- c1450_夜鷹衆_左弱弾きからの後退投擲_13"
+        "Nightjar - Throwing"
       ]
     },
     {
@@ -5296,661 +5296,661 @@
     {
       "ID": 14502000,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 1_1 -- c1450_夜鷹衆_連続投擲1_1"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502001,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 1_2 -- c1450_夜鷹衆_連続投擲1_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502002,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 1_1_2 -- c1450_夜鷹衆_連続投擲1_1_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502003,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 1_2_2 -- c1450_夜鷹衆_連続投擲1_2_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502010,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 2_1 -- c1450_夜鷹衆_連続投擲2_1"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502011,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 2_2 -- c1450_夜鷹衆_連続投擲2_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502012,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 2_1_2 -- c1450_夜鷹衆_連続投擲2_1_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502013,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 2_2_2 -- c1450_夜鷹衆_連続投擲2_2_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502020,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 3_1 -- c1450_夜鷹衆_連続投擲3_1"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502021,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 3_3 -- c1450_夜鷹衆_連続投擲3_3"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502022,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 3_1_2 -- c1450_夜鷹衆_連続投擲3_1_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502023,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 3_3_2 -- c1450_夜鷹衆_連続投擲3_3_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502030,
       "Entries": [
-        "c1450_Nightjars_Simultaneous throwing 1 -- c1450_夜鷹衆_同時投擲1"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502031,
       "Entries": [
-        "c1450_Nightjars_Simultaneous throwing 2 -- c1450_夜鷹衆_同時投擲2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502032,
       "Entries": [
-        "c1450_Nightjars_Simultaneous throwing 1_2 -- c1450_夜鷹衆_同時投擲1_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502033,
       "Entries": [
-        "c1450_Nightjars_Simultaneous throwing 2_2 -- c1450_夜鷹衆_同時投擲2_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502040,
       "Entries": [
-        "c1450_Nightjars_Jumping and throwing 1 -- c1450_夜鷹衆_跳び下がり投擲1"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502041,
       "Entries": [
-        "c1450_Nightjars_Jumping and throwing 2 -- c1450_夜鷹衆_跳び下がり投擲2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502042,
       "Entries": [
-        "c1450_Nightjars_Jumping and throwing 1_2 -- c1450_夜鷹衆_跳び下がり投擲1_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502043,
       "Entries": [
-        "c1450_Nightjars_Jumping and throwing 2_2 -- c1450_夜鷹衆_跳び下がり投擲2_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502044,
       "Entries": [
-        "c1450_Nightjars_Jumping and throwing 1_3 -- c1450_夜鷹衆_跳び下がり投擲1_3"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502045,
       "Entries": [
-        "c1450_Nightjars_Jumping and throwing 2_3 -- c1450_夜鷹衆_跳び下がり投擲2_3"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502046,
       "Entries": [
-        "c1450_Nightjars_Jumping and throwing 1_4 -- c1450_夜鷹衆_跳び下がり投擲1_4"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502047,
       "Entries": [
-        "c1450_Nightjars_Jumping and throwing 2_4 -- c1450_夜鷹衆_跳び下がり投擲2_4"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502051,
       "Entries": [
-        "c1450_Nightjars_Step slash throwing_Left -- c1450_夜鷹衆_ステップ斬り投擲_左"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502061,
       "Entries": [
-        "c1450_Nightjars_Step slash throwing_Right -- c1450_夜鷹衆_ステップ斬り投擲_右"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502100,
       "Entries": [
-        "c1450_Nightjars_Left simultaneous throwing 1 -- c1450_夜鷹衆_左同時投擲1"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502101,
       "Entries": [
-        "c1450_Nightjars_Left simultaneous throwing 2 -- c1450_夜鷹衆_左同時投擲2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502120,
       "Entries": [
-        "c1450_Nightjars_Sidestep throwing_Left_1 -- c1450_夜鷹衆_サイドステップ投擲_左_1"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502121,
       "Entries": [
-        "c1450_Nightjars_Side step throwing_Left_2 -- c1450_夜鷹衆_サイドステップ投擲_左_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502130,
       "Entries": [
-        "c1450_Nightjars_Sidestep throwing_Right_1 -- c1450_夜鷹衆_サイドステップ投擲_右_1"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502131,
       "Entries": [
-        "c1450_Nightjars_Sidestep throwing_Right_2 -- c1450_夜鷹衆_サイドステップ投擲_右_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502140,
       "Entries": [
-        "c1450_Nightjars_Backward throwing_1 -- c1450_夜鷹衆_後方投擲_1"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502141,
       "Entries": [
-        "c1450_Nightjars_Backward throwing_2 -- c1450_夜鷹衆_後方投擲_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502300,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 1_1 -- c1450_夜鷹衆_連続投擲1_1"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502301,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 1_2 -- c1450_夜鷹衆_連続投擲1_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502302,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 1_1_2 -- c1450_夜鷹衆_連続投擲1_1_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502303,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 1_2_2 -- c1450_夜鷹衆_連続投擲1_2_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502310,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 2_1 -- c1450_夜鷹衆_連続投擲2_1"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502311,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 2_2 -- c1450_夜鷹衆_連続投擲2_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502312,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 2_1_2 -- c1450_夜鷹衆_連続投擲2_1_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502313,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 2_2_2 -- c1450_夜鷹衆_連続投擲2_2_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502320,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 3_1 -- c1450_夜鷹衆_連続投擲3_1"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502321,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 3_3 -- c1450_夜鷹衆_連続投擲3_3"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502322,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 3_1_2 -- c1450_夜鷹衆_連続投擲3_1_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502323,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 3_3_2 -- c1450_夜鷹衆_連続投擲3_3_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502330,
       "Entries": [
-        "c1450_Nightjars_Simultaneous throwing 1 -- c1450_夜鷹衆_同時投擲1"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502331,
       "Entries": [
-        "c1450_Nightjars_Simultaneous throwing 2 -- c1450_夜鷹衆_同時投擲2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502332,
       "Entries": [
-        "c1450_Nightjars_Simultaneous throwing 1_2 -- c1450_夜鷹衆_同時投擲1_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502333,
       "Entries": [
-        "c1450_Nightjars_Simultaneous throwing 2_2 -- c1450_夜鷹衆_同時投擲2_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502340,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 3_1 -- c1450_夜鷹衆_連続投擲3_1"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502341,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 3_3 -- c1450_夜鷹衆_連続投擲3_3"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502342,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 3_1_2 -- c1450_夜鷹衆_連続投擲3_1_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502343,
       "Entries": [
-        "c1450_Nightjars_Continuous throwing 3_3_2 -- c1450_夜鷹衆_連続投擲3_3_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502750,
       "Entries": [
-        "c1450_Nightjars_Retreat throwing from left weak throw_1 -- c1450_夜鷹衆_左弱弾きからの後退投擲_1"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502751,
       "Entries": [
-        "c1450_Nightjars_Retreat throwing from left weak throw_2 -- c1450_夜鷹衆_左弱弾きからの後退投擲_2"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502752,
       "Entries": [
-        "c1450_Nightjars_Retreat throwing from left weak playing_3 -- c1450_夜鷹衆_左弱弾きからの後退投擲_3"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502753,
       "Entries": [
-        "c1450_Nightjars_Retreat throwing from left weak play_4 -- c1450_夜鷹衆_左弱弾きからの後退投擲_4"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502754,
       "Entries": [
-        "c1450_Nightjars_Retreat throwing from left weak playing_5 -- c1450_夜鷹衆_左弱弾きからの後退投擲_5"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502755,
       "Entries": [
-        "c1450_Nightjars_Left throwing backwards from weak playing_6 -- c1450_夜鷹衆_左弱弾きからの後退投擲_6"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502756,
       "Entries": [
-        "c1450_Nightjars_Left throwing backwards from weak playing_7 -- c1450_夜鷹衆_左弱弾きからの後退投擲_7"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502757,
       "Entries": [
-        "c1450_Nightjars_Left throwing backwards from weak playing_8 -- c1450_夜鷹衆_左弱弾きからの後退投擲_8"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502758,
       "Entries": [
-        "c1450_Nightjars_Left throwing backwards from weak playing_9 -- c1450_夜鷹衆_左弱弾きからの後退投擲_9"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502759,
       "Entries": [
-        "c1450_Nightjars_Left throwing backwards from weak playing_10 -- c1450_夜鷹衆_左弱弾きからの後退投擲_10"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502760,
       "Entries": [
-        "c1450_Nightjars_Left throwing backwards from weak playing_11 -- c1450_夜鷹衆_左弱弾きからの後退投擲_11"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502761,
       "Entries": [
-        "c1450_Nightjars_Left throwing backwards from weak playing_12 -- c1450_夜鷹衆_左弱弾きからの後退投擲_12"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502762,
       "Entries": [
-        "c1450_Nightjars_Left throwing backwards from weak playing_13 -- c1450_夜鷹衆_左弱弾きからの後退投擲_13"
+        "Nightjar - Throwing"
       ]
     },
     {
       "ID": 14502900,
       "Entries": [
-        "c1450_Nightjars_Weapon landing explosion -- c1450_夜鷹衆_武器着弾爆発"
+        "Nightjar"
       ]
     },
     {
       "ID": 14700290,
       "Entries": [
-        "c1470_Lonely people_Kunai throwing -- c1470_孤影衆_クナイ投げ"
+        "Lone Shadow - Kunai Throw"
       ]
     },
     {
       "ID": 14700500,
       "Entries": [
-        "Dog whistle -- 犬笛"
+        "Lone Shadow - Dog Whistle"
       ]
     },
     {
       "ID": 14700980,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign Lower -- ダミー弾丸_危険な攻撃予兆\u3000下段"
+        "Lone Shadow - Perilous Attack Warning"
       ]
     },
     {
       "ID": 14700981,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign thrust -- ダミー弾丸_危険な攻撃予兆\u3000突き"
+        "Lone Shadow - Perilous Attack Warning"
       ]
     },
     {
       "ID": 15000010,
       "Entries": [
-        "c1500_Village Zombie_Bare Hands_Fertilizer Bukkake -- c1500_村人ゾンビ_素手_肥溜めぶっかけ"
+        "Mibu Villager - Throw Stone"
       ]
     },
     {
       "ID": 15000030,
       "Entries": [
-        "c1500_villager zombies_bare hands_throw stones -- c1500_村人ゾンビ_素手_石を投げる"
+        "Mibu Villager - Throw Stone"
       ]
     },
     {
       "ID": 15000031,
       "Entries": [
-        "c1500_villager zombies_bare hands_throw mad dumplings_parents -- c1500_村人ゾンビ_素手_発狂団子を投げる_親"
+        "Mibu Villager - Terror Ball"
       ]
     },
     {
       "ID": 15000032,
       "Entries": [
-        "c1500_villager zombies_bare hands_throwing mad dumplings_child -- c1500_村人ゾンビ_素手_発狂団子を投げる_子"
+        "Mibu Villager - Terror Ball"
       ]
     },
     {
       "ID": 15000280,
       "Entries": [
-        "c1500_Village Zombie Prisoner_Lacrimal Gland Throw_Dummy Bullet for Middle Stage -- c1500_村人ゾンビ囚人_涙腺抉り投げ_中段用ダミー弾丸"
+        "Mibu Villager - Terror Ball"
       ]
     },
     {
       "ID": 15000800,
       "Entries": [
-        "c1500_Village Zombie_Hallucination Change_Butterfly Guided Bullet A_Parent -- c1500_村人ゾンビ_幻覚変化_蝶誘導弾A_親"
+        "Mibu Villager - Illusion"
       ]
     },
     {
       "ID": 15000801,
       "Entries": [
-        "c1500_Village Zombie_Hallucination Change_Butterfly Guided Bullet A_Child -- c1500_村人ゾンビ_幻覚変化_蝶誘導弾A_子"
+        "Mibu Villager - Illusion"
       ]
     },
     {
       "ID": 15000802,
       "Entries": [
-        "c1500_Village Zombie_Hallucination Change_Butterfly Guided Bullet A_Grandson -- c1500_村人ゾンビ_幻覚変化_蝶誘導弾A_孫"
+        "Mibu Villager - Illusion"
       ]
     },
     {
       "ID": 15000810,
       "Entries": [
-        "c1500_Village Zombie_Hallucination Change_Butterfly Guided Bullet B_Parent -- c1500_村人ゾンビ_幻覚変化_蝶誘導弾B_親"
+        "Mibu Villager - Illusion"
       ]
     },
     {
       "ID": 15000811,
       "Entries": [
-        "c1500_Village Zombie_Hallucination Change_Butterfly Guided Bullet B_Child -- c1500_村人ゾンビ_幻覚変化_蝶誘導弾B_子"
+        "Mibu Villager - Illusion"
       ]
     },
     {
       "ID": 15000812,
       "Entries": [
-        "c1500_Village Zombie_Hallucination Change_Butterfly Guided Bullet B_Grandson -- c1500_村人ゾンビ_幻覚変化_蝶誘導弾B_孫"
+        "Mibu Villager - Illusion"
       ]
     },
     {
       "ID": 15000820,
       "Entries": [
-        "c1500_Village Zombie_Hallucination Change_Butterfly Guided Bullet C_Parent -- c1500_村人ゾンビ_幻覚変化_蝶誘導弾C_親"
+        "Mibu Villager - Illusion"
       ]
     },
     {
       "ID": 15000821,
       "Entries": [
-        "c1500_Village Zombie_Hallucination Change_Butterfly Guided Bullet C_Child -- c1500_村人ゾンビ_幻覚変化_蝶誘導弾C_子"
+        "Mibu Villager - Illusion"
       ]
     },
     {
       "ID": 15000822,
       "Entries": [
-        "c1500_Village Zombie_Hallucination Change_Butterfly Guided Bullet C_Grandson -- c1500_村人ゾンビ_幻覚変化_蝶誘導弾C_孫"
+        "Mibu Villager - Illusion"
       ]
     },
     {
       "ID": 15000850,
       "Entries": [
-        "c1500_Village Zombie_Sand for Restraint -- c1500_村人ゾンビ_拘束用砂掛け"
+        "Mibu Villager - Sand Throw"
       ]
     },
     {
       "ID": 15000980,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Grab and pierce -- ダミー弾丸_危険な攻撃予兆_掴み突き刺し"
+        "Mibu Villager - Perilous Attack Warning"
       ]
     },
     {
       "ID": 15000981,
       "Entries": [
-        "Dummy bullet _ dangerous attack sign _ thrust _ normal -- ダミー弾丸_危険な攻撃予兆_突き_通常"
+        "Mibu Villager - Perilous Attack Warning"
       ]
     },
     {
       "ID": 15000982,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign _ Thrust _ Above waist -- ダミー弾丸_危険な攻撃予兆_突き_腰より上"
+        "Mibu Villager - Perilous Attack Warning"
       ]
     },
     {
       "ID": 15000983,
       "Entries": [
-        "Dummy bullet _ dangerous attack sign _ thrust _ below the waist -- ダミー弾丸_危険な攻撃予兆_突き_腰より下"
+        "Mibu Villager - Perilous Attack Warning"
       ]
     },
     {
       "ID": 15500290,
       "Entries": [
-        "c1550_Bandit_Torches_Lucking allies -- c1550_野盗_松明_味方おびき寄せ"
+        "Bandit Torch - Ally Call"
       ]
     },
     {
       "ID": 15500390,
       "Entries": [
-        "c1550_Bandit_Shield_Dummy Bullet_Shield Bang Bang Ban -- c1550_野盗_盾_ダミー弾丸_盾バンバン禁止"
+        "Mibu Villager - Shield"
       ]
     },
     {
       "ID": 15500420,
       "Entries": [
-        "c1550_Bandit_Shield_OBJ generation -- c1550_野盗_盾_OBJ生成"
+        "Mibu Villager - Shield"
       ]
     },
     {
       "ID": 15500430,
       "Entries": [
-        "c1550_Bandit_Shield_OBJ Destruction -- c1550_野盗_盾_OBJ破壊"
+        "Mibu Villager - Shield"
       ]
     },
     {
       "ID": 15500600,
       "Entries": [
-        "c1550_Bandit_Bow_Fire Arrow -- c1550_野盗_弓_火矢"
+        "Bandit - Fire Arrow"
       ]
     },
     {
       "ID": 15500610,
       "Entries": [
-        "c1550_Bandit_Bow_Poison Arrow -- c1550_野盗_弓_毒矢"
+        "Bandit - Poison Arrow"
       ]
     },
     {
       "ID": 15500620,
       "Entries": [
-        "c1550_Bandit_Bow_Normal Arrow -- c1550_野盗_弓_通常矢"
+        "Bandit - Normal Arrow"
       ]
     },
     {
       "ID": 15500621,
       "Entries": [
-        "c1550_Bandit_Bow_Normal Arrow (Phantom) -- c1550_野盗_弓_通常矢(幻影)"
+        "Bandit Illusion - Normal Arrow"
       ]
     },
     {
       "ID": 15500700,
       "Entries": [
-        "c1550_Bandit_Aburatsubo throw -- c1550_野盗_油壺投げ"
+        "Bandit - Oil Throw"
       ]
     },
     {
       "ID": 15500800,
       "Entries": [
-        "c1550_ Sanding from the left sword -- c1550_左袈裟斬りからの砂かけ"
+        "Bandit - Sand Throw"
       ]
     },
     {
       "ID": 15500980,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign Dos thrust -- ダミー弾丸_危険な攻撃予兆\u3000ドス突き"
+        "Bandit - Perilous Attack Warning"
       ]
     },
     {
       "ID": 15500981,
       "Entries": [
-        "Dummy bullet _ Dangerous attack sign Sword thrust -- ダミー弾丸_危険な攻撃予兆\u3000刀突き"
+        "Bandit - Perilous Attack Warning"
       ]
     },
     {
       "ID": 17000650,
       "Entries": [
-        "c1700_Tokugawa Samurai_Flame _Fire -- c1700_徳川侍_炎放_火炎を放射"
+        "Interior Ministry Samurai - Flame Shot"
       ]
     },
     {
       "ID": 17000651,
       "Entries": [
-        "c1700_Samurai Tokugawa_Flame _Fire flame_DL1 bullet -- c1700_徳川侍_炎放_火炎を放射_DL1弾丸"
+        "Interior Ministry Samurai - Flame Shot"
       ]
     },
     {
       "ID": 17000699,
       "Entries": [
-        "c1700_Tokugawa Samurai_Flame _Bullet when reloading -- c1700_徳川侍_炎放_リロード時弾丸"
+        "Interior Ministry Samurai - Flame Shot"
       ]
     },
     {
       "ID": 17000800,
       "Entries": [
-        "c1700_Tokugawa Samurai_Incendiary Gun_Shooting -- c1700_徳川侍_焼夷銃_射撃"
+        "Interior Ministry Samurai - Flamethrower"
       ]
     },
     {
       "ID": 17000801,
       "Entries": [
-        "c1700_Tokugawa Samurai_Incendiary Gun_Shooting_Impact -- c1700_徳川侍_焼夷銃_射撃_着弾"
+        "Interior Ministry Samurai - Flamethrower"
       ]
     },
     {
       "ID": 17000980,
       "Entries": [
-        "Dummy bullet _ dangerous attack sign _ thrust -- ダミー弾丸_危険な攻撃予兆_突き"
+        "Interior Ministry Samurai - Perilous Attack Warning"
       ]
     },
     {
       "ID": 20210110,
       "Entries": [
-        "c2021: Dog_Basic_Barking (AI sound bullet shooting at the PC) -- c2021：イヌ_基本_吠える（PCに向かって撃つAI音弾丸）"
+        "Dog Barking AI Sound"
       ]
     },
     {

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/BulletCreateLimitParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/BulletCreateLimitParam.json
@@ -4,67 +4,67 @@
     {
       "ID": 0,
       "Entries": [
-        "unused -- 未使用"
+        "\n"
       ]
     },
     {
       "ID": 1,
       "Entries": [
-        "[PC magic] Activity of the dead -- 【PC魔法】死者の活性"
+        "\n"
       ]
     },
     {
       "ID": 2,
       "Entries": [
-        "[PC magic] Warmth fire -- 【PC魔法】ぬくもりの火"
+        "\n"
       ]
     },
     {
       "ID": 3,
       "Entries": [
-        "[PC magic] Miasma of death -- 【PC魔法】死の瘴気"
+        "\n"
       ]
     },
     {
       "ID": 4,
       "Entries": [
-        "[PC magic] Poison fog -- 【PC魔法】毒の霧"
+        "\n"
       ]
     },
     {
       "ID": 5,
       "Entries": [
-        "[PC magic] Poisonous fog -- 【PC魔法】猛毒の霧"
+        "\n"
       ]
     },
     {
       "ID": 6,
       "Entries": [
-        "[PC magic] Acid mist -- 【PC魔法】酸の霧"
+        "\n"
       ]
     },
     {
       "ID": 7,
       "Entries": [
-        "[PC Arts] Zombie Crow Wand_Poison Fog -- 【PCアーツ】ゾンビ鴉の杖_毒の霧"
+        "\n"
       ]
     },
     {
       "ID": 8,
       "Entries": [
-        "[PC magic] Nozomi -- 【PC魔法】望郷"
+        "\n"
       ]
     },
     {
       "ID": 9,
       "Entries": [
-        "Falling Soul: Bullet for generation -- 降り注ぐソウル：発生用弾丸"
+        "\n"
       ]
     },
     {
       "ID": 10,
       "Entries": [
-        "Falling soul (slot 2: for target bullets): bullets for generation -- 降り注ぐソウル（スロット２：狙う弾用）：発生用弾丸"
+        "\n"
       ]
     }
   ]

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/CalcCorrectGraph.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/CalcCorrectGraph.json
@@ -4,469 +4,469 @@
     {
       "ID": 0,
       "Entries": [
-        "0: None -- 0:なし"
+        "\n"
       ]
     },
     {
       "ID": 1,
       "Entries": [
-        "1: Hard stone -- 1:硬石"
+        "\n"
       ]
     },
     {
       "ID": 2,
       "Entries": [
-        "2: Sharp stone -- 2:鋭石"
+        "\n"
       ]
     },
     {
       "ID": 3,
       "Entries": [
-        "3: Minagi stone -- 3:みなぎ石"
+        "\n"
       ]
     },
     {
       "ID": 4,
       "Entries": [
-        "4: Nibi stone -- 4:にび石"
+        "\n"
       ]
     },
     {
       "ID": 5,
       "Entries": [
-        "5: Blade stone -- 5:刃石"
+        "\n"
       ]
     },
     {
       "ID": 6,
       "Entries": [
-        "6: Spider thread steel wire -- 6:蜘蛛糸鋼線"
+        "\n"
       ]
     },
     {
       "ID": 7,
       "Entries": [
-        "7: Mercury stone -- 7:水銀石"
+        "\n"
       ]
     },
     {
       "ID": 8,
       "Entries": [
-        "8: Dragon stone -- 8:竜石"
+        "\n"
       ]
     },
     {
       "ID": 9,
       "Entries": [
-        "9: Sucking stone -- 9:吸いつき石"
+        "\n"
       ]
     },
     {
       "ID": 10,
       "Entries": [
-        "10: Pith stone -- 10:髄石"
+        "\n"
       ]
     },
     {
       "ID": 11,
       "Entries": [
-        "11: Moonlight stone -- 11:月光石"
+        "\n"
       ]
     },
     {
       "ID": 12,
       "Entries": [
-        "12: Moonlight stone -- 12:月影石"
+        "\n"
       ]
     },
     {
       "ID": 13,
       "Entries": [
-        "13: Faint stone -- 13:微光石"
+        "\n"
       ]
     },
     {
       "ID": 14,
       "Entries": [
-        "14: Magic shield stone -- 14:魔法盾石"
+        "\n"
       ]
     },
     {
       "ID": 15,
       "Entries": [
-        "15: Ore Spirit DS -- 15:鉱石の精霊DS"
+        "\n"
       ]
     },
     {
       "ID": 16,
       "Entries": [
-        "16: DS -- 16:ＤＳ"
+        "\n"
       ]
     },
     {
       "ID": 50,
       "Entries": [
-        "The lower the equipment weight, the higher the attack power -- 装備重量が低いほど攻撃力アップ"
+        "\n"
       ]
     },
     {
       "ID": 51,
       "Entries": [
-        "The heavier the equipment weight, the higher the attack power -- 装備重量が重いほど攻撃力アップ"
+        "\n"
       ]
     },
     {
       "ID": 100,
       "Entries": [
-        "(Old) Maximum HP -- （旧）最大HP"
+        "\n"
       ]
     },
     {
       "ID": 101,
       "Entries": [
-        "Maximum MP -- 最大MP"
+        "\n"
       ]
     },
     {
       "ID": 102,
       "Entries": [
-        "Defense (soul level) -- 防御力（ソウルレベル）"
+        "\n"
       ]
     },
     {
       "ID": 110,
       "Entries": [
-        "Disease resistance (former poison: soul level dependent) -- 病毒耐性（旧毒：ソウルレベル依存）"
+        "Poison Resistance"
       ]
     },
     {
       "ID": 111,
       "Entries": [
-        "Madness resistance (former plague: soul level dependent) -- 発狂耐性（旧疫病：ソウルレベル依存）"
+        "Terror Resistance"
       ]
     },
     {
       "ID": 112,
       "Entries": [
-        "Flame resistance (former bleeding: soul level dependent) -- 炎上耐性（旧出血：ソウルレベル依存）"
+        "Burn Resistance"
       ]
     },
     {
       "ID": 113,
       "Entries": [
-        "Aging resistance (old curse: soul level dependent) -- 老化耐性（旧呪い：ソウルレベル依存）"
+        "Enfeeble Resistance"
       ]
     },
     {
       "ID": 114,
       "Entries": [
-        "Electric shock resistance (former: cold air (depending on soul level) -- 感電耐性（旧：冷気（ソウルレベル依存）"
+        "Shock Resistance"
       ]
     },
     {
       "ID": 120,
       "Entries": [
-        "Poison resistance (physical strength) -- 毒耐性（体力）"
+        "\n"
       ]
     },
     {
       "ID": 121,
       "Entries": [
-        "Epidemic resistance (physical strength) -- 疫病耐性（体力）"
+        "\n"
       ]
     },
     {
       "ID": 122,
       "Entries": [
-        "Bleeding resistance (endurance) -- 出血耐性（持久力）"
+        "\n"
       ]
     },
     {
       "ID": 123,
       "Entries": [
-        "Curse resistance (luck) -- 呪い耐性（運）"
+        "\n"
       ]
     },
     {
       "ID": 124,
       "Entries": [
-        "Cold resistance (life force) -- 冷気耐性（生命力）"
+        "\n"
       ]
     },
     {
       "ID": 130,
       "Entries": [
-        "Physical defense (muscle strength) -- 物理防御力（筋力）"
+        "\n"
       ]
     },
     {
       "ID": 131,
       "Entries": [
-        "Physical defense (physical strength) -- 物理防御力（体力）"
+        "\n"
       ]
     },
     {
       "ID": 132,
       "Entries": [
-        "Magic defense (faith) -- 魔法防御力（信仰）"
+        "\n"
       ]
     },
     {
       "ID": 133,
       "Entries": [
-        "Flame defense (muscle strength) -- 炎防御力（筋力）"
+        "\n"
       ]
     },
     {
       "ID": 134,
       "Entries": [
-        "Lightning defense (endurance) -- 雷防御力（持久力）"
+        "\n"
       ]
     },
     {
       "ID": 135,
       "Entries": [
-        "Dark defense (faith) -- 闇防御力（信仰）"
+        "\n"
       ]
     },
     {
       "ID": 140,
       "Entries": [
-        "Drop rate (luck) -- ドロップ率（運）"
+        "\n"
       ]
     },
     {
       "ID": 150,
       "Entries": [
-        "Maximum number of recovery spots replenished -- 回復スポットの最大補充数"
+        "\n"
       ]
     },
     {
       "ID": 160,
       "Entries": [
-        "Shield status correction Physical cut rate -- 盾ステータス補正 物理カット率"
+        "\n"
       ]
     },
     {
       "ID": 161,
       "Entries": [
-        "Shield status correction Attribute cut rate -- 盾ステータス補正 属性カット率"
+        "\n"
       ]
     },
     {
       "ID": 162,
       "Entries": [
-        "Shield Status Correction Resistance Cut Rate -- 盾ステータス補正 耐性カット率"
+        "\n"
       ]
     },
     {
       "ID": 163,
       "Entries": [
-        "Shield status correction Stamina cut rate -- 盾ステータス補正 スタミナカット率"
+        "\n"
       ]
     },
     {
       "ID": 170,
       "Entries": [
-        "Maximum arts point (muscle strength) -- アーツポイント最大値（筋力）"
+        "\n"
       ]
     },
     {
       "ID": 171,
       "Entries": [
-        "Maximum arts point (skill) -- アーツポイント最大値（技量）"
+        "\n"
       ]
     },
     {
       "ID": 172,
       "Entries": [
-        "Maximum arts point (magic) -- アーツポイント最大値（魔法）"
+        "\n"
       ]
     },
     {
       "ID": 173,
       "Entries": [
-        "Maximum arts point (miracle) -- アーツポイント最大値（奇跡）"
+        "\n"
       ]
     },
     {
       "ID": 200,
       "Entries": [
-        "Growth consumption soul -- 成長消費ソウル"
+        "\n"
       ]
     },
     {
       "ID": 210,
       "Entries": [
-        "Fall damage basic value -- 落下ダメージ基本値"
+        "Fall Damage"
       ]
     },
     {
       "ID": 211,
       "Entries": [
-        "Fall damage weight ratio correction -- 落下ダメージ重量割合補正"
+        "\n"
       ]
     },
     {
       "ID": 212,
       "Entries": [
-        "Fall damage vitality correction -- 落下ダメージ生命力補正"
+        "\n"
       ]
     },
     {
       "ID": 213,
       "Entries": [
-        "Fall damage skill correction -- 落下ダメージ技量補正"
+        "\n"
       ]
     },
     {
       "ID": 300,
       "Entries": [
-        "Level sync: HP -- レベルシンク：HP"
+        "\n"
       ]
     },
     {
       "ID": 301,
       "Entries": [
-        "Level sync: MP -- レベルシンク：MP"
+        "\n"
       ]
     },
     {
       "ID": 302,
       "Entries": [
-        "Level Sync: Stamina -- レベルシンク：スタミナ"
+        "\n"
       ]
     },
     {
       "ID": 303,
       "Entries": [
-        "Level Sync: Defense -- レベルシンク：防御力"
+        "\n"
       ]
     },
     {
       "ID": 304,
       "Entries": [
-        "Level sync: Resistance value -- レベルシンク：耐性値"
+        "\n"
       ]
     },
     {
       "ID": 310,
       "Entries": [
-        "Level Sync: Weapon: Straight Sword -- レベルシンク：武器：直剣"
+        "\n"
       ]
     },
     {
       "ID": 320,
       "Entries": [
-        "Level Sync: Weapon: Dagger -- レベルシンク：武器：短剣"
+        "\n"
       ]
     },
     {
       "ID": 330,
       "Entries": [
-        "Level Sync: Weapon: Oversized Sword -- レベルシンク：武器：特大剣"
+        "\n"
       ]
     },
     {
       "ID": 340,
       "Entries": [
-        "Level Sync: Weapon: Bow -- レベルシンク：武器：弓"
+        "\n"
       ]
     },
     {
       "ID": 341,
       "Entries": [
-        "Level Sync: Weapon: Large Bow -- レベルシンク：武器：大弓"
+        "\n"
       ]
     },
     {
       "ID": 342,
       "Entries": [
-        "Level Sync: Weapon: Crossbow -- レベルシンク：武器：クロスボウ"
+        "\n"
       ]
     },
     {
       "ID": 350,
       "Entries": [
-        "Level Sync: Weapon: Wand -- レベルシンク：武器：杖"
+        "\n"
       ]
     },
     {
       "ID": 351,
       "Entries": [
-        "Level Sync: Weapon: Talisman and Bell -- レベルシンク：武器：タリスマンと鈴"
+        "\n"
       ]
     },
     {
       "ID": 352,
       "Entries": [
-        "Level Sync: Weapon: Fire of Magic -- レベルシンク：武器：呪術の火"
+        "\n"
       ]
     },
     {
       "ID": 400,
       "Entries": [
-        "Level Sync: Item: Throw Knife -- レベルシンク：アイテム：投げナイフ"
+        "\n"
       ]
     },
     {
       "ID": 401,
       "Entries": [
-        "Level Sync: Item: Throw Bin -- レベルシンク：アイテム：投げビン"
+        "\n"
       ]
     },
     {
       "ID": 500,
       "Entries": [
-        "Maximum HP -- 最大HP"
+        "HP"
       ]
     },
     {
       "ID": 501,
       "Entries": [
-        "Maximum stamina -- 最大スタミナ"
+        "Posture"
       ]
     },
     {
       "ID": 502,
       "Entries": [
-        "Kick stamina attack power multiplier -- 蹴りスタミナ攻撃力倍率"
+        "Kick Posture Damage"
       ]
     },
     {
       "ID": 503,
       "Entries": [
-        "Attack contact parry (closeout) stamina attack power multiplier -- 攻撃接触パリィ（見切り）スタミナ攻撃力倍率"
+        "Deflect Posture Multiplier"
       ]
     },
     {
       "ID": 504,
       "Entries": [
-        "Stamina recovery speed -- スタミナ回復速度"
+        "Posture Recovery Speed"
       ]
     },
     {
       "ID": 600,
       "Entries": [
-        "Required skill experience value -- 必要スキル経験値"
+        "XP needed for Skill Point"
       ]
     },
     {
       "ID": 610,
       "Entries": [
-        "Remaining machine protection price -- 残機プロテクトの値段"
+        "Remaining machine protection price"
       ]
     },
     {
       "ID": 620,
       "Entries": [
-        "Dragon cough incidence [%] -- 竜咳発生率[%]"
+        "Dragonrot Incidence"
       ]
     },
     {
       "ID": 630,
       "Entries": [
-        "Money / Skill Experience Lost Rate [%] -- お金/スキル経験値ロスト発生率[%]"
+        "Sen / XP Loss Rate"
       ]
     }
   ]

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/CharMakeMenuListItemParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/CharMakeMenuListItemParam.json
@@ -4,1315 +4,1315 @@
     {
       "ID": 0,
       "Entries": [
-        "Not set -- 未設定"
+        "\n"
       ]
     },
     {
       "ID": 1,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 2,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 100,
       "Entries": [
-        "Base body shape -- ベース体型"
+        "\n"
       ]
     },
     {
       "ID": 101,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 102,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 103,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 104,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 105,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 106,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 107,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 108,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 120,
       "Entries": [
-        "Muscle mass -- 筋肉量"
+        "\n"
       ]
     },
     {
       "ID": 121,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 130,
       "Entries": [
-        "Hair volume -- 体毛量"
+        "\n"
       ]
     },
     {
       "ID": 131,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 200,
       "Entries": [
-        "Base face * Frames 90 to 99 are for rendered images only, so switch to a different ID -- ベース顔 ※フレーム90~99はレンダリング画像専用のため、別IDに切り替え"
+        "\n"
       ]
     },
     {
       "ID": 201,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 202,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 203,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 204,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 205,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 206,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 207,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 208,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 209,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 220,
       "Entries": [
-        "Base face for women display -- ベース顔\u3000女性用表示"
+        "\n"
       ]
     },
     {
       "ID": 221,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 222,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 223,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 224,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 225,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 226,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 227,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 228,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 229,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 300,
       "Entries": [
-        "Eyes (right) -- 瞳(右)"
+        "\n"
       ]
     },
     {
       "ID": 301,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 302,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 303,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 304,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 305,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 306,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 307,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 308,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 400,
       "Entries": [
-        "Eyes (left) -- 瞳(左)"
+        "\n"
       ]
     },
     {
       "ID": 401,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 402,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 403,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 404,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 405,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 406,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 407,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 408,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 500,
       "Entries": [
-        "eyebrow -- 眉"
+        "\n"
       ]
     },
     {
       "ID": 501,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 502,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 503,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 504,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 505,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 506,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 507,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 508,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 509,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 510,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 511,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 512,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 513,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 514,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 515,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 516,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 600,
       "Entries": [
-        "beard -- 髭"
+        "\n"
       ]
     },
     {
       "ID": 601,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 602,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 603,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 604,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 605,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 606,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 607,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 608,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 609,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 610,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 611,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 620,
       "Entries": [
-        "Beard for women (same as men) -- 髭\u3000女性用(男と同じ)"
+        "\n"
       ]
     },
     {
       "ID": 621,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 622,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 623,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 624,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 625,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 626,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 627,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 628,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 629,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 630,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 631,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 700,
       "Entries": [
-        "Hairstyle -- 髪型"
+        "\n"
       ]
     },
     {
       "ID": 701,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 702,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 703,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 704,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 705,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 706,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 707,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 708,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 709,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 710,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 711,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 712,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 713,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 714,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 715,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 716,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 717,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 718,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 719,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 720,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 721,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 722,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 723,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 800,
       "Entries": [
-        "Decal -- デカール"
+        "\n"
       ]
     },
     {
       "ID": 801,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 802,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 803,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 804,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 805,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 806,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 807,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 808,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 809,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 810,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 811,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 812,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 813,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 814,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 815,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 816,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 817,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 818,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 819,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 820,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 821,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 822,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 823,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 824,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 825,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 826,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 827,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 828,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 829,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 830,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 831,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 832,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 833,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 834,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 835,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 836,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 837,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 838,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 839,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 840,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 841,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 842,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 843,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 844,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 845,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 846,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 847,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 848,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 849,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 900,
       "Entries": [
-        "accessory -- アクセサリ"
+        "\n"
       ]
     },
     {
       "ID": 901,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 902,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 903,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 904,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 905,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 906,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 907,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 908,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 1000,
       "Entries": [
-        "Eyes (for both eyes) -- 瞳(両瞳用）"
+        "\n"
       ]
     },
     {
       "ID": 1001,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 1002,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 1003,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 1004,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 1005,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 1006,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 1007,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 1008,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 1100,
       "Entries": [
-        "eyelash -- まつげ"
+        "\n"
       ]
     },
     {
       "ID": 1101,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 1102,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 1103,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 100000,
       "Entries": [
-        "sex -- 性別"
+        "\n"
       ]
     },
     {
       "ID": 100001,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 100100,
       "Entries": [
-        "Age group -- 年齢層"
+        "\n"
       ]
     },
     {
       "ID": 100101,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 100102,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 100200,
       "Entries": [
-        "Feature -- 素性"
+        "\n"
       ]
     },
     {
       "ID": 100201,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 100202,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 100203,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 100204,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 100205,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 100206,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 100207,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 100208,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 100209,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 100300,
       "Entries": [
-        "gift -- 贈り物"
+        "\n"
       ]
     },
     {
       "ID": 100301,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 100302,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 100303,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 100304,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 100305,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 100306,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 100307,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 100308,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 100309,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 100400,
       "Entries": [
-        "voice -- ボイス"
+        "\n"
       ]
     },
     {
       "ID": 100401,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 100402,
       "Entries": [
-        ""
+        "\n"
       ]
     }
   ]

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/CharMakeMenuTopParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/CharMakeMenuTopParam.json
@@ -4,1879 +4,1879 @@
     {
       "ID": 1,
       "Entries": [
-        "sex -- 性別"
+        "\n"
       ]
     },
     {
       "ID": 2,
       "Entries": [
-        "Around the age -- 年頃"
+        "\n"
       ]
     },
     {
       "ID": 3,
       "Entries": [
-        "voice -- 声"
+        "\n"
       ]
     },
     {
       "ID": 4,
       "Entries": [
-        "----- {Constitution -- -----｛体質"
+        "\n"
       ]
     },
     {
       "ID": 5,
       "Entries": [
-        "Muscle mass -- 筋肉量"
+        "\n"
       ]
     },
     {
       "ID": 6,
       "Entries": [
-        "Hair volume -- 体毛量"
+        "\n"
       ]
     },
     {
       "ID": 7,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 8,
       "Entries": [
-        "Physique -- 体格"
+        "\n"
       ]
     },
     {
       "ID": 9,
       "Entries": [
-        "----- {Details of physique -- -----｛体格詳細"
+        "\n"
       ]
     },
     {
       "ID": 10,
       "Entries": [
-        "head -- 頭部"
+        "\n"
       ]
     },
     {
       "ID": 11,
       "Entries": [
-        "Chest -- 胸部"
+        "\n"
       ]
     },
     {
       "ID": 12,
       "Entries": [
-        "abdomen -- 腹部"
+        "\n"
       ]
     },
     {
       "ID": 13,
       "Entries": [
-        "Arm -- 腕部"
+        "\n"
       ]
     },
     {
       "ID": 14,
       "Entries": [
-        "leg -- 脚部"
+        "\n"
       ]
     },
     {
       "ID": 15,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 16,
       "Entries": [
-        "Face -- 顔つき"
+        "\n"
       ]
     },
     {
       "ID": 17,
       "Entries": [
-        "----- {Details of face -- -----｛顔つき詳細"
+        "\n"
       ]
     },
     {
       "ID": 18,
       "Entries": [
-        "Similar face -- 似た顔"
+        "\n"
       ]
     },
     {
       "ID": 19,
       "Entries": [
-        "----- {Characteristics -- -----｛特徴付け"
+        "\n"
       ]
     },
     {
       "ID": 20,
       "Entries": [
-        "Age image -- 年齢イメージ"
+        "\n"
       ]
     },
     {
       "ID": 21,
       "Entries": [
-        "Gender image -- 性別イメージ"
+        "\n"
       ]
     },
     {
       "ID": 22,
       "Entries": [
-        "Shape exaggeration -- 形状誇張"
+        "\n"
       ]
     },
     {
       "ID": 23,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 24,
       "Entries": [
-        "----- {Face shape -- -----｛顔の形状"
+        "\n"
       ]
     },
     {
       "ID": 25,
       "Entries": [
-        "----- {Face balance -- -----｛顔のバランス"
+        "\n"
       ]
     },
     {
       "ID": 26,
       "Entries": [
-        "Nose occupancy -- 鼻の占める比率"
+        "\n"
       ]
     },
     {
       "ID": 27,
       "Entries": [
-        "Nose to forehead ratio -- 鼻と額の比率"
+        "\n"
       ]
     },
     {
       "ID": 28,
       "Entries": [
-        "Unevenness of the face -- 顔の凹凸"
+        "\n"
       ]
     },
     {
       "ID": 29,
       "Entries": [
-        "Top and bottom spacing of face parts -- 顔パーツの上下の間隔"
+        "\n"
       ]
     },
     {
       "ID": 30,
       "Entries": [
-        "Tilt of face parts -- 顔パーツの傾き"
+        "\n"
       ]
     },
     {
       "ID": 31,
       "Entries": [
-        "Left and right spacing of face parts -- 顔パーツの左右の間隔"
+        "\n"
       ]
     },
     {
       "ID": 32,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 33,
       "Entries": [
-        "----- {Forehead / glabellar -- -----｛額/眉間"
+        "\n"
       ]
     },
     {
       "ID": 34,
       "Entries": [
-        "Forehead depth -- 額の深さ"
+        "\n"
       ]
     },
     {
       "ID": 35,
       "Entries": [
-        "Unevenness of the forehead -- 額の凹凸"
+        "\n"
       ]
     },
     {
       "ID": 36,
       "Entries": [
-        "Height of the upper part of the bridge of the nose -- 鼻梁上部の高さ"
+        "\n"
       ]
     },
     {
       "ID": 37,
       "Entries": [
-        "Concavities and convexities above the bridge of the nose 1 -- 鼻梁上部の凹凸1"
+        "\n"
       ]
     },
     {
       "ID": 38,
       "Entries": [
-        "Unevenness on the upper part of the bridge of the nose 2 -- 鼻梁上部の凹凸2"
+        "\n"
       ]
     },
     {
       "ID": 39,
       "Entries": [
-        "Width of the upper part of the bridge of the nose -- 鼻梁上部の幅"
+        "\n"
       ]
     },
     {
       "ID": 40,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 41,
       "Entries": [
-        "----- {Eyebrows -- -----｛眉骨"
+        "\n"
       ]
     },
     {
       "ID": 42,
       "Entries": [
-        "Eyebrow height -- 眉骨の高さ"
+        "\n"
       ]
     },
     {
       "ID": 43,
       "Entries": [
-        "Inner edge of the eyebrow -- 眉骨の内端"
+        "\n"
       ]
     },
     {
       "ID": 44,
       "Entries": [
-        "Outer edge of the eyebrow -- 眉骨の外端"
+        "\n"
       ]
     },
     {
       "ID": 45,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 46,
       "Entries": [
-        "-----{eye -- -----｛眼"
+        "\n"
       ]
     },
     {
       "ID": 47,
       "Entries": [
-        "Eye position -- 眼の位置"
+        "\n"
       ]
     },
     {
       "ID": 48,
       "Entries": [
-        "Eye size -- 眼の大きさ"
+        "\n"
       ]
     },
     {
       "ID": 49,
       "Entries": [
-        "Eye tilt -- 眼の傾き"
+        "\n"
       ]
     },
     {
       "ID": 50,
       "Entries": [
-        "Eye spacing -- 眼の間隔"
+        "\n"
       ]
     },
     {
       "ID": 51,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 52,
       "Entries": [
-        "----- {nose muscle -- -----｛鼻筋"
+        "\n"
       ]
     },
     {
       "ID": 53,
       "Entries": [
-        "Depth of the nose -- 鼻筋の深さ"
+        "\n"
       ]
     },
     {
       "ID": 54,
       "Entries": [
-        "Nose length -- 鼻筋の長さ"
+        "\n"
       ]
     },
     {
       "ID": 55,
       "Entries": [
-        "Nose position -- 鼻の位置"
+        "\n"
       ]
     },
     {
       "ID": 56,
       "Entries": [
-        "Nose height -- 鼻先の高さ"
+        "\n"
       ]
     },
     {
       "ID": 57,
       "Entries": [
-        "Unevenness of the nose -- 鼻の凹凸"
+        "\n"
       ]
     },
     {
       "ID": 58,
       "Entries": [
-        "Nose height -- 鼻の高さ"
+        "\n"
       ]
     },
     {
       "ID": 59,
       "Entries": [
-        "Nose tilt -- 鼻の傾斜"
+        "\n"
       ]
     },
     {
       "ID": 60,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 61,
       "Entries": [
-        "----- {Nose -- -----｛小鼻"
+        "\n"
       ]
     },
     {
       "ID": 62,
       "Entries": [
-        "Inclination of the nose -- 小鼻の傾斜"
+        "\n"
       ]
     },
     {
       "ID": 63,
       "Entries": [
-        "Nose size -- 小鼻の大きさ"
+        "\n"
       ]
     },
     {
       "ID": 64,
       "Entries": [
-        "Nose width -- 小鼻の幅"
+        "\n"
       ]
     },
     {
       "ID": 65,
       "Entries": [
-        "Nostril size -- 鼻孔の大きさ"
+        "\n"
       ]
     },
     {
       "ID": 66,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 67,
       "Entries": [
-        "-----{cheek -- -----｛頬"
+        "\n"
       ]
     },
     {
       "ID": 68,
       "Entries": [
-        "Cheekbone height -- 頬骨の高さ"
+        "\n"
       ]
     },
     {
       "ID": 69,
       "Entries": [
-        "Cheekbone depth -- 頬骨の深さ"
+        "\n"
       ]
     },
     {
       "ID": 70,
       "Entries": [
-        "The size of the cheekbones -- 頬骨の広さ"
+        "\n"
       ]
     },
     {
       "ID": 71,
       "Entries": [
-        "Uneven cheeks -- 頬の凹凸"
+        "\n"
       ]
     },
     {
       "ID": 72,
       "Entries": [
-        "cheek -- 頬"
+        "\n"
       ]
     },
     {
       "ID": 73,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 74,
       "Entries": [
-        "-----{lips -- -----｛唇"
+        "\n"
       ]
     },
     {
       "ID": 75,
       "Entries": [
-        "Lip shape -- 唇の形"
+        "\n"
       ]
     },
     {
       "ID": 76,
       "Entries": [
-        "Facial expression on the mouth -- 口元の表情"
+        "\n"
       ]
     },
     {
       "ID": 77,
       "Entries": [
-        "Lip bulge -- 唇の膨らみ"
+        "\n"
       ]
     },
     {
       "ID": 78,
       "Entries": [
-        "Lip size -- 唇の大きさ"
+        "\n"
       ]
     },
     {
       "ID": 79,
       "Entries": [
-        "Concavo-convex lips -- 唇の凹凸"
+        "\n"
       ]
     },
     {
       "ID": 80,
       "Entries": [
-        "Lip thickness -- 唇の厚さ"
+        "\n"
       ]
     },
     {
       "ID": 81,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 82,
       "Entries": [
-        "-----{mouth -- -----｛口"
+        "\n"
       ]
     },
     {
       "ID": 83,
       "Entries": [
-        "Concavo-convex mouth -- 口の凹凸"
+        "\n"
       ]
     },
     {
       "ID": 84,
       "Entries": [
-        "Mouth tilt -- 口の傾き"
+        "\n"
       ]
     },
     {
       "ID": 85,
       "Entries": [
-        "Engagement -- かみ合わせ"
+        "\n"
       ]
     },
     {
       "ID": 86,
       "Entries": [
-        "Mouth position -- 口の位置"
+        "\n"
       ]
     },
     {
       "ID": 87,
       "Entries": [
-        "Mouth width -- 口の幅"
+        "\n"
       ]
     },
     {
       "ID": 88,
       "Entries": [
-        "Distance from mouth to chin -- 口から顎先の距離"
+        "\n"
       ]
     },
     {
       "ID": 89,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 90,
       "Entries": [
-        "-----{lower jaw -- -----｛下顎"
+        "\n"
       ]
     },
     {
       "ID": 91,
       "Entries": [
-        "Before and after the tip of the chin -- 顎先端の前後"
+        "\n"
       ]
     },
     {
       "ID": 92,
       "Entries": [
-        "Jaw length -- 顎先の長さ"
+        "\n"
       ]
     },
     {
       "ID": 93,
       "Entries": [
-        "Chin protrusion -- 顎先の突き出し"
+        "\n"
       ]
     },
     {
       "ID": 94,
       "Entries": [
-        "Jaw depth -- 顎先の深さ"
+        "\n"
       ]
     },
     {
       "ID": 95,
       "Entries": [
-        "Jaw size -- 顎先の大きさ"
+        "\n"
       ]
     },
     {
       "ID": 96,
       "Entries": [
-        "Jaw height -- 顎先の高さ"
+        "\n"
       ]
     },
     {
       "ID": 97,
       "Entries": [
-        "Jaw size -- 顎先の広さ"
+        "\n"
       ]
     },
     {
       "ID": 98,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 99,
       "Entries": [
-        "----- {Maxilla -- -----｛上顎"
+        "\n"
       ]
     },
     {
       "ID": 100,
       "Entries": [
-        "Jaw stick out -- 顎の突き出し"
+        "\n"
       ]
     },
     {
       "ID": 101,
       "Entries": [
-        "Jaw width -- 顎の幅"
+        "\n"
       ]
     },
     {
       "ID": 102,
       "Entries": [
-        "Lower chin -- 顎下部"
+        "\n"
       ]
     },
     {
       "ID": 103,
       "Entries": [
-        "Jaw contour -- 顎の輪郭"
+        "\n"
       ]
     },
     {
       "ID": 104,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 105,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 106,
       "Entries": [
-        "----- {Hair / Eyebrows / Beard / Eyelashes -- -----｛髪/眉/髭/まつげ"
+        "\n"
       ]
     },
     {
       "ID": 107,
       "Entries": [
-        "Hair / eyebrows / beard color -- 髪/眉/髭色"
+        "\n"
       ]
     },
     {
       "ID": 108,
       "Entries": [
-        "hair -- 髪"
+        "\n"
       ]
     },
     {
       "ID": 109,
       "Entries": [
-        "Hair color -- 髪色"
+        "\n"
       ]
     },
     {
       "ID": 110,
       "Entries": [
-        "eyebrow -- 眉"
+        "\n"
       ]
     },
     {
       "ID": 111,
       "Entries": [
-        "Eyebrow color -- 眉色"
+        "\n"
       ]
     },
     {
       "ID": 112,
       "Entries": [
-        "beard -- 髭"
+        "\n"
       ]
     },
     {
       "ID": 113,
       "Entries": [
-        "beard -- 髭"
+        "\n"
       ]
     },
     {
       "ID": 114,
       "Entries": [
-        "Beard color -- 髭色"
+        "\n"
       ]
     },
     {
       "ID": 115,
       "Entries": [
-        "eyelash -- まつげ"
+        "\n"
       ]
     },
     {
       "ID": 116,
       "Entries": [
-        "Eyelash color -- まつげ色"
+        "\n"
       ]
     },
     {
       "ID": 117,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 118,
       "Entries": [
-        "-----{pupil -- -----｛瞳"
+        "\n"
       ]
     },
     {
       "ID": 119,
       "Entries": [
-        "Both eyes -- 両瞳"
+        "\n"
       ]
     },
     {
       "ID": 120,
       "Entries": [
-        "Color of both eyes -- 両瞳の色"
+        "\n"
       ]
     },
     {
       "ID": 121,
       "Entries": [
-        "Right pupil -- 右瞳"
+        "\n"
       ]
     },
     {
       "ID": 122,
       "Entries": [
-        "Right eye color -- 右瞳の色"
+        "\n"
       ]
     },
     {
       "ID": 123,
       "Entries": [
-        "Left pupil -- 左瞳"
+        "\n"
       ]
     },
     {
       "ID": 124,
       "Entries": [
-        "Left eye color -- 左瞳の色"
+        "\n"
       ]
     },
     {
       "ID": 125,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 126,
       "Entries": [
-        "-----{make up -- -----｛化粧"
+        "\n"
       ]
     },
     {
       "ID": 127,
       "Entries": [
-        "Brightness of the eyes -- 目元の明るさ"
+        "\n"
       ]
     },
     {
       "ID": 128,
       "Entries": [
-        "Brightness of the orbit -- 眼窩の明るさ"
+        "\n"
       ]
     },
     {
       "ID": 129,
       "Entries": [
-        "Eyelid brightness -- まぶたの明るさ"
+        "\n"
       ]
     },
     {
       "ID": 130,
       "Entries": [
-        "Eyelid color -- まぶたの色"
+        "\n"
       ]
     },
     {
       "ID": 131,
       "Entries": [
-        "eyeliner -- アイライナー"
+        "\n"
       ]
     },
     {
       "ID": 132,
       "Entries": [
-        "Eye shadow -- アイシャドー"
+        "\n"
       ]
     },
     {
       "ID": 133,
       "Entries": [
-        "Lipstick 1 -- 口紅1"
+        "\n"
       ]
     },
     {
       "ID": 134,
       "Entries": [
-        "Lipstick 2 -- 口紅2"
+        "\n"
       ]
     },
     {
       "ID": 135,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 136,
       "Entries": [
-        "----- {Tattoo / Bruise -- -----｛入れ墨/痣"
+        "\n"
       ]
     },
     {
       "ID": 137,
       "Entries": [
-        "Tattoos / bruises -- 入れ墨/痣"
+        "\n"
       ]
     },
     {
       "ID": 138,
       "Entries": [
-        "Tattoo / bruise color -- 入れ墨/痣の色"
+        "\n"
       ]
     },
     {
       "ID": 139,
       "Entries": [
-        "----- {Tattoo / Bruise Adjustment -- -----｛入れ墨/痣の調整"
+        "\n"
       ]
     },
     {
       "ID": 140,
       "Entries": [
-        "Position up and down -- 位置 上下"
+        "\n"
       ]
     },
     {
       "ID": 141,
       "Entries": [
-        "Position left and right -- 位置 左右"
+        "\n"
       ]
     },
     {
       "ID": 142,
       "Entries": [
-        "angle -- 角度"
+        "\n"
       ]
     },
     {
       "ID": 143,
       "Entries": [
-        "Expansion rate -- 拡大率"
+        "\n"
       ]
     },
     {
       "ID": 144,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 145,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 146,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 147,
       "Entries": [
-        "Skin color base -- 肌色ベース"
+        "\n"
       ]
     },
     {
       "ID": 148,
       "Entries": [
-        "----- {Details of skin color -- -----｛肌色詳細"
+        "\n"
       ]
     },
     {
       "ID": 149,
       "Entries": [
-        "Skin brightness -- 肌の明るさ"
+        "\n"
       ]
     },
     {
       "ID": 150,
       "Entries": [
-        "Skin color adjustment 1 -- 肌色調整1"
+        "\n"
       ]
     },
     {
       "ID": 151,
       "Entries": [
-        "Skin color adjustment 2 -- 肌色調整2"
+        "\n"
       ]
     },
     {
       "ID": 152,
       "Entries": [
-        "Skin color adjustment 3 -- 肌色調整3"
+        "\n"
       ]
     },
     {
       "ID": 153,
       "Entries": [
-        "Skin color adjustment 4 -- 肌色調整4"
+        "\n"
       ]
     },
     {
       "ID": 154,
       "Entries": [
-        "Nose bridge color -- 鼻梁の色"
+        "\n"
       ]
     },
     {
       "ID": 155,
       "Entries": [
-        "Cheek color -- 頬の色"
+        "\n"
       ]
     },
     {
       "ID": 156,
       "Entries": [
-        "Law line -- 法令線"
+        "\n"
       ]
     },
     {
       "ID": 157,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 158,
       "Entries": [
-        "----- {Details of face -- -----｛顔つき詳細"
+        "\n"
       ]
     },
     {
       "ID": 159,
       "Entries": [
-        "Similar face -- 似た顔"
+        "\n"
       ]
     },
     {
       "ID": 160,
       "Entries": [
-        "----- {Characteristics -- -----｛特徴付け"
+        "\n"
       ]
     },
     {
       "ID": 161,
       "Entries": [
-        "Age image -- 年齢イメージ"
+        "\n"
       ]
     },
     {
       "ID": 162,
       "Entries": [
-        "Gender image -- 性別イメージ"
+        "\n"
       ]
     },
     {
       "ID": 163,
       "Entries": [
-        "Shape exaggeration -- 形状誇張"
+        "\n"
       ]
     },
     {
       "ID": 164,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 165,
       "Entries": [
-        "----- {Face shape -- -----｛顔の形状"
+        "\n"
       ]
     },
     {
       "ID": 166,
       "Entries": [
-        "----- {Face balance -- -----｛顔のバランス"
+        "\n"
       ]
     },
     {
       "ID": 167,
       "Entries": [
-        "Nose occupancy -- 鼻の占める比率"
+        "\n"
       ]
     },
     {
       "ID": 168,
       "Entries": [
-        "Nose to forehead ratio -- 鼻と額の比率"
+        "\n"
       ]
     },
     {
       "ID": 169,
       "Entries": [
-        "Unevenness of the face -- 顔の凹凸"
+        "\n"
       ]
     },
     {
       "ID": 170,
       "Entries": [
-        "Top and bottom spacing of face parts -- 顔パーツの上下の間隔"
+        "\n"
       ]
     },
     {
       "ID": 171,
       "Entries": [
-        "Tilt of face parts -- 顔パーツの傾き"
+        "\n"
       ]
     },
     {
       "ID": 172,
       "Entries": [
-        "Left and right spacing of face parts -- 顔パーツの左右の間隔"
+        "\n"
       ]
     },
     {
       "ID": 173,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 174,
       "Entries": [
-        "----- {Forehead / glabellar -- -----｛額/眉間"
+        "\n"
       ]
     },
     {
       "ID": 175,
       "Entries": [
-        "Forehead depth -- 額の深さ"
+        "\n"
       ]
     },
     {
       "ID": 176,
       "Entries": [
-        "Unevenness of the forehead -- 額の凹凸"
+        "\n"
       ]
     },
     {
       "ID": 177,
       "Entries": [
-        "Height of the upper part of the bridge of the nose -- 鼻梁上部の高さ"
+        "\n"
       ]
     },
     {
       "ID": 178,
       "Entries": [
-        "Concavities and convexities above the bridge of the nose 1 -- 鼻梁上部の凹凸1"
+        "\n"
       ]
     },
     {
       "ID": 179,
       "Entries": [
-        "Unevenness on the upper part of the bridge of the nose 2 -- 鼻梁上部の凹凸2"
+        "\n"
       ]
     },
     {
       "ID": 180,
       "Entries": [
-        "Width of the upper part of the bridge of the nose -- 鼻梁上部の幅"
+        "\n"
       ]
     },
     {
       "ID": 181,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 182,
       "Entries": [
-        "----- {Eyebrows -- -----｛眉骨"
+        "\n"
       ]
     },
     {
       "ID": 183,
       "Entries": [
-        "Eyebrow height -- 眉骨の高さ"
+        "\n"
       ]
     },
     {
       "ID": 184,
       "Entries": [
-        "Inner edge of the eyebrow -- 眉骨の内端"
+        "\n"
       ]
     },
     {
       "ID": 185,
       "Entries": [
-        "Outer edge of the eyebrow -- 眉骨の外端"
+        "\n"
       ]
     },
     {
       "ID": 186,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 187,
       "Entries": [
-        "-----{eye -- -----｛眼"
+        "\n"
       ]
     },
     {
       "ID": 188,
       "Entries": [
-        "Eye position -- 眼の位置"
+        "\n"
       ]
     },
     {
       "ID": 189,
       "Entries": [
-        "Eye size -- 眼の大きさ"
+        "\n"
       ]
     },
     {
       "ID": 190,
       "Entries": [
-        "Eye tilt -- 眼の傾き"
+        "\n"
       ]
     },
     {
       "ID": 191,
       "Entries": [
-        "Eye spacing -- 眼の間隔"
+        "\n"
       ]
     },
     {
       "ID": 192,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 193,
       "Entries": [
-        "----- {nose muscle -- -----｛鼻筋"
+        "\n"
       ]
     },
     {
       "ID": 194,
       "Entries": [
-        "Depth of the nose -- 鼻筋の深さ"
+        "\n"
       ]
     },
     {
       "ID": 195,
       "Entries": [
-        "Nose length -- 鼻筋の長さ"
+        "\n"
       ]
     },
     {
       "ID": 196,
       "Entries": [
-        "Nose position -- 鼻の位置"
+        "\n"
       ]
     },
     {
       "ID": 197,
       "Entries": [
-        "Nose height -- 鼻先の高さ"
+        "\n"
       ]
     },
     {
       "ID": 198,
       "Entries": [
-        "Unevenness of the nose -- 鼻の凹凸"
+        "\n"
       ]
     },
     {
       "ID": 199,
       "Entries": [
-        "Nose height -- 鼻の高さ"
+        "\n"
       ]
     },
     {
       "ID": 200,
       "Entries": [
-        "Nose tilt -- 鼻の傾斜"
+        "\n"
       ]
     },
     {
       "ID": 201,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 202,
       "Entries": [
-        "----- {Nose -- -----｛小鼻"
+        "\n"
       ]
     },
     {
       "ID": 203,
       "Entries": [
-        "Inclination of the nose -- 小鼻の傾斜"
+        "\n"
       ]
     },
     {
       "ID": 204,
       "Entries": [
-        "Nose size -- 小鼻の大きさ"
+        "\n"
       ]
     },
     {
       "ID": 205,
       "Entries": [
-        "Nose width -- 小鼻の幅"
+        "\n"
       ]
     },
     {
       "ID": 206,
       "Entries": [
-        "Nostril size -- 鼻孔の大きさ"
+        "\n"
       ]
     },
     {
       "ID": 207,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 208,
       "Entries": [
-        "-----{cheek -- -----｛頬"
+        "\n"
       ]
     },
     {
       "ID": 209,
       "Entries": [
-        "Cheekbone height -- 頬骨の高さ"
+        "\n"
       ]
     },
     {
       "ID": 210,
       "Entries": [
-        "Cheekbone depth -- 頬骨の深さ"
+        "\n"
       ]
     },
     {
       "ID": 211,
       "Entries": [
-        "The size of the cheekbones -- 頬骨の広さ"
+        "\n"
       ]
     },
     {
       "ID": 212,
       "Entries": [
-        "Uneven cheeks -- 頬の凹凸"
+        "\n"
       ]
     },
     {
       "ID": 213,
       "Entries": [
-        "cheek -- 頬"
+        "\n"
       ]
     },
     {
       "ID": 214,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 215,
       "Entries": [
-        "-----{lips -- -----｛唇"
+        "\n"
       ]
     },
     {
       "ID": 216,
       "Entries": [
-        "Lip shape -- 唇の形"
+        "\n"
       ]
     },
     {
       "ID": 217,
       "Entries": [
-        "Facial expression on the mouth -- 口元の表情"
+        "\n"
       ]
     },
     {
       "ID": 218,
       "Entries": [
-        "Lip bulge -- 唇の膨らみ"
+        "\n"
       ]
     },
     {
       "ID": 219,
       "Entries": [
-        "Lip size -- 唇の大きさ"
+        "\n"
       ]
     },
     {
       "ID": 220,
       "Entries": [
-        "Concavo-convex lips -- 唇の凹凸"
+        "\n"
       ]
     },
     {
       "ID": 221,
       "Entries": [
-        "Lip thickness -- 唇の厚さ"
+        "\n"
       ]
     },
     {
       "ID": 222,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 223,
       "Entries": [
-        "-----{mouth -- -----｛口"
+        "\n"
       ]
     },
     {
       "ID": 224,
       "Entries": [
-        "Concavo-convex mouth -- 口の凹凸"
+        "\n"
       ]
     },
     {
       "ID": 225,
       "Entries": [
-        "Mouth tilt -- 口の傾き"
+        "\n"
       ]
     },
     {
       "ID": 226,
       "Entries": [
-        "Engagement -- かみ合わせ"
+        "\n"
       ]
     },
     {
       "ID": 227,
       "Entries": [
-        "Mouth position -- 口の位置"
+        "\n"
       ]
     },
     {
       "ID": 228,
       "Entries": [
-        "Mouth width -- 口の幅"
+        "\n"
       ]
     },
     {
       "ID": 229,
       "Entries": [
-        "Distance from mouth to chin -- 口から顎先の距離"
+        "\n"
       ]
     },
     {
       "ID": 230,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 231,
       "Entries": [
-        "-----{lower jaw -- -----｛下顎"
+        "\n"
       ]
     },
     {
       "ID": 232,
       "Entries": [
-        "Before and after the tip of the chin -- 顎先端の前後"
+        "\n"
       ]
     },
     {
       "ID": 233,
       "Entries": [
-        "Jaw length -- 顎先の長さ"
+        "\n"
       ]
     },
     {
       "ID": 234,
       "Entries": [
-        "Chin protrusion -- 顎先の突き出し"
+        "\n"
       ]
     },
     {
       "ID": 235,
       "Entries": [
-        "Jaw depth -- 顎先の深さ"
+        "\n"
       ]
     },
     {
       "ID": 236,
       "Entries": [
-        "Jaw size -- 顎先の大きさ"
+        "\n"
       ]
     },
     {
       "ID": 237,
       "Entries": [
-        "Jaw height -- 顎先の高さ"
+        "\n"
       ]
     },
     {
       "ID": 238,
       "Entries": [
-        "Jaw size -- 顎先の広さ"
+        "\n"
       ]
     },
     {
       "ID": 239,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 240,
       "Entries": [
-        "----- {Maxilla -- -----｛上顎"
+        "\n"
       ]
     },
     {
       "ID": 241,
       "Entries": [
-        "Jaw stick out -- 顎の突き出し"
+        "\n"
       ]
     },
     {
       "ID": 242,
       "Entries": [
-        "Jaw width -- 顎の幅"
+        "\n"
       ]
     },
     {
       "ID": 243,
       "Entries": [
-        "Lower chin -- 顎下部"
+        "\n"
       ]
     },
     {
       "ID": 244,
       "Entries": [
-        "Jaw contour -- 顎の輪郭"
+        "\n"
       ]
     },
     {
       "ID": 245,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 246,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 247,
       "Entries": [
-        "----- {Hair / Eyebrows / Beard / Eyelashes -- -----｛髪/眉/髭/まつげ"
+        "\n"
       ]
     },
     {
       "ID": 248,
       "Entries": [
-        "Hair / eyebrows / beard color -- 髪/眉/髭色"
+        "\n"
       ]
     },
     {
       "ID": 249,
       "Entries": [
-        "hair -- 髪"
+        "\n"
       ]
     },
     {
       "ID": 250,
       "Entries": [
-        "Hair color -- 髪色"
+        "\n"
       ]
     },
     {
       "ID": 251,
       "Entries": [
-        "eyebrow -- 眉"
+        "\n"
       ]
     },
     {
       "ID": 252,
       "Entries": [
-        "Eyebrow color -- 眉色"
+        "\n"
       ]
     },
     {
       "ID": 253,
       "Entries": [
-        "beard -- 髭"
+        "\n"
       ]
     },
     {
       "ID": 254,
       "Entries": [
-        "beard -- 髭"
+        "\n"
       ]
     },
     {
       "ID": 255,
       "Entries": [
-        "Beard color -- 髭色"
+        "\n"
       ]
     },
     {
       "ID": 256,
       "Entries": [
-        "eyelash -- まつげ"
+        "\n"
       ]
     },
     {
       "ID": 257,
       "Entries": [
-        "Eyelash color -- まつげ色"
+        "\n"
       ]
     },
     {
       "ID": 258,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 259,
       "Entries": [
-        "-----{pupil -- -----｛瞳"
+        "\n"
       ]
     },
     {
       "ID": 260,
       "Entries": [
-        "Both eyes -- 両瞳"
+        "\n"
       ]
     },
     {
       "ID": 261,
       "Entries": [
-        "Color of both eyes -- 両瞳の色"
+        "\n"
       ]
     },
     {
       "ID": 262,
       "Entries": [
-        "Right pupil -- 右瞳"
+        "\n"
       ]
     },
     {
       "ID": 263,
       "Entries": [
-        "Right eye color -- 右瞳の色"
+        "\n"
       ]
     },
     {
       "ID": 264,
       "Entries": [
-        "Left pupil -- 左瞳"
+        "\n"
       ]
     },
     {
       "ID": 265,
       "Entries": [
-        "Left eye color -- 左瞳の色"
+        "\n"
       ]
     },
     {
       "ID": 266,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 267,
       "Entries": [
-        "-----{make up -- -----｛化粧"
+        "\n"
       ]
     },
     {
       "ID": 268,
       "Entries": [
-        "Brightness of the eyes -- 目元の明るさ"
+        "\n"
       ]
     },
     {
       "ID": 269,
       "Entries": [
-        "Brightness of the orbit -- 眼窩の明るさ"
+        "\n"
       ]
     },
     {
       "ID": 270,
       "Entries": [
-        "Eyelid brightness -- まぶたの明るさ"
+        "\n"
       ]
     },
     {
       "ID": 271,
       "Entries": [
-        "Eyelid color -- まぶたの色"
+        "\n"
       ]
     },
     {
       "ID": 272,
       "Entries": [
-        "eyeliner -- アイライナー"
+        "\n"
       ]
     },
     {
       "ID": 273,
       "Entries": [
-        "Eye shadow -- アイシャドー"
+        "\n"
       ]
     },
     {
       "ID": 274,
       "Entries": [
-        "Lipstick 1 -- 口紅1"
+        "\n"
       ]
     },
     {
       "ID": 275,
       "Entries": [
-        "Lipstick 2 -- 口紅2"
+        "\n"
       ]
     },
     {
       "ID": 276,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 277,
       "Entries": [
-        "----- {Tattoo / Bruise -- -----｛入れ墨/痣"
+        "\n"
       ]
     },
     {
       "ID": 278,
       "Entries": [
-        "Tattoos / bruises -- 入れ墨/痣"
+        "\n"
       ]
     },
     {
       "ID": 279,
       "Entries": [
-        "Tattoo / bruise color -- 入れ墨/痣の色"
+        "\n"
       ]
     },
     {
       "ID": 280,
       "Entries": [
-        "----- {Tattoo / Bruise Adjustment -- -----｛入れ墨/痣の調整"
+        "\n"
       ]
     },
     {
       "ID": 281,
       "Entries": [
-        "Position up and down -- 位置 上下"
+        "\n"
       ]
     },
     {
       "ID": 282,
       "Entries": [
-        "Position left and right -- 位置 左右"
+        "\n"
       ]
     },
     {
       "ID": 283,
       "Entries": [
-        "angle -- 角度"
+        "\n"
       ]
     },
     {
       "ID": 284,
       "Entries": [
-        "Expansion rate -- 拡大率"
+        "\n"
       ]
     },
     {
       "ID": 285,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 286,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 287,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 288,
       "Entries": [
-        "----- {Details of skin color -- -----｛肌色詳細"
+        "\n"
       ]
     },
     {
       "ID": 289,
       "Entries": [
-        "Skin brightness -- 肌の明るさ"
+        "\n"
       ]
     },
     {
       "ID": 290,
       "Entries": [
-        "Skin color adjustment 1 -- 肌色調整1"
+        "\n"
       ]
     },
     {
       "ID": 291,
       "Entries": [
-        "Skin color adjustment 2 -- 肌色調整2"
+        "\n"
       ]
     },
     {
       "ID": 292,
       "Entries": [
-        "Skin color adjustment 3 -- 肌色調整3"
+        "\n"
       ]
     },
     {
       "ID": 293,
       "Entries": [
-        "Skin color adjustment 4 -- 肌色調整4"
+        "\n"
       ]
     },
     {
       "ID": 294,
       "Entries": [
-        "Nose bridge color -- 鼻梁の色"
+        "\n"
       ]
     },
     {
       "ID": 295,
       "Entries": [
-        "Cheek color -- 頬の色"
+        "\n"
       ]
     },
     {
       "ID": 296,
       "Entries": [
-        "Law line -- 法令線"
+        "\n"
       ]
     },
     {
       "ID": 297,
       "Entries": [
-        "} ----- -- ｝-----"
+        "\n"
       ]
     },
     {
       "ID": 298,
       "Entries": [
-        "Appearance preservation -- 外見保存"
+        "\n"
       ]
     },
     {
       "ID": 299,
       "Entries": [
-        "Appearance reading -- 外見読み込み"
+        "\n"
       ]
     },
     {
       "ID": 300,
       "Entries": [
-        "Initialize -- 初期化"
+        "\n"
       ]
     },
     {
       "ID": 301,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 302,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 303,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 304,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 305,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 306,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 307,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 308,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 309,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 310,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 311,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 312,
       "Entries": [
-        ""
+        "\n"
       ]
     },
     {
       "ID": 313,
       "Entries": [
-        ""
+        "\n"
       ]
     }
   ]

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/CharaInitParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/CharaInitParam.json
@@ -4,1219 +4,1219 @@
     {
       "ID": 9000,
       "Entries": [
-        "9000: Default_blood smoke -- 9000：デフォルト_血煙"
+        "\n"
       ]
     },
     {
       "ID": 9001,
       "Entries": [
-        "9001: Default_puppet -- 9001：デフォルト_傀儡"
+        "\n"
       ]
     },
     {
       "ID": 9002,
       "Entries": [
-        "9002: Default_Encha -- 9002：デフォルト_エンチャ"
+        "\n"
       ]
     },
     {
       "ID": 9010,
       "Entries": [
-        "9010: Default_All actions unbanned -- 9010：デフォルト_全アクション未解禁"
+        "\n"
       ]
     },
     {
       "ID": 9497,
       "Entries": [
-        "☆************************************************ ☆ -- ☆************************************************☆"
+        "\n"
       ]
     },
     {
       "ID": 9498,
       "Entries": [
-        "↓ For in-house debugging -- ↓社内デバッグ用"
+        "\n"
       ]
     },
     {
       "ID": 9499,
       "Entries": [
-        "☆************************************************ ☆ -- ☆************************************************☆"
+        "\n"
       ]
     },
     {
       "ID": 9600,
       "Entries": [
-        "9600: Default equipment_Blood smoke / Puppet -- 9600：デフォルト装備_血煙/傀儡"
+        "\n"
       ]
     },
     {
       "ID": 9602,
       "Entries": [
-        "9602: No killing _ for ninja killing check (trunk attack power MAX &amp; Jasuga confirmed playing ninja killing) -- 9602：無殺_忍殺チェック用（体幹攻撃力MAX & ジャスガ確定弾き忍殺）"
+        "\n"
       ]
     },
     {
       "ID": 9603,
       "Entries": [
-        "9603: Deadly _ for shinobi check (core attack power MAX &amp; Jasuga confirmed shinobi) -- 9603：必殺_忍殺チェック用（体幹攻撃力MAX & ジャスガ確定弾き忍殺）"
+        "\n"
       ]
     },
     {
       "ID": 9605,
       "Entries": [
-        "9605: Always dying -- 9605：常に瀕死"
+        "\n"
       ]
     },
     {
       "ID": 9606,
       "Entries": [
-        "9606: Always Jasuga -- 9606：常にジャスガ"
+        "\n"
       ]
     },
     {
       "ID": 9609,
       "Entries": [
-        "9609: Sub-weapon automatic equipment check -- 9609：サブウェポン自動装備チェック"
+        "\n"
       ]
     },
     {
       "ID": 9610,
       "Entries": [
-        "9610: Underwater cross confirmation equipment -- 9610：水中クロス確認装備"
+        "\n"
       ]
     },
     {
       "ID": 9620,
       "Entries": [
-        "9620: Default equipment _MPMAX_ For confirmation of resurrection technique -- 9620：デフォルト装備_MPMAX_復活の術確認用"
+        "\n"
       ]
     },
     {
       "ID": 9640,
       "Entries": [
-        "9640: AI sound confirmation -- 9640：AI音確認"
+        "\n"
       ]
     },
     {
       "ID": 9650,
       "Entries": [
-        "9650: Enchantment system confirmation A -- 9650：エンチャント系確認A"
+        "\n"
       ]
     },
     {
       "ID": 9651,
       "Entries": [
-        "9651: Enchantment system confirmation B -- 9651：エンチャント系確認B"
+        "\n"
       ]
     },
     {
       "ID": 9660,
       "Entries": [
-        "9660: Always bare hands -- 9660：常に素手"
+        "\n"
       ]
     },
     {
       "ID": 9997,
       "Entries": [
-        "☆************************************************ ☆ -- ☆************************************************☆"
+        "\n"
       ]
     },
     {
       "ID": 9998,
       "Entries": [
-        "↓ For checking the progress of the game -- ↓ゲーム進行チェック用"
+        "\n"
       ]
     },
     {
       "ID": 9999,
       "Entries": [
-        "☆************************************************ ☆ -- ☆************************************************☆"
+        "\n"
       ]
     },
     {
       "ID": 10000,
       "Entries": [
-        "Actual Player Character Start"
+        "Actual Player Character"
       ]
     },
     {
       "ID": 10010,
       "Entries": [
-        "10010: Castle -- 10010：城下"
+        "\n"
       ]
     },
     {
       "ID": 10020,
       "Entries": [
-        "10020: Samurai residence -- 10020：武家屋敷"
+        "\n"
       ]
     },
     {
       "ID": 10025,
       "Entries": [
-        "10025: After the samurai residence head family-first half of the main castle -- 10025：武家屋敷本家以降～本城前半"
+        "\n"
       ]
     },
     {
       "ID": 10030,
       "Entries": [
-        "10030: Honjo -- 10030：本城"
+        "\n"
       ]
     },
     {
       "ID": 10040,
       "Entries": [
-        "10040: Hidden prison -- 10040：隠し牢"
+        "\n"
       ]
     },
     {
       "ID": 10050,
       "Entries": [
-        "10050: Dungeon -- 10050：地下牢"
+        "\n"
       ]
     },
     {
       "ID": 10060,
       "Entries": [
-        "10060: Temple -- 10060：寺"
+        "\n"
       ]
     },
     {
       "ID": 10070,
       "Entries": [
-        "10070: Valley -- 10070：渓谷"
+        "\n"
       ]
     },
     {
       "ID": 10080,
       "Entries": [
-        "10080: Lower valley -- 10080：渓谷下層"
+        "\n"
       ]
     },
     {
       "ID": 10090,
       "Entries": [
-        "10090: Sick village -- 10090：病み村"
+        "\n"
       ]
     },
     {
       "ID": 10100,
       "Entries": [
-        "10100: Honjo_Ninja army invasion -- 10100：本城_忍軍襲来時"
+        "\n"
       ]
     },
     {
       "ID": 10110,
       "Entries": [
-        "10110: Samurai residence truth edition -- 10110：武家屋敷真相編"
+        "\n"
       ]
     },
     {
       "ID": 10120,
       "Entries": [
-        "10120: Submerged city_no hidden sacred treasure -- 10120：水没都_隠し神器なし"
+        "\n"
       ]
     },
     {
       "ID": 10121,
       "Entries": [
-        "10121: Submerged city_with hidden sacred treasure -- 10121：水没都_隠し神器あり"
+        "\n"
       ]
     },
     {
       "ID": 10130,
       "Entries": [
-        "10130: When Honjo_Tokugawa invades -- 10130：本城_徳川襲来時"
+        "\n"
       ]
     },
     {
       "ID": 10140,
       "Entries": [
-        "10140: Hidden prison _ At the time of the Tokugawa invasion -- 10140：隠し牢_徳川襲来時"
+        "\n"
       ]
     },
     {
       "ID": 10141,
       "Entries": [
-        "10141: Hidden prison_When Tokugawa attacks_Mermaid dragon tears (God) -- 10141：隠し牢_徳川襲来時_人魚竜の涙（神）"
+        "\n"
       ]
     },
     {
       "ID": 10150,
       "Entries": [
-        "10150: Castle_At the time of the Tokugawa invasion -- 10150：城下_徳川襲来時"
+        "\n"
       ]
     },
     {
       "ID": 10160,
       "Entries": [
-        "10160: Game clear -- 10160：ゲームクリア"
+        "\n"
       ]
     },
     {
       "ID": 10170,
       "Entries": [
-        "10170: Midfield_Morning -- 10170：中盤_朝"
+        "\n"
       ]
     },
     {
       "ID": 10171,
       "Entries": [
-        "10171: Mid-day_noon -- 10171：中盤_昼"
+        "\n"
       ]
     },
     {
       "ID": 10172,
       "Entries": [
-        "10172: Midfield_Evening -- 10172：中盤_夕"
+        "\n"
       ]
     },
     {
       "ID": 11000,
       "Entries": [
-        "11000: Enemy Check_New Game -- 11000：敵チェック_ニューゲーム"
+        "\n"
       ]
     },
     {
       "ID": 11010,
       "Entries": [
-        "11010: Enemy check_Castle -- 11010：敵チェック_城下"
+        "\n"
       ]
     },
     {
       "ID": 11020,
       "Entries": [
-        "11020: Enemy check_Samurai residence -- 11020：敵チェック_武家屋敷"
+        "\n"
       ]
     },
     {
       "ID": 11025,
       "Entries": [
-        "11025: Enemy check_Samurai residence Honke and later-first half of Honjo -- 11025：敵チェック_武家屋敷本家以降～本城前半"
+        "\n"
       ]
     },
     {
       "ID": 11030,
       "Entries": [
-        "11030: Enemy check_Honjo -- 11030：敵チェック_本城"
+        "\n"
       ]
     },
     {
       "ID": 11040,
       "Entries": [
-        "11040: Enemy Check_Hidden Prison -- 11040：敵チェック_隠し牢"
+        "\n"
       ]
     },
     {
       "ID": 11050,
       "Entries": [
-        "11050: Enemy Check_Dungeon -- 11050：敵チェック_地下牢"
+        "\n"
       ]
     },
     {
       "ID": 11060,
       "Entries": [
-        "11060: Enemy check_temple -- 11060：敵チェック_寺"
+        "\n"
       ]
     },
     {
       "ID": 11070,
       "Entries": [
-        "11070: Enemy Check_Valley -- 11070：敵チェック_渓谷"
+        "\n"
       ]
     },
     {
       "ID": 11080,
       "Entries": [
-        "11080: Enemy check_Valley lower layer -- 11080：敵チェック_渓谷下層"
+        "\n"
       ]
     },
     {
       "ID": 11090,
       "Entries": [
-        "11090: Enemy Check_Sick Village -- 11090：敵チェック_病み村"
+        "\n"
       ]
     },
     {
       "ID": 11100,
       "Entries": [
-        "11100: Enemy check_Honjo_Ninja army invasion -- 11100：敵チェック_本城_忍軍襲来時"
+        "\n"
       ]
     },
     {
       "ID": 11110,
       "Entries": [
-        "11110: Enemy check_Samurai residence truth edition -- 11110：敵チェック_武家屋敷真相編"
+        "\n"
       ]
     },
     {
       "ID": 11120,
       "Entries": [
-        "11120: Enemy check_Submerged city_No hidden sacred treasure -- 11120：敵チェック_水没都_隠し神器なし"
+        "\n"
       ]
     },
     {
       "ID": 11121,
       "Entries": [
-        "11121: Enemy check_Submerged city_Hidden sacred treasure -- 11121：敵チェック_水没都_隠し神器あり"
+        "\n"
       ]
     },
     {
       "ID": 11130,
       "Entries": [
-        "11130: Enemy check_Honjo_Tokugawa invasion -- 11130：敵チェック_本城_徳川襲来時"
+        "\n"
       ]
     },
     {
       "ID": 11140,
       "Entries": [
-        "11140: Enemy check_Hidden prison_When Tokugawa invades -- 11140：敵チェック_隠し牢_徳川襲来時"
+        "\n"
       ]
     },
     {
       "ID": 11141,
       "Entries": [
-        "11141: Enemy check_Hidden prison_When Tokugawa attacks_Mermaid dragon tears (God) -- 11141：敵チェック_隠し牢_徳川襲来時_人魚竜の涙（神）"
+        "\n"
       ]
     },
     {
       "ID": 11150,
       "Entries": [
-        "11150: Enemy check_Castle_Tokugawa invasion -- 11150：敵チェック_城下_徳川襲来時"
+        "\n"
       ]
     },
     {
       "ID": 11160,
       "Entries": [
-        "11160: Enemy check_Game clear -- 11160：敵チェック_ゲームクリア"
+        "\n"
       ]
     },
     {
       "ID": 11161,
       "Entries": [
-        "11161: Enemy check-early lap _2 (castle) -- 11161：敵チェック_2周目序盤（城下）"
+        "\n"
       ]
     },
     {
       "ID": 11162,
       "Entries": [
-        "11162: Enemy check-Middle of the second lap (valley) -- 11162：敵チェック_2周目中盤（渓谷）"
+        "\n"
       ]
     },
     {
       "ID": 11163,
       "Entries": [
-        "11163: Enemy check-The end of the second lap (hidden prison_Tokugawa invasion) -- 11163：敵チェック_2周目終盤（隠し牢_徳川襲来）"
+        "\n"
       ]
     },
     {
       "ID": 11164,
       "Entries": [
-        "11164: Enemy check _ 3rd lap early (castle) -- 11164：敵チェック_3周目序盤（城下）"
+        "\n"
       ]
     },
     {
       "ID": 11165,
       "Entries": [
-        "11165: Enemy check_Middle of the 3rd lap (valley) -- 11165：敵チェック_3周目中盤（渓谷）"
+        "\n"
       ]
     },
     {
       "ID": 11166,
       "Entries": [
-        "11166: Enemy check_late 3rd lap (hidden prison_Tokugawa invasion) -- 11166：敵チェック_3周目終盤（隠し牢_徳川襲来）"
+        "\n"
       ]
     },
     {
       "ID": 11167,
       "Entries": [
-        "11167: Enemy check_early 4th lap (castle) -- 11167：敵チェック_4周目序盤（城下）"
+        "\n"
       ]
     },
     {
       "ID": 11168,
       "Entries": [
-        "11168: Enemy check_Mid 4th lap (valley) -- 11168：敵チェック_4周目中盤（渓谷）"
+        "\n"
       ]
     },
     {
       "ID": 11169,
       "Entries": [
-        "11169: Enemy check_late 4th lap (hidden prison_Tokugawa invasion) -- 11169：敵チェック_4周目終盤（隠し牢_徳川襲来）"
+        "\n"
       ]
     },
     {
       "ID": 11170,
       "Entries": [
-        "11170: Enemy check_early 5th lap (castle) -- 11170：敵チェック_5周目序盤（城下）"
+        "\n"
       ]
     },
     {
       "ID": 11171,
       "Entries": [
-        "11171: Enemy check_Middle of lap 5 (valley) -- 11171：敵チェック_5周目中盤（渓谷）"
+        "\n"
       ]
     },
     {
       "ID": 11172,
       "Entries": [
-        "11172: Enemy check_late 5th lap (hidden prison_Tokugawa invasion) -- 11172：敵チェック_5周目終盤（隠し牢_徳川襲来）"
+        "\n"
       ]
     },
     {
       "ID": 11173,
       "Entries": [
-        "11173: Enemy check_early on lap 6 (castle) -- 11173：敵チェック_6周目序盤（城下）"
+        "\n"
       ]
     },
     {
       "ID": 11174,
       "Entries": [
-        "11174: Enemy check_Mid 6th lap (valley) -- 11174：敵チェック_6周目中盤（渓谷）"
+        "\n"
       ]
     },
     {
       "ID": 11175,
       "Entries": [
-        "11175: Enemy check_6th lap counter stop -- 11175：敵チェック_6周目カンスト"
+        "\n"
       ]
     },
     {
       "ID": 14997,
       "Entries": [
-        "☆************************************************ ☆ -- ☆************************************************☆"
+        "\n"
       ]
     },
     {
       "ID": 14998,
       "Entries": [
-        "↓ For cutscene / PV shooting -- ↓カットシーン/PV撮影用"
+        "\n"
       ]
     },
     {
       "ID": 14999,
       "Entries": [
-        "☆************************************************ ☆ -- ☆************************************************☆"
+        "\n"
       ]
     },
     {
       "ID": 15000,
       "Entries": [
-        "15000: Left hand defect -- 15000：左手欠損"
+        "\n"
       ]
     },
     {
       "ID": 15010,
       "Entries": [
-        "15010: The hero who became a Buddhist priest -- 15010：仏師になった主人公"
+        "\n"
       ]
     },
     {
       "ID": 15020,
       "Entries": [
-        "15020: barefoot -- 15020：裸足"
+        "\n"
       ]
     },
     {
       "ID": 15030,
       "Entries": [
-        "15030: Headless hero -- 15030：首なし主人公"
+        "\n"
       ]
     },
     {
       "ID": 15040,
       "Entries": [
-        "15040: Left hand prosthesis_high resolution -- 15040：左手義手_高解像度"
+        "\n"
       ]
     },
     {
       "ID": 16997,
       "Entries": [
-        "☆************************************************ ☆ -- ☆************************************************☆"
+        "\n"
       ]
     },
     {
       "ID": 16998,
       "Entries": [
-        "↓ For checking prosthetic hand ninja (left hand weapon) -- ↓義手忍具（左手武器）チェック用"
+        "\n"
       ]
     },
     {
       "ID": 16999,
       "Entries": [
-        "☆************************************************ ☆ -- ☆************************************************☆"
+        "\n"
       ]
     },
     {
       "ID": 17000,
       "Entries": [
-        "17000: Shuriken LV1 / 2 / 3-A -- 17000：手裏剣LV1/2/3-A"
+        "\n"
       ]
     },
     {
       "ID": 17001,
       "Entries": [
-        "17001: Shuriken LV3-B / 3-C / 4 -- 17001：手裏剣LV3-B/3-C/4"
+        "\n"
       ]
     },
     {
       "ID": 17002,
       "Entries": [
-        "17002: Shuriken LV3-C_ Money Throw LV0 -- 17002：手裏剣LV3-C_銭投げLV0"
+        "\n"
       ]
     },
     {
       "ID": 17003,
       "Entries": [
-        "17003: Shuriken LV3-C_ Money Throw LV1 -- 17003：手裏剣LV3-C_銭投げLV1"
+        "\n"
       ]
     },
     {
       "ID": 17004,
       "Entries": [
-        "17004: Shuriken LV3-C_ Money Throw LV2 -- 17004：手裏剣LV3-C_銭投げLV2"
+        "\n"
       ]
     },
     {
       "ID": 17005,
       "Entries": [
-        "17005: Shuriken LV3-C_ Money Throw LV3 -- 17005：手裏剣LV3-C_銭投げLV3"
+        "\n"
       ]
     },
     {
       "ID": 17100,
       "Entries": [
-        "17100: Firecracker LV1 / 2 / 3-A -- 17100：爆竹LV1/2/3-A"
+        "\n"
       ]
     },
     {
       "ID": 17101,
       "Entries": [
-        "17101: Firecracker LV3-B -- 17101：爆竹LV3-B"
+        "\n"
       ]
     },
     {
       "ID": 17200,
       "Entries": [
-        "17200: Ignition LV1 / 2/3 -- 17200：発火LV1/2/3"
+        "\n"
       ]
     },
     {
       "ID": 17201,
       "Entries": [
-        "17201: Ignition LV4 -- 17201：発火LV4"
+        "\n"
       ]
     },
     {
       "ID": 17300,
       "Entries": [
-        "17300: Ax LV1 / 2/3 -- 17300：斧LV1/2/3"
+        "\n"
       ]
     },
     {
       "ID": 17301,
       "Entries": [
-        "17301: Ax LV4 -- 17301：斧LV4"
+        "\n"
       ]
     },
     {
       "ID": 17400,
       "Entries": [
-        "17400: Kodachi LV1 / 2 / 3-A -- 17400：小太刀LV1/2/3-A"
+        "\n"
       ]
     },
     {
       "ID": 17401,
       "Entries": [
-        "17401: Kodachi LV3-B -- 17401：小太刀LV3-B"
+        "\n"
       ]
     },
     {
       "ID": 17500,
       "Entries": [
-        "17500: Spear LV1 / 2-A / 3-A -- 17500：槍LV1/2-A/3-A"
+        "\n"
       ]
     },
     {
       "ID": 17501,
       "Entries": [
-        "17501: Spear LV2-B / 3-B -- 17501：槍LV2-B/3-B"
+        "\n"
       ]
     },
     {
       "ID": 17600,
       "Entries": [
-        "17600: Transformation LV1 / 2/3 -- 17600：変わり身LV1/2/3"
+        "\n"
       ]
     },
     {
       "ID": 17700,
       "Entries": [
-        "17700: Iron fan LV1 / 2 / 3-A -- 17700：鉄扇LV1/2/3-A"
+        "\n"
       ]
     },
     {
       "ID": 17701,
       "Entries": [
-        "17701: Iron fan LV3-B -- 17701：鉄扇LV3-B"
+        "\n"
       ]
     },
     {
       "ID": 17800,
       "Entries": [
-        "17800: Enemy turning LV1 / 2/3 -- 17800：敵回しLV1/2/3"
+        "\n"
       ]
     },
     {
       "ID": 17900,
       "Entries": [
-        "17900: Finger whistle LV1 / 2/3 -- 17900：指笛LV1/2/3"
+        "\n"
       ]
     },
     {
       "ID": 18000,
       "Entries": [
-        "18000: Shuriken / Firecracker / Ignition -- 18000：手裏剣/爆竹/発火"
+        "\n"
       ]
     },
     {
       "ID": 18100,
       "Entries": [
-        "18100: Ax / Kodachi / Ignition -- 18100：斧/小太刀/発火"
+        "\n"
       ]
     },
     {
       "ID": 18200,
       "Entries": [
-        "18200: Spear / Transformation / Ignition -- 18200：槍/変わり身/発火"
+        "\n"
       ]
     },
     {
       "ID": 18300,
       "Entries": [
-        "18300: Iron fan / enemy turning / firing -- 18300：鉄扇/敵回し/発火"
+        "\n"
       ]
     },
     {
       "ID": 18400,
       "Entries": [
-        "18400: Finger whistle / ignition / spear -- 18400：指笛/発火/槍（なぎ払い）"
+        "\n"
       ]
     },
     {
       "ID": 18500,
       "Entries": [
-        "18500: Additive Weapon Anime Test: Prepared Ax / Prepared Spear -- 18500：加算武器アニメテスト：仕込み斧・仕込み槍"
+        "\n"
       ]
     },
     {
       "ID": 18600,
       "Entries": [
-        "18600: No derivative attack_Shuriken / Firecracker / Ignition -- 18600：派生攻撃なし_手裏剣/爆竹/発火"
+        "\n"
       ]
     },
     {
       "ID": 18601,
       "Entries": [
-        "18601: No derivative attack_ax / kodachi / transformation -- 18601：派生攻撃なし_斧/小太刀/変わり身"
+        "\n"
       ]
     },
     {
       "ID": 18602,
       "Entries": [
-        "18602: No derivative attack_Iron fan / Enemy turn / Finger whistle -- 18602：派生攻撃なし_鉄扇/敵回し/指笛"
+        "\n"
       ]
     },
     {
       "ID": 18603,
       "Entries": [
-        "18603: No derivative attack_Spear A / Spear B -- 18603：派生攻撃なし_槍A/槍B"
+        "\n"
       ]
     },
     {
       "ID": 19997,
       "Entries": [
-        "☆************************************************ ☆ -- ☆************************************************☆"
+        "\n"
       ]
     },
     {
       "ID": 19998,
       "Entries": [
-        "↓ For skill check -- ↓スキルチェック用"
+        "\n"
       ]
     },
     {
       "ID": 19999,
       "Entries": [
-        "☆************************************************ ☆ -- ☆************************************************☆"
+        "\n"
       ]
     },
     {
       "ID": 20000,
       "Entries": [
-        "20000: Skill unbanned: No skill points -- 20000：スキル未解禁：スキルポイントなし"
+        "\n"
       ]
     },
     {
       "ID": 20001,
       "Entries": [
-        "20001: Skill unbanned: 5 skill points -- 20001：スキル未解禁：スキルポイント5個"
+        "\n"
       ]
     },
     {
       "ID": 20002,
       "Entries": [
-        "20002: Skills unbanned: Skill points MAX -- 20002：スキル未解禁：スキルポイントMAX"
+        "\n"
       ]
     },
     {
       "ID": 29997,
       "Entries": [
-        "☆************************************************ ☆ -- ☆************************************************☆"
+        "\n"
       ]
     },
     {
       "ID": 29998,
       "Entries": [
-        "↓ For item check -- ↓アイテムチェック用"
+        "\n"
       ]
     },
     {
       "ID": 29999,
       "Entries": [
-        "☆************************************************ ☆ -- ☆************************************************☆"
+        "\n"
       ]
     },
     {
       "ID": 30000,
       "Entries": [
-        "30000: HP system A (est / regen / elixir) -- 30000：HP系A（エスト/リジェネ/エリクサー）"
+        "\n"
       ]
     },
     {
       "ID": 30001,
       "Entries": [
-        "30001: HP system B (Ohagi / Ohagi (Sorry) / Persimmon / Lower man&#39;s persimmon) -- 30001：HP系B（おはぎ/おはぎ（惜別）/柿/下男の柿）"
+        "\n"
       ]
     },
     {
       "ID": 30003,
       "Entries": [
-        "30003: HP system C (children&#39;s rice / light snow&#39;s children&#39;s rice) + five-colored rice -- 30003：HP系C（稚児米/細雪の稚児米） + 五色米"
+        "\n"
       ]
     },
     {
       "ID": 30010,
       "Entries": [
-        "30010: Abnormal condition system (virus release / flame release / madness release / electric shock delay / self-disease poison) -- 30010：状態異常系（病毒解除/炎上解除/発狂解除/感電遅延/自病毒）"
+        "\n"
       ]
     },
     {
       "ID": 30020,
       "Entries": [
-        "30020: Abnormal condition system (poison prevention / flame prevention / madness prevention / suicide / infinite suicide) -- 30020：状態異常系（病毒予防/炎上予防/発狂予防/自殺/無限の自殺）"
+        "\n"
       ]
     },
     {
       "ID": 30030,
       "Entries": [
-        "30030: Strengthening system A (attack / attack with demerit / defense / trunk / stealth / anti-spirit) -- 30030：強化系A（攻撃/デメリット付き攻撃/防御/体幹/ステルス/対霊）"
+        "\n"
       ]
     },
     {
       "ID": 30031,
       "Entries": [
-        "30031: Reinforcement system B (infinite use form consumption Ver. + Weird young water thrombus) -- 30031：強化系B（無限使用形代消費Ver. + 変若水血栓）"
+        "\n"
       ]
     },
     {
       "ID": 30040,
       "Entries": [
-        "30040: Attack system (stone / sand / oil / illusion release) -- 30040：攻撃系（石/砂/油/幻術解除）"
+        "\n"
       ]
     },
     {
       "ID": 30050,
       "Entries": [
-        "30050: Amulet system (money acquisition amount UP / resurrection right acquisition amount UP / item drop rate UP / shape fee drop rate UP / white paper balloon) -- 30050：お守り系（お金入手量UP/復活権入手量UP/アイテムドロップ率UP/形代ドロップ率UP/白らっぱ紙風船）"
+        "\n"
       ]
     },
     {
       "ID": 30060,
       "Entries": [
-        "30060: Resource acquisition system (small gold nugget / medium gold nugget / large gold nugget / resurrection right bullion / female player resurrection right bullion) -- 30060：リソース入手系（金塊小/金塊中/金塊大/復活権塊/女奏者の復活権塊）"
+        "\n"
       ]
     },
     {
       "ID": 30070,
       "Entries": [
-        "30070: Form conversion system (form conversion) -- 30070：形代変換系（形代変換）"
+        "\n"
       ]
     },
     {
       "ID": 30080,
       "Entries": [
-        "30080: Others (Telescope / Redo bell / Buddha image of return / Release of flame (Tokugawa)) -- 30080：その他（遠眼鏡/やりなおし鈴/帰還の仏像/炎上解除（徳川））"
+        "\n"
       ]
     },
     {
       "ID": 30090,
       "Entries": [
-        "30090: Other (bell demon / dragon cough treatment) -- 30090：その他（鐘鬼/竜咳治療）"
+        "\n"
       ]
     },
     {
       "ID": 30100,
       "Entries": [
-        "30100: VP appearance item 1 -- 30100：VP登場アイテム1"
+        "\n"
       ]
     },
     {
       "ID": 30101,
       "Entries": [
-        "30101: VP appearance item 2 -- 30101：VP登場アイテム2"
+        "\n"
       ]
     },
     {
       "ID": 39997,
       "Entries": [
-        "☆************************************************ ☆ -- ☆************************************************☆"
+        "\n"
       ]
     },
     {
       "ID": 39998,
       "Entries": [
-        "↓ For checking the deadly sword -- ↓必殺剣確認用"
+        "\n"
       ]
     },
     {
       "ID": 39999,
       "Entries": [
-        "☆************************************************ ☆ -- ☆************************************************☆"
+        "\n"
       ]
     },
     {
       "ID": 40000,
       "Entries": [
-        "40000: School technique: None -- 40000：流派技：なし"
+        "\n"
       ]
     },
     {
       "ID": 40001,
       "Entries": [
-        "40001: School technique: Rotating slash -- 40001：流派技：回転斬り"
+        "\n"
       ]
     },
     {
       "ID": 40002,
       "Entries": [
-        "40002: School technique: Jumping and slashing -- 40002：流派技：飛びかかり斬り"
+        "\n"
       ]
     },
     {
       "ID": 40003,
       "Entries": [
-        "40003: School technique: Jump slash + 1_ slash retreat added -- 40003：流派技：飛びかかり斬り+1_斬り退がり追加"
+        "\n"
       ]
     },
     {
       "ID": 40004,
       "Entries": [
-        "40004: School technique: Face-to-face -- 40004：流派技：面打ち"
+        "\n"
       ]
     },
     {
       "ID": 40005,
       "Entries": [
-        "40005: School technique: Face-up + 102 4th step added -- 40005：流派技：面打ち+1_2段目追加"
+        "\n"
       ]
     },
     {
       "ID": 40006,
       "Entries": [
-        "40006: School technique: Kensei Iai -- 40006：流派技：剣聖居合"
+        "\n"
       ]
     },
     {
       "ID": 40007,
       "Entries": [
-        "40007: School technique: Iai -- 40007：流派技：居合"
+        "\n"
       ]
     },
     {
       "ID": 40009,
       "Entries": [
-        "40009: School technique: Invisible Iai continuous attack -- 40009：流派技：見えない居合連撃"
+        "\n"
       ]
     },
     {
       "ID": 40010,
       "Entries": [
-        "40010: School technique: Eight-flying rush -- 40010：流派技：八艘飛びラッシュ"
+        "\n"
       ]
     },
     {
       "ID": 40011,
       "Entries": [
-        "40011: School technique: Eight-flying rush + 1_ increase in the number of stages -- 40011：流派技：八艘飛びラッシュ+1_段数増加"
+        "\n"
       ]
     },
     {
       "ID": 40012,
       "Entries": [
-        "40012: School technique: Immortal slash -- 40012：流派技：不死斬り"
+        "\n"
       ]
     },
     {
       "ID": 40013,
       "Entries": [
-        "40013: School technique: Immortal slash + 1_ Reservoir added -- 40013：流派技：不死斬り+1_溜め追加"
+        "\n"
       ]
     },
     {
       "ID": 40014,
       "Entries": [
-        "40014: School technique: Kick rush -- 40014：流派技：蹴りラッシュ"
+        "\n"
       ]
     },
     {
       "ID": 40015,
       "Entries": [
-        "40015: School technique: Kick rush + 1_ increase in number of steps -- 40015：流派技：蹴りラッシュ+1_段数増加"
+        "\n"
       ]
     },
     {
       "ID": 40016,
       "Entries": [
-        "40016: School technique: Fist attack -- 40016：流派技：拳撃"
+        "\n"
       ]
     },
     {
       "ID": 40017,
       "Entries": [
-        "40017: School technique: Fist attack + 1_ Yasushi Tetsuyama added -- 40017：流派技：拳撃+1_鉄山靠追加"
+        "\n"
       ]
     },
     {
       "ID": 40018,
       "Entries": [
-        "40018: School technique: Shinobi stab -- 40018：流派技：忍刺し"
+        "\n"
       ]
     },
     {
       "ID": 40019,
       "Entries": [
-        "40019: School technique: Shinobi stab + 1_Descent rotation slash added -- 40019：流派技：忍刺し+1_降下回転斬り追加"
+        "\n"
       ]
     },
     {
       "ID": 40020,
       "Entries": [
-        "40020: School technique: New technique -- 40020：流派技：新技"
+        "\n"
       ]
     },
     {
       "ID": 40021,
       "Entries": [
-        "40021: School Technique: New Technique_Flame / Spirit / Blood Encha -- 40021：流派技：新技_炎/霊/血エンチャ"
+        "\n"
       ]
     },
     {
       "ID": 40022,
       "Entries": [
-        "40022: School technique: New technique_Orange style / Gold style / Blood enchantment -- 40022：流派技：新技_橙風/金風/血エンチャ"
+        "\n"
       ]
     },
     {
       "ID": 89997,
       "Entries": [
-        "☆************************************************ ☆ -- ☆************************************************☆"
+        "\n"
       ]
     },
     {
       "ID": 89998,
       "Entries": [
-        "↓ For other checks -- ↓その他チェック用"
+        "\n"
       ]
     },
     {
       "ID": 89999,
       "Entries": [
-        "☆************************************************ ☆ -- ☆************************************************☆"
+        "\n"
       ]
     },
     {
       "ID": 90000,
       "Entries": [
-        "90000: Anime test: Damage_levels 1-7 -- 90000：アニメテスト：ダメージ_レベル1～7"
+        "\n"
       ]
     },
     {
       "ID": 90001,
       "Entries": [
-        "90001: Anime test: Damage_levels 8-11 + Break -- 90001：アニメテスト：ダメージ_レベル8～11 + 崩し"
+        "\n"
       ]
     },
     {
       "ID": 90002,
       "Entries": [
-        "90002: Anime test: Damage_Burning -- 90002：アニメテスト：ダメージ_炎上"
+        "\n"
       ]
     },
     {
       "ID": 90010,
       "Entries": [
-        "90010: Item / Resource Item Acquisition Test -- 90010：アイテム/リソースアイテム入手テスト"
+        "\n"
       ]
     },
     {
       "ID": 90997,
       "Entries": [
-        "☆************************************************ ☆ -- ☆************************************************☆"
+        "\n"
       ]
     },
     {
       "ID": 90998,
       "Entries": [
-        "↓ For costume confirmation -- ↓コスチューム確認用"
+        "\n"
       ]
     },
     {
       "ID": 90999,
       "Entries": [
-        "☆************************************************ ☆ -- ☆************************************************☆"
+        "\n"
       ]
     },
     {
       "ID": 91000,
       "Entries": [
-        "91000: Costume_Shura_No Immortal Slash -- 91000：コスチューム_修羅_不死斬りなし"
+        "\n"
       ]
     },
     {
       "ID": 91001,
       "Entries": [
-        "91001: Costume_Shura_Immortal Slash -- 91001：コスチューム_修羅_不死斬りあり"
+        "\n"
       ]
     },
     {
       "ID": 91002,
       "Entries": [
-        "91002: Costume_Shura_Hair confirmation (with immortal slash) -- 91002：コスチューム_修羅_髪確認（不死斬りあり）"
+        "\n"
       ]
     },
     {
       "ID": 91010,
       "Entries": [
-        "91010: Costume_Ashiname_No Immortal Slash -- 91010：コスチューム_葦名_不死斬りなし"
+        "\n"
       ]
     },
     {
       "ID": 91011,
       "Entries": [
-        "91011: Costume_Ashiname_Immortal slash -- 91011：コスチューム_葦名_不死斬りあり"
+        "\n"
       ]
     },
     {
       "ID": 91020,
       "Entries": [
-        "91020: Costume_Tengu_No Immortal Slash -- 91020：コスチューム_天狗_不死斬りなし"
+        "\n"
       ]
     },
     {
       "ID": 91021,
       "Entries": [
-        "91021: Costume_Tengu_Immortal Slash -- 91021：コスチューム_天狗_不死斬りあり"
+        "\n"
       ]
     },
     {
       "ID": 91997,
       "Entries": [
-        "☆************************************************ ☆ -- ☆************************************************☆"
+        "\n"
       ]
     },
     {
       "ID": 91998,
       "Entries": [
-        "↓ Stadia version -- ↓Stadia版"
+        "\n"
       ]
     },
     {
       "ID": 91999,
       "Entries": [
-        "☆************************************************ ☆ -- ☆************************************************☆"
+        "\n"
       ]
     },
     {
       "ID": 92000,
       "Entries": [
-        "92000: Stadia_α_ShuraEndingBuild -- 92000：Stadia_α_ShuraEndingBuild"
+        "\n"
       ]
     },
     {
       "ID": 92001,
       "Entries": [
-        "92001: Stadia_β_Inner Genichiro -- 92001：Stadia_β_Inner Genichiro"
+        "\n"
       ]
     },
     {
       "ID": 92002,
       "Entries": [
-        "92002: Stadia_β_Inner Father -- 92002：Stadia_β_Inner Father"
+        "\n"
       ]
     },
     {
       "ID": 92010,
       "Entries": [
-        "92010: All routes -- 92010：全ルート"
+        "\n"
       ]
     },
     {
       "ID": 199997,
       "Entries": [
-        "☆ ********************************************** ☆ -- ☆ **********************************************☆"
+        "\n"
       ]
     },
     {
       "ID": 199998,
       "Entries": [
-        "↓ E3 -- ↓E3"
+        "\n"
       ]
     },
     {
       "ID": 199999,
       "Entries": [
-        "☆ ********************************************** ☆ -- ☆ **********************************************☆"
+        "\n"
       ]
     },
     {
       "ID": 200000,
       "Entries": [
-        "200000: E3_Presentation_Shuriken / Ignition / Ax -- 200000：E3_プレゼン_手裏剣/発火/斧"
+        "\n"
       ]
     },
     {
       "ID": 200001,
       "Entries": [
-        "200001: E3_Firecracker / Kodachi / Iron fan -- 200001：E3_爆竹/小太刀/鉄扇"
+        "\n"
       ]
     },
     {
       "ID": 200002,
       "Entries": [
-        "200002: E3_Transformation / Enemy Turn / Spear -- 200002：E3_変わり身/敵回し/槍"
+        "\n"
       ]
     },
     {
       "ID": 200003,
       "Entries": [
-        "200003: E3_finger whistle -- 200003：E3_指笛"
+        "\n"
       ]
     },
     {
       "ID": 200010,
       "Entries": [
-        "200010: E3_Trial_Shuriken / Fire / Ax + Immortal Slash -- 200010：E3_試遊_手裏剣/発火/斧 + 不死斬り"
+        "\n"
       ]
     }
   ]

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/EquipParamAccessory.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/EquipParamAccessory.json
@@ -4,7 +4,7 @@
     {
       "ID": 0,
       "Entries": [
-        "test -- test"
+        ""
       ]
     }
   ]

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/EquipParamGoods.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/EquipParamGoods.json
@@ -160,7 +160,7 @@
     {
       "ID": 500,
       "Entries": [
-        "Remaining machine"
+        "Unseen Aid Remaining"
       ]
     },
     {

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/EquipParamGoods.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/EquipParamGoods.json
@@ -1834,313 +1834,313 @@
     {
       "ID": 910000,
       "Entries": [
-        "Debugging Skills Lifted: New Game -- デバッグ用スキル解禁：ニューゲーム"
+        ""
       ]
     },
     {
       "ID": 910010,
       "Entries": [
-        "Debugging skills lifted: Castle -- デバッグ用スキル解禁：城下"
+        ""
       ]
     },
     {
       "ID": 910020,
       "Entries": [
-        "Debugging skills lifted: Samurai residence -- デバッグ用スキル解禁：武家屋敷"
+        ""
       ]
     },
     {
       "ID": 910030,
       "Entries": [
-        "Debugging skills lifted: Honjo -- デバッグ用スキル解禁：本城"
+        ""
       ]
     },
     {
       "ID": 910040,
       "Entries": [
-        "Debugging skills lifted: Hidden prison -- デバッグ用スキル解禁：隠し牢"
+        ""
       ]
     },
     {
       "ID": 910050,
       "Entries": [
-        "Debugging skills lifted: Dungeon -- デバッグ用スキル解禁：地下牢"
+        ""
       ]
     },
     {
       "ID": 910060,
       "Entries": [
-        "Debugging skills lifted: Temple -- デバッグ用スキル解禁：寺"
+        ""
       ]
     },
     {
       "ID": 910070,
       "Entries": [
-        "Debugging skills lifted: Valley -- デバッグ用スキル解禁：渓谷"
+        ""
       ]
     },
     {
       "ID": 910080,
       "Entries": [
-        "Debugging skills lifted: Lower valley -- デバッグ用スキル解禁：渓谷下層"
+        ""
       ]
     },
     {
       "ID": 910090,
       "Entries": [
-        "Debugging Skills Lifted: Sick Village -- デバッグ用スキル解禁：病み村"
+        ""
       ]
     },
     {
       "ID": 910100,
       "Entries": [
-        "Debugging skill lifted: Honjo_Ninja army invasion -- デバッグ用スキル解禁：本城_忍軍襲来時"
+        ""
       ]
     },
     {
       "ID": 910110,
       "Entries": [
-        "Debugging skill lifted: Submerged city -- デバッグ用スキル解禁：水没都"
+        ""
       ]
     },
     {
       "ID": 910120,
       "Entries": [
-        "Debugging skills lifted: Honjo_Tokugawa invasion -- デバッグ用スキル解禁：本城_徳川襲来時"
+        ""
       ]
     },
     {
       "ID": 910130,
       "Entries": [
-        "Debugging skill lifted: Hidden prison _ When Tokugawa attacks -- デバッグ用スキル解禁：隠し牢_徳川襲来時"
+        ""
       ]
     },
     {
       "ID": 910140,
       "Entries": [
-        "Debugging skills lifted: Castle_Tokugawa invasion -- デバッグ用スキル解禁：城下_徳川襲来時"
+        ""
       ]
     },
     {
       "ID": 910150,
       "Entries": [
-        "Debugging skills lifted: Game clear -- デバッグ用スキル解禁：ゲームクリア"
+        ""
       ]
     },
     {
       "ID": 920000,
       "Entries": [
-        "Debugging skills lifted: New game for checking enemies -- デバッグ用スキル解禁：敵チェック用ニューゲーム"
+        ""
       ]
     },
     {
       "ID": 920010,
       "Entries": [
-        "Debugging skill lifted: Castle for checking enemies -- デバッグ用スキル解禁：敵チェック用城下"
+        ""
       ]
     },
     {
       "ID": 920020,
       "Entries": [
-        "Debugging skills lifted: Samurai residence for checking enemies -- デバッグ用スキル解禁：敵チェック用武家屋敷"
+        ""
       ]
     },
     {
       "ID": 920030,
       "Entries": [
-        "Debugging skill lifted: Honjo for checking enemies -- デバッグ用スキル解禁：敵チェック用本城"
+        ""
       ]
     },
     {
       "ID": 920040,
       "Entries": [
-        "Debugging skill lifted: Hidden prison for checking enemies -- デバッグ用スキル解禁：敵チェック用隠し牢"
+        ""
       ]
     },
     {
       "ID": 920050,
       "Entries": [
-        "Debugging skills lifted: Enemy check dungeon -- デバッグ用スキル解禁：敵チェック用地下牢"
+        ""
       ]
     },
     {
       "ID": 920060,
       "Entries": [
-        "Debugging skill lifted: Enemy check temple -- デバッグ用スキル解禁：敵チェック用寺"
+        ""
       ]
     },
     {
       "ID": 920070,
       "Entries": [
-        "Debugging skills lifted: Enemy check valley -- デバッグ用スキル解禁：敵チェック用渓谷"
+        ""
       ]
     },
     {
       "ID": 920080,
       "Entries": [
-        "Debugging skill lifted: Lower layer of valley for checking enemies -- デバッグ用スキル解禁：敵チェック用渓谷下層"
+        ""
       ]
     },
     {
       "ID": 920090,
       "Entries": [
-        "Debugging skill lifted: Enemy check sick village -- デバッグ用スキル解禁：敵チェック用病み村"
+        ""
       ]
     },
     {
       "ID": 920100,
       "Entries": [
-        "Debugging skill lifted: Enemy check Honjo_Ninja army invasion -- デバッグ用スキル解禁：敵チェック用本城_忍軍襲来時"
+        ""
       ]
     },
     {
       "ID": 920110,
       "Entries": [
-        "Debugging skill lifted: Submerged city for checking enemies -- デバッグ用スキル解禁：敵チェック用水没都"
+        ""
       ]
     },
     {
       "ID": 920120,
       "Entries": [
-        "Debugging skill lifted: Enemy check Honjo_When Tokugawa attacks -- デバッグ用スキル解禁：敵チェック用本城_徳川襲来時"
+        ""
       ]
     },
     {
       "ID": 920130,
       "Entries": [
-        "Debugging skill lifted: Hidden prison for checking enemies_When Tokugawa attacks -- デバッグ用スキル解禁：敵チェック用隠し牢_徳川襲来時"
+        ""
       ]
     },
     {
       "ID": 920140,
       "Entries": [
-        "Debugging skill lifted: Enemy check castle _ Tokugawa invasion -- デバッグ用スキル解禁：敵チェック用城下_徳川襲来時"
+        ""
       ]
     },
     {
       "ID": 920150,
       "Entries": [
-        "Debugging skill lifted: Clear enemy check game -- デバッグ用スキル解禁：敵チェック用ゲームクリア"
+        ""
       ]
     },
     {
       "ID": 930000,
       "Entries": [
-        "Debugging skill voucher: New game for checking enemies -- デバッグ用スキル引換券：敵チェック用ニューゲーム"
+        ""
       ]
     },
     {
       "ID": 930010,
       "Entries": [
-        "Debugging skill voucher: Castle for checking enemies -- デバッグ用スキル引換券：敵チェック用城下"
+        ""
       ]
     },
     {
       "ID": 930020,
       "Entries": [
-        "Debugging skill voucher: Samurai residence for checking enemies -- デバッグ用スキル引換券：敵チェック用武家屋敷"
+        ""
       ]
     },
     {
       "ID": 930030,
       "Entries": [
-        "Debugging skill voucher: Honjo for checking enemies -- デバッグ用スキル引換券：敵チェック用本城"
+        ""
       ]
     },
     {
       "ID": 930040,
       "Entries": [
-        "Debugging skill voucher: Hidden prison for checking enemies -- デバッグ用スキル引換券：敵チェック用隠し牢"
+        ""
       ]
     },
     {
       "ID": 930050,
       "Entries": [
-        "Debugging skill voucher: Enemy check dungeon -- デバッグ用スキル引換券：敵チェック用地下牢"
+        ""
       ]
     },
     {
       "ID": 930060,
       "Entries": [
-        "Debugging skill voucher: Enemy check temple -- デバッグ用スキル引換券：敵チェック用寺"
+        ""
       ]
     },
     {
       "ID": 930070,
       "Entries": [
-        "Debugging skill voucher: Enemy check valley -- デバッグ用スキル引換券：敵チェック用渓谷"
+        ""
       ]
     },
     {
       "ID": 930080,
       "Entries": [
-        "Debugging skill voucher: Lower layer of valley for checking enemies -- デバッグ用スキル引換券：敵チェック用渓谷下層"
+        ""
       ]
     },
     {
       "ID": 930090,
       "Entries": [
-        "Debugging skill voucher: Enemy check sick village -- デバッグ用スキル引換券：敵チェック用病み村"
+        ""
       ]
     },
     {
       "ID": 930100,
       "Entries": [
-        "Debugging skill voucher: Honjo for enemy check_When the Ninja army invades -- デバッグ用スキル引換券：敵チェック用本城_忍軍襲来時"
+        ""
       ]
     },
     {
       "ID": 930110,
       "Entries": [
-        "Debugging skill voucher: Submerged city for checking enemies -- デバッグ用スキル引換券：敵チェック用水没都"
+        ""
       ]
     },
     {
       "ID": 930120,
       "Entries": [
-        "Debugging skill voucher: Honjo for enemy check_When Tokugawa attacks -- デバッグ用スキル引換券：敵チェック用本城_徳川襲来時"
+        ""
       ]
     },
     {
       "ID": 930130,
       "Entries": [
-        "Debugging skill voucher: Hidden prison for checking enemies_When Tokugawa attacks -- デバッグ用スキル引換券：敵チェック用隠し牢_徳川襲来時"
+        ""
       ]
     },
     {
       "ID": 930140,
       "Entries": [
-        "Debugging skill voucher: Castle for checking enemies_When Tokugawa attacks -- デバッグ用スキル引換券：敵チェック用城下_徳川襲来時"
+        ""
       ]
     },
     {
       "ID": 930150,
       "Entries": [
-        "Debugging skill voucher: Clear enemy check game -- デバッグ用スキル引換券：敵チェック用ゲームクリア"
+        ""
       ]
     },
     {
       "ID": 999996,
       "Entries": [
-        "Debugging skill lifted: No derivative attacks -- デバッグ用スキル解禁：派生攻撃なし"
+        ""
       ]
     },
     {
       "ID": 999997,
       "Entries": [
-        "Debugging skills lifted: Everything except immortal slashing / acquisition of form charges -- デバッグ用スキル解禁：不死斬り/形代取得以外全て"
+        ""
       ]
     },
     {
       "ID": 999998,
       "Entries": [
-        "Debugging Skills Lifted: Everything except Immortal Slash -- デバッグ用スキル解禁：不死斬り以外全て"
+        ""
       ]
     },
     {
       "ID": 999999,
       "Entries": [
-        "Debugging skills lifted: All -- デバッグ用スキル解禁：全て"
+        ""
       ]
     }
   ]

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/EquipParamGoods.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/EquipParamGoods.json
@@ -4,157 +4,157 @@
     {
       "ID": 60,
       "Entries": [
-        "ID monitoring item 1"
+        ""
       ]
     },
     {
       "ID": 61,
       "Entries": [
-        "ID monitoring item 2"
+        ""
       ]
     },
     {
       "ID": 62,
       "Entries": [
-        "ID monitoring item 3"
+        ""
       ]
     },
     {
       "ID": 63,
       "Entries": [
-        "ID monitoring item 4"
+        ""
       ]
     },
     {
       "ID": 64,
       "Entries": [
-        "ID monitoring item 5"
+        ""
       ]
     },
     {
       "ID": 65,
       "Entries": [
-        "ID monitoring item 6"
+        ""
       ]
     },
     {
       "ID": 66,
       "Entries": [
-        "ID monitoring item 7"
+        ""
       ]
     },
     {
       "ID": 67,
       "Entries": [
-        "ID monitoring item 8"
+        ""
       ]
     },
     {
       "ID": 68,
       "Entries": [
-        "ID monitoring item 9"
+        ""
       ]
     },
     {
       "ID": 69,
       "Entries": [
-        "ID monitoring item 10"
+        ""
       ]
     },
     {
       "ID": 70,
       "Entries": [
-        "[FDP] Avatar Ritual 1 A-1"
+        ""
       ]
     },
     {
       "ID": 71,
       "Entries": [
-        "[FDP] Avatar Ritual 2 B-1"
+        ""
       ]
     },
     {
       "ID": 72,
       "Entries": [
-        "[FDP] Avatar Ritual 3 C-1"
+        ""
       ]
     },
     {
       "ID": 73,
       "Entries": [
-        "[FDP] Avatar Ritual 4 A-2"
+        ""
       ]
     },
     {
       "ID": 74,
       "Entries": [
-        "[FDP] Avatar Ritual 5 B-2"
+        ""
       ]
     },
     {
       "ID": 75,
       "Entries": [
-        "[FDP] Avatar Ritual 6 C-2"
+        ""
       ]
     },
     {
       "ID": 76,
       "Entries": [
-        "[FDP] Avatar Ritual 7 A-3"
+        ""
       ]
     },
     {
       "ID": 77,
       "Entries": [
-        "[FDP] Avatar Ritual 8 B-3"
+        ""
       ]
     },
     {
       "ID": 78,
       "Entries": [
-        "[FDP] Avatar Ritual 9 C-3"
+        ""
       ]
     },
     {
       "ID": 79,
       "Entries": [
-        "[FDP] Battle Royale"
+        ""
       ]
     },
     {
       "ID": 90,
       "Entries": [
-        "[FDP] Connect with other worlds"
+        ""
       ]
     },
     {
       "ID": 91,
       "Entries": [
-        "[FDP] Dragon egg"
+        ""
       ]
     },
     {
       "ID": 92,
       "Entries": [
-        "[FDP] Corrosion ritual"
+        ""
       ]
     },
     {
       "ID": 93,
       "Entries": [
-        "[FDP] Invasion ritual"
+        ""
       ]
     },
     {
       "ID": 94,
       "Entries": [
-        "Dummy for playing PC animation when creating blood characters"
+        ""
       ]
     },
     {
       "ID": 95,
       "Entries": [
-        "Dummy for playing PC animation when calling blood character illusion"
+        ""
       ]
     },
     {

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/EquipParamWeapon.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/EquipParamWeapon.json
@@ -100,7 +100,7 @@
     {
       "ID": 7100,
       "Entries": [
-        "Ichimonji: Doubel"
+        "Ichimonji: Double"
       ]
     },
     {

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/EquipParamWeapon.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/EquipParamWeapon.json
@@ -4,19 +4,19 @@
     {
       "ID": 1000,
       "Entries": [
-        "Uncorrected weapon"
+        ""
       ]
     },
     {
       "ID": 1100,
       "Entries": [
-        "Throw knife"
+        ""
       ]
     },
     {
       "ID": 1200,
       "Entries": [
-        "Molotov cocktail"
+        ""
       ]
     },
     {
@@ -436,13 +436,13 @@
     {
       "ID": 210000,
       "Entries": [
-        "Skill Tree: Whirlwind Slash"
+        "Virtual Weapon: Whirlwind Slash"
       ]
     },
     {
       "ID": 211000,
       "Entries": [
-        "Skill Tree: Shadowrush"
+        "Virtual Weapon: Shadowrush"
       ]
     },
     {
@@ -472,73 +472,73 @@
     {
       "ID": 310000,
       "Entries": [
-        "Skill Tree: Nightjar Slash"
+        "Virtual Weapon: Nightjar Slash"
       ]
     },
     {
       "ID": 310100,
       "Entries": [
-        "Skill Tree: Nightjar Slash Reversal"
+        "Virtual Weapon: Nightjar Slash Reversal"
       ]
     },
     {
       "ID": 410000,
       "Entries": [
-        "Skill Tree: Ichimonji"
+        "Virtual Weapon: Ichimonji"
       ]
     },
     {
       "ID": 410100,
       "Entries": [
-        "Skill Tree: Ichimonji: Double"
+        "Virtual Weapon: Ichimonji: Double"
       ]
     },
     {
       "ID": 411000,
       "Entries": [
-        "Skill Tree: Ashina Cross"
+        "Virtual Weapon: Ashina Cross"
       ]
     },
     {
       "ID": 510000,
       "Entries": [
-        "Skill Tree: Praying Strikes"
+        "Virtual Weapon: Praying Strikes"
       ]
     },
     {
       "ID": 510100,
       "Entries": [
-        "Skill Tree: Praying Strikes - Exorcism"
+        "Virtual Weapon: Praying Strikes - Exorcism"
       ]
     },
     {
       "ID": 511000,
       "Entries": [
-        "Skill Tree: Senpou Leaping Kicks"
+        "Virtual Weapon: Senpou Leaping Kicks"
       ]
     },
     {
       "ID": 511100,
       "Entries": [
-        "Skill Tree: High Monk"
+        "Virtual Weapon: High Monk"
       ]
     },
     {
       "ID": 610100,
       "Entries": [
-        "Skill Tree: Shadowfall"
+        "Virtual Weapon: Shadowfall"
       ]
     },
     {
       "ID": 611100,
       "Entries": [
-        "Skill Tree: Spiral Cloud Passage"
+        "Virtual Weapon: Spiral Cloud Passage"
       ]
     },
     {
       "ID": 612100,
       "Entries": [
-        "Skill Tree: Empowered Mortal Draw"
+        "Virtual Weapon: Empowered Mortal Draw"
       ]
     },
     {
@@ -682,13 +682,13 @@
     {
       "ID": 670000,
       "Entries": [
-        "Mortal Draw"
+        "Virtual Weapon: Mortal Draw"
       ]
     },
     {
       "ID": 671000,
       "Entries": [
-        "Dragon Flash"
+        "Virtual Weapon: Dragon Flash"
       ]
     },
     {
@@ -700,13 +700,13 @@
     {
       "ID": 673000,
       "Entries": [
-        "One Mind"
+        "Virtual Weapon: One Mind"
       ]
     },
     {
       "ID": 674000,
       "Entries": [
-        "Sakura Dance"
+        "Virtual Weapon: Sakura Dance"
       ]
     },
     {
@@ -1006,37 +1006,37 @@
     {
       "ID": 8000000,
       "Entries": [
-        "Debug non-killing sword -- デバッグ無殺刀"
+        ""
       ]
     },
     {
       "ID": 8000100,
       "Entries": [
-        "Debug Special Sword -- デバッグ必殺刀"
+        ""
       ]
     },
     {
       "ID": 8000200,
       "Entries": [
-        "Debug bare hand sword -- デバッグ素手刀"
+        ""
       ]
     },
     {
       "ID": 9500000,
       "Entries": [
-        "Wire weapon -- ワイヤー武器"
+        ""
       ]
     },
     {
       "ID": 9600000,
       "Entries": [
-        "parachute -- 落下傘"
+        ""
       ]
     },
     {
       "ID": 9700000,
       "Entries": [
-        "Immortal sword -- 不死斬りの刀"
+        ""
       ]
     }
   ]

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/FaceGenParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/FaceGenParam.json
@@ -4,883 +4,883 @@
     {
       "ID": 0,
       "Entries": [
-        "testData -- testData"
+        "\n"
       ]
     },
     {
       "ID": 1,
       "Entries": [
-        "Male_Prototype 1 -- 男性_試作1"
+        "\n"
       ]
     },
     {
       "ID": 2,
       "Entries": [
-        "Male_Prototype 2 -- 男性_試作2"
+        "\n"
       ]
     },
     {
       "ID": 3,
       "Entries": [
-        "Male_Prototype 3 -- 男性_試作3"
+        "\n"
       ]
     },
     {
       "ID": 4,
       "Entries": [
-        "Male_Prototype 4 -- 男性_試作4"
+        "\n"
       ]
     },
     {
       "ID": 5,
       "Entries": [
-        "Male_Prototype 5 -- 男性_試作5"
+        "\n"
       ]
     },
     {
       "ID": 6,
       "Entries": [
-        "Male_Prototype 6 -- 男性_試作6"
+        "\n"
       ]
     },
     {
       "ID": 7,
       "Entries": [
-        "Male_Prototype 7 -- 男性_試作7"
+        "\n"
       ]
     },
     {
       "ID": 8,
       "Entries": [
-        "Male_Prototype 8 -- 男性_試作8"
+        "\n"
       ]
     },
     {
       "ID": 9,
       "Entries": [
-        "Male_Prototype 9 -- 男性_試作9"
+        "\n"
       ]
     },
     {
       "ID": 10,
       "Entries": [
-        "Male_Prototype 10 -- 男性_試作10"
+        "\n"
       ]
     },
     {
       "ID": 11,
       "Entries": [
-        "Male_Prototype 11 -- 男性_試作11"
+        "\n"
       ]
     },
     {
       "ID": 12,
       "Entries": [
-        "Male_Prototype 12 -- 男性_試作12"
+        "\n"
       ]
     },
     {
       "ID": 13,
       "Entries": [
-        "Male_Prototype 13 -- 男性_試作13"
+        "\n"
       ]
     },
     {
       "ID": 14,
       "Entries": [
-        "Male_Prototype 14 -- 男性_試作14"
+        "\n"
       ]
     },
     {
       "ID": 20,
       "Entries": [
-        "Female_Prototype 1 -- 女性_試作1"
+        "\n"
       ]
     },
     {
       "ID": 21,
       "Entries": [
-        "Female_Prototype 2 -- 女性_試作2"
+        "\n"
       ]
     },
     {
       "ID": 30,
       "Entries": [
-        "4 Final Edition Warrior_Man -- ４末版\u3000戦士_男"
+        "\n"
       ]
     },
     {
       "ID": 31,
       "Entries": [
-        "4 Final Edition Knight_Man -- ４末版\u3000騎士_男"
+        "\n"
       ]
     },
     {
       "ID": 32,
       "Entries": [
-        "4 Final Edition Wizard_Woman -- ４末版\u3000魔法使い_女"
+        "\n"
       ]
     },
     {
       "ID": 33,
       "Entries": [
-        "4 Final Edition Shaman_Man -- ４末版\u3000呪術師_男"
+        "\n"
       ]
     },
     {
       "ID": 34,
       "Entries": [
-        "E3 Sun Knight_Man -- E3\u3000太陽騎士_男"
+        "\n"
       ]
     },
     {
       "ID": 100,
       "Entries": [
-        "Default face test_01 -- デフォルト顔テスト_01"
+        "\n"
       ]
     },
     {
       "ID": 101,
       "Entries": [
-        "Default face test_02 -- デフォルト顔テスト_02"
+        "\n"
       ]
     },
     {
       "ID": 102,
       "Entries": [
-        "Default face test_03 -- デフォルト顔テスト_03"
+        "\n"
       ]
     },
     {
       "ID": 103,
       "Entries": [
-        "Default face test_04 -- デフォルト顔テスト_04"
+        "\n"
       ]
     },
     {
       "ID": 104,
       "Entries": [
-        "Default face test_05 -- デフォルト顔テスト_05"
+        "\n"
       ]
     },
     {
       "ID": 105,
       "Entries": [
-        "Default face test_06 -- デフォルト顔テスト_06"
+        "\n"
       ]
     },
     {
       "ID": 106,
       "Entries": [
-        "Default face test_07 -- デフォルト顔テスト_07"
+        "\n"
       ]
     },
     {
       "ID": 107,
       "Entries": [
-        "Default face test_08 -- デフォルト顔テスト_08"
+        "\n"
       ]
     },
     {
       "ID": 108,
       "Entries": [
-        "Default face test_09 -- デフォルト顔テスト_09"
+        "\n"
       ]
     },
     {
       "ID": 109,
       "Entries": [
-        "Default face test_10 -- デフォルト顔テスト_10"
+        "\n"
       ]
     },
     {
       "ID": 110,
       "Entries": [
-        "Default face test_11 -- デフォルト顔テスト_11"
+        "\n"
       ]
     },
     {
       "ID": 111,
       "Entries": [
-        "Default face test_12 -- デフォルト顔テスト_12"
+        "\n"
       ]
     },
     {
       "ID": 112,
       "Entries": [
-        "Default face test_13 -- デフォルト顔テスト_13"
+        "\n"
       ]
     },
     {
       "ID": 113,
       "Entries": [
-        "Default face test_14 -- デフォルト顔テスト_14"
+        "\n"
       ]
     },
     {
       "ID": 114,
       "Entries": [
-        "Default face test_15 -- デフォルト顔テスト_15"
+        "\n"
       ]
     },
     {
       "ID": 115,
       "Entries": [
-        "Default face test_16 -- デフォルト顔テスト_16"
+        "\n"
       ]
     },
     {
       "ID": 116,
       "Entries": [
-        "Default face test_17 -- デフォルト顔テスト_17"
+        "\n"
       ]
     },
     {
       "ID": 117,
       "Entries": [
-        "Default face test_18 -- デフォルト顔テスト_18"
+        "\n"
       ]
     },
     {
       "ID": 118,
       "Entries": [
-        "Default face test_19 -- デフォルト顔テスト_19"
+        "\n"
       ]
     },
     {
       "ID": 119,
       "Entries": [
-        "Default face test_20 -- デフォルト顔テスト_20"
+        "\n"
       ]
     },
     {
       "ID": 120,
       "Entries": [
-        "Default face test_21 -- デフォルト顔テスト_21"
+        "\n"
       ]
     },
     {
       "ID": 121,
       "Entries": [
-        "Default face test_22 -- デフォルト顔テスト_22"
+        "\n"
       ]
     },
     {
       "ID": 122,
       "Entries": [
-        "Default face test_23 -- デフォルト顔テスト_23"
+        "\n"
       ]
     },
     {
       "ID": 123,
       "Entries": [
-        "Default face test_24 -- デフォルト顔テスト_24"
+        "\n"
       ]
     },
     {
       "ID": 124,
       "Entries": [
-        "Default face test_25 -- デフォルト顔テスト_25"
+        "\n"
       ]
     },
     {
       "ID": 125,
       "Entries": [
-        "Default face test _26 -- デフォルト顔テスト_26"
+        "\n"
       ]
     },
     {
       "ID": 126,
       "Entries": [
-        "Default face test _27 -- デフォルト顔テスト_27"
+        "\n"
       ]
     },
     {
       "ID": 127,
       "Entries": [
-        "Default face test _28 -- デフォルト顔テスト_28"
+        "\n"
       ]
     },
     {
       "ID": 128,
       "Entries": [
-        "Default face test _29 -- デフォルト顔テスト_29"
+        "\n"
       ]
     },
     {
       "ID": 129,
       "Entries": [
-        "Default face test_30 -- デフォルト顔テスト_30"
+        "\n"
       ]
     },
     {
       "ID": 130,
       "Entries": [
-        "Default face test_31 -- デフォルト顔テスト_31"
+        "\n"
       ]
     },
     {
       "ID": 131,
       "Entries": [
-        "Default face test _32 -- デフォルト顔テスト_32"
+        "\n"
       ]
     },
     {
       "ID": 132,
       "Entries": [
-        "Default face test_33 -- デフォルト顔テスト_33"
+        "\n"
       ]
     },
     {
       "ID": 133,
       "Entries": [
-        "Default face test_34 -- デフォルト顔テスト_34"
+        "\n"
       ]
     },
     {
       "ID": 134,
       "Entries": [
-        "Default face test_35 -- デフォルト顔テスト_35"
+        "\n"
       ]
     },
     {
       "ID": 135,
       "Entries": [
-        "Default face test _36 -- デフォルト顔テスト_36"
+        "\n"
       ]
     },
     {
       "ID": 136,
       "Entries": [
-        "Default face test _37 -- デフォルト顔テスト_37"
+        "\n"
       ]
     },
     {
       "ID": 137,
       "Entries": [
-        "Default face test _38 -- デフォルト顔テスト_38"
+        "\n"
       ]
     },
     {
       "ID": 138,
       "Entries": [
-        "Default face test _39 -- デフォルト顔テスト_39"
+        "\n"
       ]
     },
     {
       "ID": 139,
       "Entries": [
-        "Default face test_40 -- デフォルト顔テスト_40"
+        "\n"
       ]
     },
     {
       "ID": 140,
       "Entries": [
-        "Default face test_41 -- デフォルト顔テスト_41"
+        "\n"
       ]
     },
     {
       "ID": 141,
       "Entries": [
-        "Default face test _42 -- デフォルト顔テスト_42"
+        "\n"
       ]
     },
     {
       "ID": 142,
       "Entries": [
-        "Default face test_43 -- デフォルト顔テスト_43"
+        "\n"
       ]
     },
     {
       "ID": 143,
       "Entries": [
-        "Default face test_44 -- デフォルト顔テスト_44"
+        "\n"
       ]
     },
     {
       "ID": 144,
       "Entries": [
-        "Default face test_45 -- デフォルト顔テスト_45"
+        "\n"
       ]
     },
     {
       "ID": 145,
       "Entries": [
-        "Default face test_46 -- デフォルト顔テスト_46"
+        "\n"
       ]
     },
     {
       "ID": 146,
       "Entries": [
-        "Default face test _47 -- デフォルト顔テスト_47"
+        "\n"
       ]
     },
     {
       "ID": 147,
       "Entries": [
-        "Default face test _48 -- デフォルト顔テスト_48"
+        "\n"
       ]
     },
     {
       "ID": 148,
       "Entries": [
-        "Default face test _49 -- デフォルト顔テスト_49"
+        "\n"
       ]
     },
     {
       "ID": 149,
       "Entries": [
-        "Default face test_50 -- デフォルト顔テスト_50"
+        "\n"
       ]
     },
     {
       "ID": 300,
       "Entries": [
-        "Gray saint -- 灰色の聖女"
+        "\n"
       ]
     },
     {
       "ID": 1000,
       "Entries": [
-        "Commoner face -- 平民顔"
+        "\n"
       ]
     },
     {
       "ID": 1001,
       "Entries": [
-        "Peasant face of the Gosashi River -- 五指河の農民顔"
+        "\n"
       ]
     },
     {
       "ID": 1002,
       "Entries": [
-        "Astra noble face -- アストラの貴族顔"
+        "\n"
       ]
     },
     {
       "ID": 1003,
       "Entries": [
-        "Ryu Gakuin&#39;s student face -- 竜学院の書生顔"
+        "\n"
       ]
     },
     {
       "ID": 1004,
       "Entries": [
-        "Sol Rondo saint face -- ソルロンドの聖者顔"
+        "\n"
       ]
     },
     {
       "ID": 1005,
       "Entries": [
-        "Catalina&#39;s cheerful face -- カタリナの陽気顔"
+        "\n"
       ]
     },
     {
       "ID": 1006,
       "Entries": [
-        "Karim&#39;s gloomy face -- カリムの陰気顔"
+        "\n"
       ]
     },
     {
       "ID": 1007,
       "Entries": [
-        "Zena&#39;s old face -- ゼナの古顔"
+        "\n"
       ]
     },
     {
       "ID": 1008,
       "Entries": [
-        "Onuma&#39;s different phase -- 大沼の異相"
+        "\n"
       ]
     },
     {
       "ID": 1009,
       "Entries": [
-        "East strange face -- 東の異人顔"
+        "\n"
       ]
     },
     {
       "ID": 2000,
       "Entries": [
-        "Commoner face -- 平民顔"
+        "\n"
       ]
     },
     {
       "ID": 2001,
       "Entries": [
-        "Peasant face of the Gosashi River -- 五指河の農民顔"
+        "\n"
       ]
     },
     {
       "ID": 2002,
       "Entries": [
-        "Astra noble face -- アストラの貴族顔"
+        "\n"
       ]
     },
     {
       "ID": 2003,
       "Entries": [
-        "Ryu Gakuin&#39;s student face -- 竜学院の書生顔"
+        "\n"
       ]
     },
     {
       "ID": 2004,
       "Entries": [
-        "Sol Rondo saint face -- ソルロンドの聖者顔"
+        "\n"
       ]
     },
     {
       "ID": 2005,
       "Entries": [
-        "Catalina&#39;s cheerful face -- カタリナの陽気顔"
+        "\n"
       ]
     },
     {
       "ID": 2006,
       "Entries": [
-        "Karim&#39;s gloomy face -- カリムの陰気顔"
+        "\n"
       ]
     },
     {
       "ID": 2007,
       "Entries": [
-        "Zena&#39;s old face -- ゼナの古顔"
+        "\n"
       ]
     },
     {
       "ID": 2008,
       "Entries": [
-        "Onuma&#39;s different phase -- 大沼の異相"
+        "\n"
       ]
     },
     {
       "ID": 2009,
       "Entries": [
-        "East strange face -- 東の異人顔"
+        "\n"
       ]
     },
     {
       "ID": 6000,
       "Entries": [
-        "Knight of the sun -- 太陽の騎士"
+        "\n"
       ]
     },
     {
       "ID": 6001,
       "Entries": [
-        "Knight of the Sun (Sunworm Ver) -- 太陽の騎士（太陽虫Ver）"
+        "\n"
       ]
     },
     {
       "ID": 6002,
       "Entries": [
-        "Knight of the Sun (Dead) -- 太陽の騎士（亡者）"
+        "\n"
       ]
     },
     {
       "ID": 6010,
       "Entries": [
-        "Knight of the dark moon -- 暗月の騎士"
+        "\n"
       ]
     },
     {
       "ID": 6020,
       "Entries": [
-        "Knight Ostra -- 騎士オストラ"
+        "\n"
       ]
     },
     {
       "ID": 6021,
       "Entries": [
-        "Knight Ostra (hostile) -- 騎士オストラ（敵対）"
+        "\n"
       ]
     },
     {
       "ID": 6030,
       "Entries": [
-        "&quot;Big Hat&quot; Logan -- ”ビッグハット”ロガーン"
+        "\n"
       ]
     },
     {
       "ID": 6031,
       "Entries": [
-        "&quot;Big Hat&quot; Logan (Dead) -- ”ビッグハット”ロガーン（亡者）"
+        "\n"
       ]
     },
     {
       "ID": 6040,
       "Entries": [
-        "Logan&#39;s disciple -- ロガーンの弟子"
+        "\n"
       ]
     },
     {
       "ID": 6041,
       "Entries": [
-        "Logan&#39;s disciple (dead) -- ロガーンの弟子（亡者）"
+        "\n"
       ]
     },
     {
       "ID": 6050,
       "Entries": [
-        "Princess of the exiled country -- 亡国の王女"
+        "\n"
       ]
     },
     {
       "ID": 6060,
       "Entries": [
-        "Gray saint -- 灰色の聖女"
+        "\n"
       ]
     },
     {
       "ID": 6070,
       "Entries": [
-        "White saint -- 白の聖女"
+        "\n"
       ]
     },
     {
       "ID": 6071,
       "Entries": [
-        "White saint (dead) -- 白の聖女（亡者）"
+        "\n"
       ]
     },
     {
       "ID": 6080,
       "Entries": [
-        "Knight of the Saint A -- 聖女の騎士A"
+        "\n"
       ]
     },
     {
       "ID": 6090,
       "Entries": [
-        "Knight of the Saint B -- 聖女の騎士B"
+        "\n"
       ]
     },
     {
       "ID": 6091,
       "Entries": [
-        "Knight of the Saint B (Dead) -- 聖女の騎士B （亡者）"
+        "\n"
       ]
     },
     {
       "ID": 6100,
       "Entries": [
-        "Knight of the Saint C -- 聖女の騎士C"
+        "\n"
       ]
     },
     {
       "ID": 6101,
       "Entries": [
-        "Knight of the Saint C (Dead) -- 聖女の騎士C （亡者）"
+        "\n"
       ]
     },
     {
       "ID": 6130,
       "Entries": [
-        "Vase Shaman -- 壺の呪術師"
+        "\n"
       ]
     },
     {
       "ID": 6131,
       "Entries": [
-        "Vase Shaman (Dead) -- 壺の呪術師（亡者）"
+        "\n"
       ]
     },
     {
       "ID": 6170,
       "Entries": [
-        "Wandering chaos -- さまよう混沌"
+        "\n"
       ]
     },
     {
       "ID": 6180,
       "Entries": [
-        "Healer -- 癒し手"
+        "\n"
       ]
     },
     {
       "ID": 6220,
       "Entries": [
-        "Blacksmith Rickert -- 鍛冶屋リッケルト"
+        "\n"
       ]
     },
     {
       "ID": 6250,
       "Entries": [
-        "A broken merchant -- 心折れた商人"
+        "\n"
       ]
     },
     {
       "ID": 6260,
       "Entries": [
-        "Trickster -- トリックスター"
+        "\n"
       ]
     },
     {
       "ID": 6270,
       "Entries": [
-        "A broken warrior -- 心折れた戦士"
+        "\n"
       ]
     },
     {
       "ID": 6271,
       "Entries": [
-        "Broken heart warrior (dead) -- 心折れた戦士（亡者）"
+        "\n"
       ]
     },
     {
       "ID": 6280,
       "Entries": [
-        "Onion knight -- たまねぎ騎士"
+        "\n"
       ]
     },
     {
       "ID": 6290,
       "Entries": [
-        "Onion knight&#39;s daughter -- たまねぎ騎士の娘"
+        "\n"
       ]
     },
     {
       "ID": 6300,
       "Entries": [
-        "Embraced Knight Lautrec -- 抱かれ騎士ロートレク"
+        "\n"
       ]
     },
     {
       "ID": 6310,
       "Entries": [
-        "Nobushi -- 野武士"
+        "\n"
       ]
     },
     {
       "ID": 6320,
       "Entries": [
-        "Cemetery coward patch -- 墓地の卑怯者パッチ"
+        "\n"
       ]
     },
     {
       "ID": 6370,
       "Entries": [
-        "Dragon priest -- ドラゴンの神官"
+        "\n"
       ]
     },
     {
       "ID": 6390,
       "Entries": [
-        "Black Knight Tarkus -- 黒騎士タルカス"
+        "\n"
       ]
     },
     {
       "ID": 6400,
       "Entries": [
-        "Belka Knight -- ベルカ騎士"
+        "\n"
       ]
     },
     {
       "ID": 6410,
       "Entries": [
-        "Witch Marose -- 魔女マロース"
+        "\n"
       ]
     },
     {
       "ID": 6420,
       "Entries": [
-        "Ninja -- 忍者"
+        "\n"
       ]
     },
     {
       "ID": 6490,
       "Entries": [
-        "Lautrec&#39;s companion 1 -- ロートレクのお供１"
+        "\n"
       ]
     },
     {
       "ID": 6500,
       "Entries": [
-        "Lautrec&#39;s companion 2 -- ロートレクのお供２"
+        "\n"
       ]
     },
     {
       "ID": 6530,
       "Entries": [
-        "Swamp Woman (NPC Multi) -- 沼女（NPCマルチ）"
+        "\n"
       ]
     },
     {
       "ID": 6550,
       "Entries": [
-        "Temple Knight (NPC Multi) -- 神殿騎士（NPCマルチ）"
+        "\n"
       ]
     },
     {
       "ID": 6560,
       "Entries": [
-        "Thorn Knight (NPC Multi) -- トゲ騎士（NPCマルチ）"
+        "\n"
       ]
     },
     {
       "ID": 6570,
       "Entries": [
-        "Yellow robe (NPC multi) -- 黄衣（NPCマルチ）"
+        "\n"
       ]
     },
     {
       "ID": 6580,
       "Entries": [
-        "Castle Tower NPC (Havell) -- 城下塔のNPC（ハベル）"
+        "\n"
       ]
     },
     {
       "ID": 6600,
       "Entries": [
-        "NPC (Ricard) of the 1st Tower of the Royal Castle -- 王城1塔のNPC（リカール）"
+        "\n"
       ]
     },
     {
       "ID": 6610,
       "Entries": [
-        "Crystal Knight -- 結晶騎士"
+        "\n"
       ]
     },
     {
       "ID": 6801,
       "Entries": [
-        "Bandit A Gatekeeper -- 山賊A\u3000門番"
+        "\n"
       ]
     },
     {
       "ID": 6802,
       "Entries": [
-        "Bandit B Warrior -- 山賊B\u3000戦士"
+        "\n"
       ]
     },
     {
       "ID": 6803,
       "Entries": [
-        "Bandit C Bower -- 山賊C\u3000弓使い"
+        "\n"
       ]
     },
     {
       "ID": 6804,
       "Entries": [
-        "Bandit D Magic (Attack) -- 山賊D\u3000魔法（攻撃）"
+        "\n"
       ]
     },
     {
       "ID": 6805,
       "Entries": [
-        "Bandit E Magic (Recovery) -- 山賊E\u3000魔法（回復）"
+        "\n"
       ]
     },
     {
       "ID": 6806,
       "Entries": [
-        "Bandit F covert -- 山賊F\u3000隠密"
+        "\n"
       ]
     },
     {
       "ID": 9999,
       "Entries": [
-        "Phantom (without face) -- 幻影（顔なし）"
+        "\n"
       ]
     }
   ]

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/HitMtrlParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/HitMtrlParam.json
@@ -4,307 +4,307 @@
     {
       "ID": 0,
       "Entries": [
-        "dummy -- ダミー"
+        ""
       ]
     },
     {
       "ID": 1,
       "Entries": [
-        "Cobblestone -- 石畳"
+        "Stone"
       ]
     },
     {
       "ID": 2,
       "Entries": [
-        "unused -- 未使用"
+        "Unused"
       ]
     },
     {
       "ID": 3,
       "Entries": [
-        "soil -- 土"
+        "Dirt"
       ]
     },
     {
       "ID": 4,
       "Entries": [
-        "wood -- 木材"
+        "Wood"
       ]
     },
     {
       "ID": 5,
       "Entries": [
-        "Grassland -- 草地"
+        "Grass"
       ]
     },
     {
       "ID": 6,
       "Entries": [
-        "gravel -- 砂利"
+        "Gravel"
       ]
     },
     {
       "ID": 7,
       "Entries": [
-        "bamboo -- 竹"
+        "Bamboo"
       ]
     },
     {
       "ID": 8,
       "Entries": [
-        "Tree -- 樹木"
+        "Tree"
       ]
     },
     {
       "ID": 9,
       "Entries": [
-        "Straw (soft) -- 藁（柔）"
+        "Straw"
       ]
     },
     {
       "ID": 10,
       "Entries": [
-        "Straw (hard) -- 藁（硬）"
+        "Straw"
       ]
     },
     {
       "ID": 11,
       "Entries": [
-        "iron -- 鉄"
+        "Iron"
       ]
     },
     {
       "ID": 12,
       "Entries": [
-        "flesh and blood -- 血肉"
+        "Flesh"
       ]
     },
     {
       "ID": 13,
       "Entries": [
-        "sand -- 砂"
+        "Sand"
       ]
     },
     {
       "ID": 14,
       "Entries": [
-        "Bone -- 骨"
+        "Bone"
       ]
     },
     {
       "ID": 15,
       "Entries": [
-        "Ash -- 灰"
+        "Ash"
       ]
     },
     {
       "ID": 16,
       "Entries": [
-        "tile -- 瓦"
+        "Tiles"
       ]
     },
     {
       "ID": 17,
       "Entries": [
-        "cloth -- 布"
+        "Cloth"
       ]
     },
     {
       "ID": 18,
       "Entries": [
-        "Dead leaves -- 枯葉"
+        "Dead Leaves"
       ]
     },
     {
       "ID": 19,
       "Entries": [
-        "bell -- 鐘"
+        "Bell"
       ]
     },
     {
       "ID": 20,
       "Entries": [
-        "Water: Flat surface (about a puddle) -- 水：平面（水溜り程度）"
+        "Water Puddle"
       ]
     },
     {
       "ID": 21,
       "Entries": [
-        "Water: Plane (walkable) -- 水：平面（歩ける）"
+        "Water (Walkable)"
       ]
     },
     {
       "ID": 22,
       "Entries": [
-        "Water: Plane (dive) -- 水：平面（潜れる）"
+        "Water (Diveable)"
       ]
     },
     {
       "ID": 23,
       "Entries": [
-        "Poison Swamp (no movement restrictions) -- 毒沼（移動制限なし）"
+        "Poison Swamp"
       ]
     },
     {
       "ID": 24,
       "Entries": [
-        "Poison swamp (with movement restrictions) -- 毒沼（移動制限あり）"
+        "Poison Swamp (with slowing)"
       ]
     },
     {
       "ID": 25,
       "Entries": [
-        "unused -- 未使用"
+        "Unused"
       ]
     },
     {
       "ID": 26,
       "Entries": [
-        "unused -- 未使用"
+        "Unused"
       ]
     },
     {
       "ID": 27,
       "Entries": [
-        "mud -- 泥"
+        "Mud"
       ]
     },
     {
       "ID": 28,
       "Entries": [
-        "tatami -- 畳"
+        "Tatami"
       ]
     },
     {
       "ID": 29,
       "Entries": [
-        "None -- なし"
+        "None"
       ]
     },
     {
       "ID": 30,
       "Entries": [
-        "snow -- 雪"
+        "Snow"
       ]
     },
     {
       "ID": 31,
       "Entries": [
-        "Bushes -- 茂み"
+        "Bush"
       ]
     },
     {
       "ID": 32,
       "Entries": [
-        "Wood_indoor -- 木材_屋内"
+        "Wood Indoors"
       ]
     },
     {
       "ID": 33,
       "Entries": [
-        "Autumn leaves -- 紅葉"
+        "Autumn Leaves"
       ]
     },
     {
       "ID": 34,
       "Entries": [
-        "ice -- 氷"
+        "Ice"
       ]
     },
     {
       "ID": 35,
       "Entries": [
-        "Water: Slope (walkable) -- 水：斜面（歩ける）"
+        "Water Slope"
       ]
     },
     {
       "ID": 36,
       "Entries": [
-        "Water: Slope (swimming) -- 水：斜面（泳げる）"
+        "Water Slope (swimming)"
       ]
     },
     {
       "ID": 37,
       "Entries": [
-        "Water x grass (walkable) -- 水×草（歩ける）"
+        "Grass In Water"
       ]
     },
     {
       "ID": 38,
       "Entries": [
-        "Water x grass (swimming) -- 水×草（泳げる）"
+        "Grass In Water (swimming)"
       ]
     },
     {
       "ID": 39,
       "Entries": [
-        "unused -- 未使用"
+        "Unused"
       ]
     },
     {
       "ID": 40,
       "Entries": [
-        "cloud -- 雲"
+        "Cloud"
       ]
     },
     {
       "ID": 41,
       "Entries": [
-        "unused -- 未使用"
+        "Unused"
       ]
     },
     {
       "ID": 42,
       "Entries": [
-        "unused -- 未使用"
+        "Unused"
       ]
     },
     {
       "ID": 43,
       "Entries": [
-        "unused -- 未使用"
+        "Unused"
       ]
     },
     {
       "ID": 44,
       "Entries": [
-        "unused -- 未使用"
+        "Unused"
       ]
     },
     {
       "ID": 45,
       "Entries": [
-        "Underwater soil -- 水中土"
+        "Underwater Dirt"
       ]
     },
     {
       "ID": 46,
       "Entries": [
-        "Underwater stone -- 水中石"
+        "Underwater Stone"
       ]
     },
     {
       "ID": 47,
       "Entries": [
-        "Underwater tree -- 水中木"
+        "Underwater Wood"
       ]
     },
     {
       "ID": 48,
       "Entries": [
-        "unused -- 未使用"
+        "Unused"
       ]
     },
     {
       "ID": 49,
       "Entries": [
-        "unused -- 未使用"
+        "Unused"
       ]
     },
     {
       "ID": 80,
       "Entries": [
-        "Miasma -- 瘴気"
+        "Miasma"
       ]
     }
   ]

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/ItemLotParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/ItemLotParam.json
@@ -430,25 +430,25 @@
     {
       "ID": 3015,
       "Entries": [
-        "α (end of 11) _ Shuriken -- α（11末）_手裏剣"
+        ""
       ]
     },
     {
       "ID": 3020,
       "Entries": [
-        "α (end of 11) _ Immortal sword -- α（11末）_不死切りの刀"
+        ""
       ]
     },
     {
       "ID": 3030,
       "Entries": [
-        "α (end of 11) _ pill prescription -- α（11末）_丸薬の処方箋"
+        ""
       ]
     },
     {
       "ID": 3040,
       "Entries": [
-        "α (end of 11) _ night eyes -- α（11末）_夜目"
+        ""
       ]
     },
     {
@@ -484,7 +484,7 @@
     {
       "ID": 3100,
       "Entries": [
-        "Mystery Book Lifting School Technique: Eight Flying Rush -- 奥義書解禁流派技：八艘飛びラッシュ"
+        ""
       ]
     },
     {
@@ -646,157 +646,157 @@
     {
       "ID": 5000,
       "Entries": [
-        "Bandit Reward"
+        ""
       ]
     },
     {
       "ID": 5010,
       "Entries": [
-        "DS3 Leftovers"
+        ""
       ]
     },
     {
       "ID": 5020,
       "Entries": [
-        "DS3 Leftovers"
+        ""
       ]
     },
     {
       "ID": 5030,
       "Entries": [
-        "DS3 Leftovers"
+        ""
       ]
     },
     {
       "ID": 5040,
       "Entries": [
-        "DS3 Leftovers"
+        ""
       ]
     },
     {
       "ID": 5200,
       "Entries": [
-        "DS3 Leftovers"
+        ""
       ]
     },
     {
       "ID": 5210,
       "Entries": [
-        "DS3 Leftovers"
+        ""
       ]
     },
     {
       "ID": 5220,
       "Entries": [
-        "DS3 Leftovers"
+        ""
       ]
     },
     {
       "ID": 5230,
       "Entries": [
-        "DS3 Leftovers"
+        ""
       ]
     },
     {
       "ID": 5240,
       "Entries": [
-        "DS3 Leftovers"
+        ""
       ]
     },
     {
       "ID": 5250,
       "Entries": [
-        "DS3 Leftovers"
+        ""
       ]
     },
     {
       "ID": 5260,
       "Entries": [
-        "DS3 Leftovers"
+        ""
       ]
     },
     {
       "ID": 5270,
       "Entries": [
-        "DS3 Leftovers"
+        ""
       ]
     },
     {
       "ID": 5280,
       "Entries": [
-        "DS3 Leftovers"
+        ""
       ]
     },
     {
       "ID": 5500,
       "Entries": [
-        "DS3 Leftovers"
+        ""
       ]
     },
     {
       "ID": 5510,
       "Entries": [
-        "DS3 Leftovers"
+        ""
       ]
     },
     {
       "ID": 5520,
       "Entries": [
-        "DS3 Leftovers"
+        ""
       ]
     },
     {
       "ID": 5530,
       "Entries": [
-        "DS3 Leftovers"
+        ""
       ]
     },
     {
       "ID": 5540,
       "Entries": [
-        "DS3 Leftovers"
+        ""
       ]
     },
     {
       "ID": 5550,
       "Entries": [
-        "DS3 Leftovers"
+        ""
       ]
     },
     {
       "ID": 5560,
       "Entries": [
-        "DS3 Leftovers"
+        ""
       ]
     },
     {
       "ID": 5570,
       "Entries": [
-        "DS3 Leftovers"
+        ""
       ]
     },
     {
       "ID": 5580,
       "Entries": [
-        "DS3 Leftovers"
+        ""
       ]
     },
     {
       "ID": 5590,
       "Entries": [
-        "DS3 Leftovers"
+        ""
       ]
     },
     {
       "ID": 5600,
       "Entries": [
-        "DS3 Leftovers"
+        ""
       ]
     },
     {
       "ID": 5610,
       "Entries": [
-        "DS3 Leftovers"
+        ""
       ]
     },
     {

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/LodPlatform.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/LodPlatform.json
@@ -4,49 +4,49 @@
     {
       "ID": 0,
       "Entries": [
-        "PS4 -- PS4"
+        "PS4"
       ]
     },
     {
       "ID": 1,
       "Entries": [
-        "PS4 Pro -- PS4Pro"
+        "PS4 Pro"
       ]
     },
     {
       "ID": 2,
       "Entries": [
-        "Xbox One -- XboxOne"
+        "Xbox One"
       ]
     },
     {
       "ID": 3,
       "Entries": [
-        "XboxOneX -- XboxOneX"
+        "XboxOneX"
       ]
     },
     {
       "ID": 4,
       "Entries": [
-        "Windows Low -- Windows Low"
+        "Windows Low"
       ]
     },
     {
       "ID": 5,
       "Entries": [
-        "Windows Middle -- Windows Middle"
+        "Windows Middle"
       ]
     },
     {
       "ID": 6,
       "Entries": [
-        "Windows High -- Windows High"
+        "Windows High"
       ]
     },
     {
       "ID": 7,
       "Entries": [
-        "Stadia -- Stadia"
+        "Stadia"
       ]
     }
   ]

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/Magic.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/Magic.json
@@ -4,7 +4,7 @@
     {
       "ID": 0,
       "Entries": [
-        "Don't Erase"
+        ""
       ]
     }
   ]

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/NpcParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/NpcParam.json
@@ -2776,7 +2776,7 @@
     {
       "ID": 13001000,
       "Entries": [
-        "Mist Noble"
+        "Mist Noble - Ashina Depths"
       ]
     },
     {

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/NpcThinkParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/NpcThinkParam.json
@@ -4,931 +4,931 @@
     {
       "ID": 0,
       "Entries": [
-        "for test -- テスト用"
+        ""
       ]
     },
     {
       "ID": 1,
       "Entries": [
-        "For doing nothing -- なにもしない用"
+        ""
       ]
     },
     {
       "ID": 2,
       "Entries": [
-        "Non-touch data (recommended by copy / paste) -- あたりさわりのないデータ（コピペ元推奨）"
+        ""
       ]
     },
     {
       "ID": 3,
       "Entries": [
-        "For conversations that do nothing -- なにもしない会話用"
+        ""
       ]
     },
     {
       "ID": 10,
       "Entries": [
-        "Anime check logic: Near -- アニメチェック用ロジック：近"
+        ""
       ]
     },
     {
       "ID": 11,
       "Entries": [
-        "Anime check logic: Far -- アニメチェック用ロジック：遠"
+        ""
       ]
     },
     {
       "ID": 50,
       "Entries": [
-        "Ishizaki test -- 石崎テスト"
+        ""
       ]
     },
     {
       "ID": 100,
       "Entries": [
-        "For automatic patrol (default) -- 自動巡回用(デフォルト)"
+        ""
       ]
     },
     {
       "ID": 540,
       "Entries": [
-        "For automatic patrol (running) -- 自動巡回用(走り)"
+        ""
       ]
     },
     {
       "ID": 541,
       "Entries": [
-        "For automatic patrol (walking) -- 自動巡回用(歩き)"
+        ""
       ]
     },
     {
       "ID": 542,
       "Entries": [
-        "For automatic patrol (super dash) -- 自動巡回用(スーパーダッシュ)"
+        ""
       ]
     },
     {
       "ID": 10001,
       "Entries": [
-        "For funnel -- ファンネル用"
+        ""
       ]
     },
     {
       "ID": 10000000,
       "Entries": [
-        "Group patrol dummy leader -- 集団巡回ダミーリーダー"
+        ""
       ]
     },
     {
       "ID": 10001000,
       "Entries": [
-        "Form _ bullet owner -- 形代_弾丸オーナー"
+        ""
       ]
     },
     {
       "ID": 10002080,
       "Entries": [
-        "General-purpose dummy character for conversation -- 会話用汎用ダミーキャラ"
+        ""
       ]
     },
     {
       "ID": 10003000,
       "Entries": [
-        "Dummy character for display that seems to find a big snake -- 大蛇見つかりそう表示用ダミーキャラ"
+        ""
       ]
     },
     {
       "ID": 10003001,
       "Entries": [
-        "Dummy character for display that seems to find a big snake _ Wide view around -- 大蛇見つかりそう表示用ダミーキャラ_周辺視界広いバージョン"
+        ""
       ]
     },
     {
       "ID": 10003002,
       "Entries": [
-        "Dummy character for display that seems to find a large snake _ Wide view of enemy search -- 大蛇見つかりそう表示用ダミーキャラ_索敵視界広いバージョン"
+        ""
       ]
     },
     {
       "ID": 10004000,
       "Entries": [
-        "Okiryu Dummy Leader -- 翁竜ダミーリーダー"
+        ""
       ]
     },
     {
       "ID": 10010000,
       "Entries": [
-        "Dummy character for demon Buddha -- 鬼仏用ダミーキャラ"
+        ""
       ]
     },
     {
       "ID": 10010010,
       "Entries": [
-        "Dummy character for camera inside / outside judgment -- カメラ内外判定用ダミーキャラ"
+        ""
       ]
     },
     {
       "ID": 10090000,
       "Entries": [
-        "Careless -- 軽率"
+        ""
       ]
     },
     {
       "ID": 10090001,
       "Entries": [
-        "Normal -- 通常"
+        ""
       ]
     },
     {
       "ID": 10090002,
       "Entries": [
-        "Big game -- 大物"
+        ""
       ]
     },
     {
       "ID": 10090003,
       "Entries": [
-        "Guardian -- 番人"
+        ""
       ]
     },
     {
       "ID": 10090004,
       "Entries": [
-        "ambush -- 待ち伏せ"
+        ""
       ]
     },
     {
       "ID": 10100000,
       "Entries": [
-        "Ochimusha Protomap One-handed sword -- 落武者\u3000プロトマップ\u3000片手刀"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100001,
       "Entries": [
-        "Ochimusha Protomap One-handed Sword Exclusive -- 落武者\u3000プロトマップ\u3000片手刀\u3000専守"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100002,
       "Entries": [
-        "Ochimusha Protomap One-handed sword open space Samurai general&#39;s companion -- 落武者\u3000プロトマップ\u3000片手刀\u3000広場\u3000侍大将のお供"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100003,
       "Entries": [
-        "Ochimusha Protomap One-handed sword for first battle -- 落武者\u3000プロトマップ\u3000片手刀\u3000初戦闘用"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100004,
       "Entries": [
-        "Ochimusha Protomap One-handed sword Do not go in the direction of sound -- 落武者\u3000プロトマップ\u3000片手刀\u3000音方向に行かない"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100005,
       "Entries": [
-        "Ochimusha Protomap One-handed Sword Stopper -- 落武者\u3000プロトマップ\u3000片手刀\u3000ストッパー"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100006,
       "Entries": [
-        "Ochimusha Protomap One-handed sword stopper Short field of view -- 落武者\u3000プロトマップ\u3000片手刀\u3000ストッパー\u3000短視界"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100007,
       "Entries": [
-        "Ochimusha Protomap One-handed sword Stopper Position fixed -- 落武者\u3000プロトマップ\u3000片手刀\u3000ストッパー\u3000位置固定"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100008,
       "Entries": [
-        "Ochimusha Protomap One-handed sword Suspension bridge collapse aim only -- 落武者\u3000プロトマップ\u3000片手刀\u3000吊橋崩落狙い専用"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100009,
       "Entries": [
-        "Ochimusha Protomap One-handed sword Narrow / short field of view: For Proto2 -- 落武者\u3000プロトマップ\u3000片手刀\u3000視界狭い/短い：プロト2用"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100010,
       "Entries": [
-        "Ochimusha Protomap One-handed sword for steep slopes -- 落武者\u3000プロトマップ\u3000片手刀\u3000急な坂用"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100011,
       "Entries": [
-        "Ochimusha Protomap One-handed sword Samurai General Area_Monitor in front of stairs -- 落武者\u3000プロトマップ\u3000片手刀 侍大将エリア_階段前で監視"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100012,
       "Entries": [
-        "Ochimusha Protomap One-handed sword Near the start of the stone wall Surveillance -- 落武者\u3000プロトマップ\u3000片手刀 スタート付近石垣の上\u3000監視"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100020,
       "Entries": [
-        "Ochimusha E3 One-handed sword -- 落武者\u3000E3\u3000片手刀"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100021,
       "Entries": [
-        "Ochimusha E3 One-handed sword E3 Early return home -- 落武者\u3000E3\u3000片手刀\u3000Ｅ３帰巣早め"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100080,
       "Entries": [
-        "Ochimusha One-handed sword The voice of the end of the bridge [Conversation] -- 落武者\u3000片手刀\u3000橋にいる末期の声【会話】"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100100,
       "Entries": [
-        "Ochimusha Protomap Eight Phases -- 落武者\u3000プロトマップ\u3000八相"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100101,
       "Entries": [
-        "Ochimusha Protomap Eight Phases Long Visual -- 落武者\u3000プロトマップ\u3000八相\u3000視覚長め"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100102,
       "Entries": [
-        "Ochimusha Protomap Eight Phase Stopper -- 落武者\u3000プロトマップ\u3000八相\u3000ストッパー"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100103,
       "Entries": [
-        "Ochimusha Protomap Eight-Phase Stopper Short Field of View -- 落武者\u3000プロトマップ\u3000八相\u3000ストッパー\u3000短視界"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100104,
       "Entries": [
-        "Ochimusha Protomap Eight Phases Short visibility -- 落武者\u3000プロトマップ\u3000八相\u3000視界距離短い"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100105,
       "Entries": [
-        "Ochimusha Protomap Eight Phases Narrow / Short: For Proto2 -- 落武者\u3000プロトマップ\u3000八相\u3000視界狭い/短い：プロト2用"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100106,
       "Entries": [
-        "Ochimusha Protomap Eight Phases For steep slopes -- 落武者\u3000プロトマップ\u3000八相\u3000急な坂用"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100107,
       "Entries": [
-        "Ochimusha Protomap Yaso Hiroba Samurai General&#39;s companion -- 落武者\u3000プロトマップ\u3000八相\u3000広場\u3000侍大将のお供"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100108,
       "Entries": [
-        "Ochimusha Protomap Yaso Samurai General Area_Monitor in front of stairs -- 落武者\u3000プロトマップ\u3000八相 侍大将エリア_階段前で監視"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100121,
       "Entries": [
-        "Ochimusha Protomap Eighth Phase E3 Early Return to Home -- 落武者\u3000プロトマップ\u3000八相\u3000Ｅ３帰巣早め"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100200,
       "Entries": [
-        "Ochimusha Protomap Spear -- 落武者\u3000プロトマップ\u3000槍"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100201,
       "Entries": [
-        "Ochimusha Protomap Spear Narrow visual sense -- 落武者\u3000プロトマップ\u3000槍\u3000視覚幅狭い"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100202,
       "Entries": [
-        "Ochimusha Protomap Spear Exclusive -- 落武者\u3000プロトマップ\u3000槍\u3000専守"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100203,
       "Entries": [
-        "Ochimusha Protomap Spear Short visibility -- 落武者\u3000プロトマップ\u3000槍\u3000視界距離短い"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100204,
       "Entries": [
-        "Ochimusha Protomap Spear on the stone wall -- 落武者\u3000プロトマップ\u3000槍\u3000石垣の上"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100205,
       "Entries": [
-        "Ochimusha Protomap Spear For steep slopes -- 落武者\u3000プロトマップ\u3000槍\u3000急な坂用"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100206,
       "Entries": [
-        "Ochimusha Protomap Spear Exclusive For steep slopes -- 落武者\u3000プロトマップ\u3000槍\u3000専守\u3000急な坂用"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100207,
       "Entries": [
-        "Ochimusha Protomap Spear Start Ishigakigami -- 落武者\u3000プロトマップ\u3000槍 \u3000スタートの石垣上"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100220,
       "Entries": [
-        "Ochimusha E3 Spear -- 落武者\u3000E3\u3000槍"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100300,
       "Entries": [
-        "Ochimusha Protomap Matchlock -- 落武者\u3000プロトマップ\u3000火縄銃"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100301,
       "Entries": [
-        "Ochimusha Protomap Matchlock Breakthrough Situation Steep Slope -- 落武者\u3000プロトマップ\u3000火縄銃\u3000突破シチュエーション\u3000急坂"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100302,
       "Entries": [
-        "Ochimusha Protomap Matchlock Ishigakigami -- 落武者\u3000プロトマップ\u3000火縄銃\u3000石垣上"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100303,
       "Entries": [
-        "Ochimusha Protomap Matchlock Gun in front of Yaguramon -- 落武者\u3000プロトマップ\u3000火縄銃\u3000櫓門前"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100304,
       "Entries": [
-        "Ochimusha Protomap Matchlock Fixed Battery -- 落武者\u3000プロトマップ\u3000火縄銃 固定砲台"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100305,
       "Entries": [
-        "Ochimusha Protomap Matchlock Fixed Battery -- 落武者\u3000プロトマップ\u3000火縄銃 固定砲台"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100306,
       "Entries": [
-        "Ochimusha Protomap Matchlock Yaguramon Surveillance Indoors -- 落武者\u3000プロトマップ\u3000火縄銃 櫓門監視\u3000屋内"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100307,
       "Entries": [
-        "Ochimusha Protomap Matchlock Matchlock Strong Gate -- 落武者\u3000プロトマップ\u3000火縄銃 強固な門前"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100308,
       "Entries": [
-        "Ochimusha Gray Box Map Matchlock Indoor -- 落武者\u3000グレイボックスマップ\u3000火縄銃 屋内用"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100309,
       "Entries": [
-        "Ochimusha Gray Box Map Matchlock Outdoor _ Combat + Stealth Area -- 落武者\u3000グレイボックスマップ\u3000火縄銃 屋外用_戦闘＋ステルスエリア"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100310,
       "Entries": [
-        "Ochimusha E3 Matchlock Fixed Battery Koguchi -- 落武者\u3000E3\u3000火縄銃 固定砲台 虎口"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100312,
       "Entries": [
-        "Ochimusha Tokugawa invades Matchlock gun Hashigami -- 落武者\u3000徳川襲来\u3000火縄銃\u3000橋上"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100320,
       "Entries": [
-        "Ochimusha E3 Matchlock Fixed Battery -- 落武者\u3000E3\u3000火縄銃 固定砲台"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100330,
       "Entries": [
-        "Ochimusha Dungeon Matchlock -- 落武者\u3000地下牢\u3000火縄銃"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10100390,
       "Entries": [
-        "Ochimusha Valley Test Map Matchlock -- 落武者\u3000渓谷テストマップ\u3000火縄銃"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10101300,
       "Entries": [
-        "Ochimusha Honjo Matchlock Grand Staircase -- 落武者\u3000本城\u3000火縄銃\u3000大階段"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10101310,
       "Entries": [
-        "Ochimusha Honjo Matchlock Outer -- 落武者\u3000本城\u3000火縄銃\u3000外郭"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10102000,
       "Entries": [
-        "Ochimusha Honjo_When Tokugawa attacks_Large stairs One-handed sword -- 落武者\u3000本城_徳川襲来時_大階段\u3000片手刀"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10102100,
       "Entries": [
-        "Ochimusha Honjo_When Tokugawa attacks_Great stairs Eight phases -- 落武者\u3000本城_徳川襲来時_大階段\u3000八相"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10102200,
       "Entries": [
-        "Ochimusha Honjo_When Tokugawa attacks_Great staircase spear -- 落武者\u3000本城_徳川襲来時_大階段\u3000槍"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10103000,
       "Entries": [
-        "Ochimusha Hidden Prison_Normal One-handed Sword -- 落武者\u3000隠し牢_平常時\u3000片手刀"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10103001,
       "Entries": [
-        "Ochimusha Hidden Prison_Normal One-handed Sword -- 落武者\u3000隠し牢_平常時\u3000片手刀\u3000視界狭い"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10103100,
       "Entries": [
-        "Ochimusha Hidden Prison_Normal Eight Phases -- 落武者\u3000隠し牢_平常時\u3000八相"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10103101,
       "Entries": [
-        "Ochimusha Hidden Prison _ Normal Eight Phases Narrow visibility -- 落武者\u3000隠し牢_平常時\u3000八相\u3000\u3000 視界狭い"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10103200,
       "Entries": [
-        "Ochimusha Hidden Prison_Normal Spear -- 落武者\u3000隠し牢_平常時\u3000槍"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10103300,
       "Entries": [
-        "Ochimusha Hidden Prison_Normal Matchlock -- 落武者\u3000隠し牢_平常時\u3000火縄銃"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10103500,
       "Entries": [
-        "Ochimusha Hidden Prison _ During Tutorial Matchlock _ In front of the station -- 落武者\u3000隠し牢_チュートリアル時\u3000火縄銃_詰所前"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10103510,
       "Entries": [
-        "Ochimusha Hidden Prison _ During Tutorial Matchlock _ On the Stairs -- 落武者\u3000隠し牢_チュートリアル時\u3000火縄銃_階段上"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10103520,
       "Entries": [
-        "Ochimusha Hidden Prison _ During Tutorial Matchlock _ In front of Tsukimi Tower -- 落武者\u3000隠し牢_チュートリアル時\u3000火縄銃_月見櫓前"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10109000,
       "Entries": [
-        "Ochimusha sample one-handed sword -- 落武者\u3000サンプル\u3000片手刀"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10109010,
       "Entries": [
-        "Ochimusha sample One-handed sword corpse discovery test -- 落武者\u3000サンプル\u3000片手刀\u3000死体発見テスト"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10109011,
       "Entries": [
-        "Ochimusha sample One-handed sword corpse discovery test_for sign target discovery -- 落武者\u3000サンプル\u3000片手刀\u3000死体発見テスト_気配タゲ発見用"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10109100,
       "Entries": [
-        "Ochimusha sample eight phases -- 落武者\u3000サンプル\u3000八相"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10109200,
       "Entries": [
-        "Ochimusha sample spear -- 落武者\u3000サンプル\u3000槍"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10109300,
       "Entries": [
-        "Ochimusha sample matchlock -- 落武者\u3000サンプル\u3000火縄銃"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10110000,
       "Entries": [
-        "Ochimusha Hidden Prison One-handed Sword -- 落武者\u3000隠し牢\u3000片手刀"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10110001,
       "Entries": [
-        "Ochimusha Hidden Prison One-handed sword First approach and move sideways -- 落武者\u3000隠し牢\u3000片手刀\u3000初回近づいて横移動"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10110002,
       "Entries": [
-        "Ochimusha Hidden Prison One-handed sword First jump slash → Move a little sideways -- 落武者\u3000隠し牢\u3000片手刀\u3000初回飛び掛かり斬り→ちょっと横移動"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10110003,
       "Entries": [
-        "Ochimusha Hidden Prison One-handed sword for eavesdropping -- 落武者\u3000隠し牢\u3000片手刀\u3000盗み聞き用"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10110100,
       "Entries": [
-        "Ochimusha Hidden Prison Eight Phases -- 落武者\u3000隠し牢\u3000八相"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10110101,
       "Entries": [
-        "Ochimusha Hidden Prison Eight Phases For Jasuga Tutorial -- 落武者\u3000隠し牢\u3000八相\u3000ジャスガチュートリアル用"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10110102,
       "Entries": [
-        "Ochimusha Hidden Prison Eighth Phase Early _ Gate Guard -- 落武者\u3000隠し牢\u3000八相\u3000初期_門前警備"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10110103,
       "Entries": [
-        "Ochimusha Hidden Prison Eight Phases For Eavesdropping -- 落武者\u3000隠し牢\u3000八相\u3000盗み聞き用"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10110500,
       "Entries": [
-        "Ochimusha Hidden Prison One-handed Sword Gate Guard -- 落武者\u3000隠し牢\u3000片手刀\u3000門前警備"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10110501,
       "Entries": [
-        "Ochimusha Hidden Prison Behind the One-Handed Sword Gate -- 落武者\u3000隠し牢\u3000片手刀\u3000門の裏"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10110600,
       "Entries": [
-        "Ochimusha Hidden Prison Eight-Phase Playing Tutorial -- 落武者\u3000隠し牢\u3000八相\u3000弾きチュートリアル"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10110601,
       "Entries": [
-        "Ochimusha Hidden Prison Yasomon-mae Security First Run and Attack -- 落武者\u3000隠し牢\u3000八相\u3000門前警備\u3000初回走って攻撃"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10110602,
       "Entries": [
-        "Ochimusha Hidden Prison Behind the Hachisomon -- 落武者\u3000隠し牢\u3000八相\u3000門の裏"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10110603,
       "Entries": [
-        "Ochimusha Hidden Prison Yasomon-mae Security First Walk -- 落武者\u3000隠し牢\u3000八相\u3000門前警備\u3000初回歩く"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10119000,
       "Entries": [
-        "Ochimusha Tutorial Sample One-handed Sword -- 落武者\u3000チュートリアル\u3000サンプル\u3000片手刀"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10119100,
       "Entries": [
-        "Ochimusha Tutorial Sample Eight Phases -- 落武者\u3000チュートリアル\u3000サンプル\u3000八相"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10120000,
       "Entries": [
-        "Ochimusha Combat Tutorial One-handed Sword -- 落武者\u3000戦闘チュートリアル\u3000片手刀"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10120080,
       "Entries": [
-        "Ochimusha Combat Tutorial One-handed Sword [Conversation] -- 落武者\u3000戦闘チュートリアル\u3000片手刀【会話】"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10120200,
       "Entries": [
-        "Ochimusha Combat Tutorial Spear -- 落武者\u3000戦闘チュートリアル\u3000槍"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10120300,
       "Entries": [
-        "Ochimusha Combat Tutorial Matchlock -- 落武者\u3000戦闘チュートリアル\u3000火縄銃"
+        "Ashina Soldier"
       ]
     },
     {
       "ID": 10200000,
       "Entries": [
-        "Samurai General Protomap -- 侍大将\u3000プロトマップ"
+        "Samurai General"
       ]
     },
     {
       "ID": 10200001,
       "Entries": [
-        "Samurai General Protomap For Samurai General Square -- 侍大将\u3000プロトマップ 侍大将広場用"
+        "Samurai General"
       ]
     },
     {
       "ID": 10200010,
       "Entries": [
-        "Samurai General Protomap Strong -- 侍大将\u3000プロトマップ\u3000強"
+        "General Tenzen Yamauchi"
       ]
     },
     {
       "ID": 10200011,
       "Entries": [
-        "Samurai General E3 Strong -- 侍大将\u3000Ｅ３\u3000強"
+        "Samurai General"
       ]
     },
     {
       "ID": 10200020,
       "Entries": [
-        "Samurai General Castle Lower Lower Tutorial -- 侍大将\u3000城下\u3000下段チュートリアル用"
+        "General Naoromi Kawarada"
       ]
     },
     {
       "ID": 10201000,
       "Entries": [
-        "Samurai General Hidden Prison Tutorial_Initial Placement -- 侍大将\u3000隠し牢\u3000チュートリアル_初期配置"
+        "Leader Shigenori Yamauchi - Initial Placement"
       ]
     },
     {
       "ID": 10201010,
       "Entries": [
-        "Samurai General Hidden Prison Tutorial_After Moving_Before Battle -- 侍大将\u3000隠し牢\u3000チュートリアル_移動後_戦闘前"
+        "Leader Shigenori Yamauchi - Before Battle"
       ]
     },
     {
       "ID": 10201011,
       "Entries": [
-        "Samurai General Hidden Prison Tutorial_After Moving_After Combat Begins -- 侍大将\u3000隠し牢\u3000チュートリアル_移動後_戦闘開始後"
+        "Leader Shigenori Yamauchi - During Battle"
       ]
     },
     {
       "ID": 10201080,
       "Entries": [
-        "Fascinated Samurai Hidden Prison [Conversation] -- 魅了された侍 隠し牢【会話】"
+        "Jinzaemon (Conversation - Ashina Reservoir)"
       ]
     },
     {
       "ID": 10202080,
       "Entries": [
-        "Fascinated Samurai Sick Village_Entrance [Conversation] -- 魅了された侍 病み村_入り口【会話】"
+        "Jinzaemon (Conversation - Ashina Depths)"
       ]
     },
     {
       "ID": 10202081,
       "Entries": [
-        "Fascinated Samurai Sick Village_In front of the square [Conversation] -- 魅了された侍 病み村_広場前【会話】"
+        "Jinzaemon (Conversation - Mibu Village)"
       ]
     },
     {
       "ID": 10202082,
       "Entries": [
-        "Fascinated Samurai Dungeon [Conversation] -- 魅了された侍 地下牢【会話】"
+        "Jinzaemon (Conversation - Bottomless Hole)"
       ]
     },
     {
       "ID": 10203000,
       "Entries": [
-        "Samurai General Honjo Tsuyoshi -- 侍大将\u3000本城\u3000強"
+        "Samurai General"
       ]
     },
     {
       "ID": 10203100,
       "Entries": [
-        "Samurai General Honjo For the Great Stairs -- 侍大将\u3000本城\u3000大階段用"
+        "Generai Kuranosuke Matsumoto"
       ]
     },
     {
       "ID": 10203200,
       "Entries": [
-        "Samurai General Honjo Wider view -- 侍大将\u3000本城\u3000視界\u3000広め"
+        "Samurai General"
       ]
     },
     {
       "ID": 10203300,
       "Entries": [
-        "Samurai General Hidden Prison Wider field of view -- 侍大将\u3000隠し牢\u3000視界\u3000広め"
+        "Samurai General"
       ]
     },
     {
       "ID": 10204000,
       "Entries": [
-        "Samurai General Ashina Four Tenno -- 侍大将\u3000葦名四天王"
+        "Seven Ashina Spears - Shikibu Toshikatsu Yamauchi"
       ]
     },
     {
       "ID": 10204001,
       "Entries": [
-        "Samurai General Ashina Shitenno For Hidden Prison -- 侍大将\u3000葦名四天王\u3000隠し牢用"
+        "Seven Ashina Spears - Shume Masaji Oniwa"
       ]
     },
     {
       "ID": 10209010,
       "Entries": [
-        "Samurai General Sample Tutorial -- 侍大将\u3000サンプル\u3000チュートリアル"
+        "Samurai General"
       ]
     },
     {
       "ID": 10209020,
       "Entries": [
-        "Samurai General Sample Large Spear -- 侍大将\u3000サンプル\u3000大槍"
+        "Samurai General"
       ]
     },
     {
       "ID": 10209990,
       "Entries": [
-        "Samurai General for underwater test -- 侍大将\u3000水中テスト用"
+        "Samurai General"
       ]
     },
     {
       "ID": 10300000,
       "Entries": [
-        "Centipede small prototype map -- ムカデ小\u3000プロトマップ"
+        "Small Centipede"
       ]
     },
     {
       "ID": 10300001,
       "Entries": [
-        "Centipede small prototype map Long-distance type upper row -- ムカデ小\u3000プロトマップ\u3000遠距離型上段"
+        "Small Centipede"
       ]
     },
     {
       "ID": 10300002,
       "Entries": [
-        "Centipede small prototype map Long-distance type middle stage -- ムカデ小\u3000プロトマップ\u3000遠距離型中段"
+        "Small Centipede"
       ]
     },
     {
       "ID": 10300003,
       "Entries": [
-        "Centipede small prototype map Short-distance type -- ムカデ小\u3000プロトマップ\u3000近距離型"
+        "Small Centipede"
       ]
     },
     {
       "ID": 10301000,
       "Entries": [
-        "Centipede Kodera_Gomadou -- ムカデ小\u3000寺_護摩堂"
+        "Centipede"
       ]
     },
     {
       "ID": 10301001,
       "Entries": [
-        "Centipede Kodera_Gomado Long-distance type upper tier -- ムカデ小\u3000寺_護摩堂\u3000遠距離型上段"
+        "Centipede"
       ]
     },
     {
       "ID": 10309000,
       "Entries": [
-        "Centipede small sample -- ムカデ小\u3000サンプル"
+        "Centipede"
       ]
     },
     {
       "ID": 10400000,
       "Entries": [
-        "Centipede Large Protomap -- ムカデ大\u3000プロトマップ"
+        "Long-Arm Centipede (Both)"
       ]
     },
     {
       "ID": 10409000,
       "Entries": [
-        "Centipede large sample -- ムカデ大\u3000サンプル"
+        "Centipede"
       ]
     },
     {
       "ID": 10500000,
       "Entries": [
-        "Spear monk soldier -- 槍僧兵"
+        "Shinobi Hunter"
       ]
     },
     {
       "ID": 10500010,
       "Entries": [
-        "Spear Monk Soldier_Samurai Residence_Middle Boss -- 槍僧兵_武家屋敷_中ボス"
+        "Shinobi Hunter Enshin of Misen"
       ]
     },
     {
       "ID": 10502000,
       "Entries": [
-        "Spear Monk _E3 -- 槍僧兵_E3"
+        "Shinobi Hunter"
       ]
     },
     {
       "ID": 10509000,
       "Entries": [
-        "Spear monk sample -- 槍僧兵 サンプル"
+        "Shinobi Hunter"
       ]
     },
     {
       "ID": 10600000,
       "Entries": [
-        "Rotating Spearman Precincts ① -- 回転槍術師 境内①"
+        "Spear Adept"
       ]
     },
     {
       "ID": 10600001,
       "Entries": [
-        "Rotating Spearman Precincts ① Reinforcement -- 回転槍術師 境内①\u3000増援"
+        "Spear Adept"
       ]
     },
     {
       "ID": 10601000,
       "Entries": [
-        "Rotating Spearman Temple_Main Hall -- 回転槍術師\u3000寺_本堂"
+        "Spear Adept"
       ]
     },
     {
       "ID": 10601001,
       "Entries": [
-        "Rotating Spearman Temple_Main Hall Joined after -- 回転槍術師\u3000寺_本堂 後から合流"
+        "Spear Adept"
       ]
     },
     {
       "ID": 10609000,
       "Entries": [
-        "Rotating Spearman Sample -- 回転槍術師 サンプル"
+        "Spear Adept"
       ]
     },
     {
@@ -964,13 +964,13 @@
     {
       "ID": 10800000,
       "Entries": [
-        "Seven-sided warrior -- 七面武者"
+        "Shichimen Warrior"
       ]
     },
     {
       "ID": 10800001,
       "Entries": [
-        "Seven-sided warrior valley lower layer -- 七面武者\u3000渓谷下層"
+        "Shichimen Warrior - Ashina Depths"
       ]
     },
     {
@@ -1120,7 +1120,7 @@
     {
       "ID": 11300000,
       "Entries": [
-        "Nanban armor -- 南蛮甲冑"
+        "Armored Warrior - Senpou Temple"
       ]
     },
     {
@@ -1426,13 +1426,13 @@
     {
       "ID": 11900101,
       "Entries": [
-        "Valley enemy_strong enemy (female sniper) Lower layer -- 谷敵_強敵（女スナイパー）\u3000下層"
+        "Snake Eyes Shirahagi - Ashina Depths"
       ]
     },
     {
       "ID": 11900102,
       "Entries": [
-        "Valley enemy_strong enemy (female sniper) Upper layer_only for Nakasu -- 谷敵_強敵（女スナイパー）\u3000上層_中州専用"
+        "Snake Eyes Shurafuji - Sunken Valley"
       ]
     },
     {
@@ -2230,7 +2230,7 @@
     {
       "ID": 13500000,
       "Entries": [
-        "Neckless -- 首無し"
+        "Headless - Sunken Valley"
       ]
     },
     {
@@ -2338,109 +2338,109 @@
     {
       "ID": 13700000,
       "Entries": [
-        "Fire cow main castle -- 火牛\u3000本城"
+        "Blazing Bull"
       ]
     },
     {
       "ID": 13709000,
       "Entries": [
-        "Fire cow sample -- 火牛\u3000サンプル"
+        "Bull"
       ]
     },
     {
       "ID": 13800000,
       "Entries": [
-        "Fire Cow Innsmouth Submerged City -- 火牛インスマウス\u3000水没都"
+        "Sakura Bull of the Palace"
       ]
     },
     {
       "ID": 14000000,
       "Entries": [
-        "Swordsman protection type -- 剣客\u3000守りタイプ"
+        "Ashina Fencer"
       ]
     },
     {
       "ID": 14000010,
       "Entries": [
-        "Swordsman protection type for Tokugawa grand staircase -- 剣客\u3000守りタイプ\u3000徳川大階段用"
+        "Ashina Fencer"
       ]
     },
     {
       "ID": 14000020,
       "Entries": [
-        "Swordsman protection type narrow left and right field of view -- 剣客\u3000守りタイプ\u3000左右視界狭め"
+        "Ashina Fencer"
       ]
     },
     {
       "ID": 14000080,
       "Entries": [
-        "Swordsman Suzuba&#39;s son Castle [Conversation] -- 剣客\u3000鈴ばばあの息子\u3000城下【会話】"
+        "Ashina Fencer"
       ]
     },
     {
       "ID": 14000090,
       "Entries": [
-        "Swordsman Defensive Type Samurai Residence Co-op NPC -- 剣客\u3000守りタイプ\u3000武家屋敷\u3000共闘ＮＰＣ"
+        "Ashina Fencer"
       ]
     },
     {
       "ID": 14000100,
       "Entries": [
-        "Swordsman offensive type -- 剣客\u3000攻めタイプ"
+        "Ashina Fencer"
       ]
     },
     {
       "ID": 14000110,
       "Entries": [
-        "Swordsman offensive type for Tokugawa Grand Staircase -- 剣客\u3000攻めタイプ\u3000徳川大階段用"
+        "Ashina Fencer"
       ]
     },
     {
       "ID": 14000120,
       "Entries": [
-        "Swordsman offensive type narrow left and right field of view -- 剣客\u3000攻めタイプ\u3000左右視界狭め"
+        "Ashina Fencer"
       ]
     },
     {
       "ID": 14000200,
       "Entries": [
-        "Swordsman Iai -- 剣客\u3000居合い"
+        "Ashina Elite - Ujinari Mizuo - Ashina Castle"
       ]
     },
     {
       "ID": 14000210,
       "Entries": [
-        "Swordsman Iai Honjo_Attic -- 剣客\u3000居合い\u3000本城_屋根裏部屋"
+        "Ashina Elite - Jinsuke Saze"
       ]
     },
     {
       "ID": 14001080,
       "Entries": [
-        "Swordsman Suzuba&#39;s son Samurai residence [Conversation] -- 剣客\u3000鈴ばばあの息子\u3000武家屋敷【会話】"
+        "Inosuke Nogami (Conversation)"
       ]
     },
     {
       "ID": 14001180,
       "Entries": [
-        "Sick village priest [conversation] -- 病み村神主【会話】"
+        "Mibu Village Priest (Conversation)"
       ]
     },
     {
       "ID": 14009000,
       "Entries": [
-        "Swordsman defensive type sample -- 剣客\u3000守りタイプ\u3000サンプル"
+        "Ashina Fencer"
       ]
     },
     {
       "ID": 14009100,
       "Entries": [
-        "Swordsman offensive type sample -- 剣客\u3000攻めタイプ\u3000サンプル"
+        "Ashina Fencer"
       ]
     },
     {
       "ID": 14009200,
       "Entries": [
-        "Swordsman Iai sample -- 剣客\u3000居合い\u3000サンプル"
+        "Ashina Fencer"
       ]
     },
     {
@@ -2620,19 +2620,19 @@
     {
       "ID": 14701002,
       "Entries": [
-        "The boss in the main castle -- 孤影衆\u3000本城\u3000中ボス\u3000視界広め"
+        "Lone Shadow Masanaga the Spear-Bearer - Ashina Castle"
       ]
     },
     {
       "ID": 14701003,
       "Entries": [
-        "Kokageshu Honjo Attic Boss -- 孤影衆\u3000本城\u3000屋根裏中ボスのお付"
+        "Lone Shadow Vilehand's Friend"
       ]
     },
     {
       "ID": 14701004,
       "Entries": [
-        "Kokageshu Honjo Boss in the attic Wider view -- 孤影衆\u3000本城\u3000屋根裏中ボス\u3000視界広め"
+        "Lone Shadow Vilehand"
       ]
     },
     {
@@ -2662,7 +2662,7 @@
     {
       "ID": 14703000,
       "Entries": [
-        "Lonely crowd hidden prison boss widening the field of view -- 孤影衆\u3000隠し牢\u3000中ボス\u3000視界広め"
+        "Lone Shadow Longswordsman"
       ]
     },
     {
@@ -3544,7 +3544,7 @@
     {
       "ID": 50200010,
       "Entries": [
-        "Akaoni Castle_Middle Boss -- 赤鬼 城下_中ボス"
+        "Chained Orge - Ashina Outskirts"
       ]
     },
     {
@@ -3562,7 +3562,7 @@
     {
       "ID": 50201000,
       "Entries": [
-        "Akaoni Honjo Naka Boss -- 赤鬼\u3000本城\u3000中ボス"
+        "Chained Ogre - Ashina Castle"
       ]
     },
     {
@@ -3640,7 +3640,7 @@
     {
       "ID": 50601000,
       "Entries": [
-        "The Great Honjo of the Old and Ninja Army -- 老・忍軍の長\u3000本城"
+        "Great Shinobi Owl - Ashina Castle"
       ]
     },
     {
@@ -3700,25 +3700,25 @@
     {
       "ID": 51000000,
       "Entries": [
-        "Yasha Ape -- 夜叉猿"
+        "Guardian Ape - Sunken Valley"
       ]
     },
     {
       "ID": 51000010,
       "Entries": [
-        "Yasha Ape_Bride -- 夜叉猿_嫁"
+        "Guardian Ape Bride"
       ]
     },
     {
       "ID": 51000011,
       "Entries": [
-        "Yasha Monkey_Bride_Collaboration Test -- 夜叉猿_嫁_連携テスト"
+        "Guardian Ape Bride"
       ]
     },
     {
       "ID": 51000100,
       "Entries": [
-        "Yasha Ape_Neckless -- 夜叉猿_首無し"
+        "Headless Ape - Ashina Depths"
       ]
     },
     {
@@ -3820,25 +3820,25 @@
     {
       "ID": 54300000,
       "Entries": [
-        "Revived Kensei (bed) -- 蘇った剣聖（病床）"
+        "Isshin Ashina - Ashina Castle"
       ]
     },
     {
       "ID": 54300080,
       "Entries": [
-        "Revived Kensei (bed) _ Conversation [Honjo] -- 蘇った剣聖（病床）_会話【本城】"
+        "Isshin Ashina (Conversation - Isshin's Tower)"
       ]
     },
     {
       "ID": 54301080,
       "Entries": [
-        "Skill old man (Kensei sickbed) Castle [Conversation] -- スキル爺（病床剣聖）\u3000城下【会話】"
+        "Tengu (Conversation - Ashina Outskirts)"
       ]
     },
     {
       "ID": 54302080,
       "Entries": [
-        "Skill old man (Kensei sickbed) Honjo [Conversation] -- スキル爺（病床剣聖）\u3000本城【会話】"
+        "Tengu (Conversation - Great Serpent Shrine)"
       ]
     },
     {
@@ -3910,31 +3910,31 @@
     {
       "ID": 71000000,
       "Entries": [
-        "rival -- ライバル"
+        "Genichiro Ashina - Ashina Reservoir"
       ]
     },
     {
       "ID": 71030000,
       "Entries": [
-        "Rival (back) -- ライバル（裏）"
+        "Genichiro Ashina - Ashina Castle"
       ]
     },
     {
       "ID": 71100000,
       "Entries": [
-        "Rival (naked) -- ライバル(裸)"
+        "Genichiro, Way of Tomoe - Ashina Reservoir"
       ]
     },
     {
       "ID": 71130000,
       "Entries": [
-        "Rival (naked) (back) -- ライバル(裸)（裏）"
+        "Genichiro, Way of Tomoe - Ashina Castle"
       ]
     },
     {
       "ID": 72000000,
       "Entries": [
-        "Prince -- 皇子"
+        "Lord Kuro"
       ]
     },
     {
@@ -3958,7 +3958,7 @@
     {
       "ID": 72001080,
       "Entries": [
-        "Prince_Honjo_Meditation Room [Conversation] -- 皇子_本城_瞑想部屋【会話】"
+        "Lord Kuro (Conversation - Kuro's Room)"
       ]
     },
     {
@@ -3982,13 +3982,13 @@
     {
       "ID": 74000000,
       "Entries": [
-        "Medical Holy Daughter -- 医聖の娘"
+        "Emma, the Gentle Blade"
       ]
     },
     {
       "ID": 74000080,
       "Entries": [
-        "Daughter of Isei Honjo_Meditation Room [Conversation] -- 医聖の娘 本城_瞑想部屋【会話】"
+        "Emma (Conversation - Kuro's Room)"
       ]
     },
     {
@@ -4000,13 +4000,13 @@
     {
       "ID": 74000082,
       "Entries": [
-        "Daughter of Isei Honjo_When Tokugawa invades [Conversation] -- 医聖の娘 本城_徳川襲来時【会話】"
+        "Emma (Conversation - Central Forces Invasion)"
       ]
     },
     {
       "ID": 74000083,
       "Entries": [
-        "Daughter of Isei Honjo_Separation of Kensei [Conversation] -- 医聖の娘 本城_剣聖の離れ【会話】"
+        "Emma (Conversation - Isshin's Tower)"
       ]
     },
     {

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/NpcThinkParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/NpcThinkParam.json
@@ -934,31 +934,31 @@
     {
       "ID": 10700000,
       "Entries": [
-        "Shura Samurai -- 修羅侍"
+        "Shura Samurai"
       ]
     },
     {
       "ID": 10700010,
       "Entries": [
-        "Shura Samurai_Samurai Residence Truth Edition -- 修羅侍_武家屋敷真相編"
+        "Juzou the Drunkard - Hirata Estate Revisit"
       ]
     },
     {
       "ID": 10701000,
       "Entries": [
-        "Shura Samurai E3 Castle -- 修羅侍 E3城下"
+        "Shura Samurai"
       ]
     },
     {
       "ID": 10702000,
       "Entries": [
-        "Shura Samurai Sick Village -- 修羅侍 病み村"
+        "Tokurijo the Glutton - Ashina Depths"
       ]
     },
     {
       "ID": 10709000,
       "Entries": [
-        "Shura Samurai Sample -- 修羅侍\u3000サンプル"
+        "Shura Samurai"
       ]
     },
     {
@@ -976,145 +976,145 @@
     {
       "ID": 10809000,
       "Entries": [
-        "Seven-sided warrior sample -- 七面武者 サンプル"
+        "Shichimen Warrior"
       ]
     },
     {
       "ID": 11000000,
       "Entries": [
-        "Gecko -- ヤモリ"
+        "Gecko"
       ]
     },
     {
       "ID": 11000001,
       "Entries": [
-        "Gecko Protomap Enhanced visual distance -- ヤモリ\u3000プロトマップ\u3000視覚距離強化"
+        "Gecko"
       ]
     },
     {
       "ID": 11000002,
       "Entries": [
-        "Gecko valley view 360 degrees -- ヤモリ \u3000渓谷\u3000視界360度"
+        "Gecko"
       ]
     },
     {
       "ID": 11000003,
       "Entries": [
-        "Gecko main castle for ceiling attachment -- ヤモリ \u3000本城\u3000天井張り付き用"
+        "Gecko"
       ]
     },
     {
       "ID": 11000090,
       "Entries": [
-        "Gecko treasure carp test -- ヤモリ\u3000宝鯉テスト"
+        "Gecko"
       ]
     },
     {
       "ID": 11002000,
       "Entries": [
-        "Gecko Temple -- ヤモリ\u3000寺"
+        "Gecko"
       ]
     },
     {
       "ID": 11009000,
       "Entries": [
-        "Gecko sample -- ヤモリ\u3000サンプル"
+        "Gecko"
       ]
     },
     {
       "ID": 11100000,
       "Entries": [
-        "Handmaiden Aunt Protomap -- 侍女おば\u3000プロトマップ"
+        "Old Maid"
       ]
     },
     {
       "ID": 11100001,
       "Entries": [
-        "Handmaiden Aunt Protomap 1st Playable Shop Clerk -- 侍女おば\u3000プロトマップ\u30001stプレイアブル用ショップ店員"
+        "Old Maid"
       ]
     },
     {
       "ID": 11100010,
       "Entries": [
-        "Handmaiden Aunt E3 Map -- 侍女おば\u3000E3マップ"
+        "Old Maid"
       ]
     },
     {
       "ID": 11100020,
       "Entries": [
-        "Handmaiden Aunt Valley Don&#39;t come by the sound -- 侍女おば\u3000渓谷\u3000音で寄ってこない"
+        "Old Maid"
       ]
     },
     {
       "ID": 11100080,
       "Entries": [
-        "Handmaiden Aunt Suzubaa Castle [Conversation] -- 侍女おば 鈴ばばあ\u3000城下【会話】"
+        "Old Maid"
       ]
     },
     {
       "ID": 11100084,
       "Entries": [
-        "Handmaiden Aunt Shop Clerk Castle [Conversation] -- 侍女おば ショップ店員\u3000城下【会話】"
+        "Old Maid"
       ]
     },
     {
       "ID": 11101080,
       "Entries": [
-        "Handmaiden Aunt Suzubaa Samurai Residence [Conversation] -- 侍女おば 鈴ばばあ\u3000武家屋敷【会話】"
+        "Old Maid"
       ]
     },
     {
       "ID": 11105180,
       "Entries": [
-        "Handmaiden Aunt Yayobioka Nun Honjo [Conversation] -- 侍女おば 八百比丘尼\u3000本城【会話】"
+        "Old Maid"
       ]
     },
     {
       "ID": 11109000,
       "Entries": [
-        "Handmaiden aunt sample -- 侍女おば\u3000サンプル"
+        "Old Maid"
       ]
     },
     {
       "ID": 11200000,
       "Entries": [
-        "Lookout prototype map -- 見張り番\u3000プロトマップ"
+        "Sentry"
       ]
     },
     {
       "ID": 11200001,
       "Entries": [
-        "Lookout Castle Castle Visual Downward Enhanced Version -- 見張り番\u3000城下\u3000視覚下\u3000方向強化版"
+        "Sentry"
       ]
     },
     {
       "ID": 11200002,
       "Entries": [
-        "Lookout Protomap Visual Stenosis Version -- 見張り番\u3000プロトマップ\u3000視覚狭窄版"
+        "Sentry"
       ]
     },
     {
       "ID": 11200010,
       "Entries": [
-        "Lookout Protomap Enhanced visual distance -- 見張り番\u3000プロトマップ\u3000視覚距離強化"
+        "Sentry"
       ]
     },
     {
       "ID": 11200020,
       "Entries": [
-        "Lookout E3 Castle Visual distance enhancement -- 見張り番\u3000E3城下\u3000視覚距離強化"
+        "Sentry"
       ]
     },
     {
       "ID": 11200021,
       "Entries": [
-        "Lookout Castle Tokugawa Visual distance &amp; range further strengthened -- 見張り番\u3000城下徳川\u3000視覚距離＆範囲さらに強化"
+        "Sentry"
       ]
     },
     {
       "ID": 11209000,
       "Entries": [
-        "Lookout sample -- 見張り番\u3000サンプル"
+        "Sentry"
       ]
     },
     {
@@ -1126,301 +1126,301 @@
     {
       "ID": 11309000,
       "Entries": [
-        "Nanban armor sample -- 南蛮甲冑 サンプル"
+        "Armored Warrior"
       ]
     },
     {
       "ID": 11400000,
       "Entries": [
-        "Earthen wall soldier burrow -- 土塀兵\u3000巣穴"
+        "Rock Diver"
       ]
     },
     {
       "ID": 11409000,
       "Entries": [
-        "Earthen wall soldier sample -- 土塀兵\u3000サンプル"
+        "Rock Diver"
       ]
     },
     {
       "ID": 11500000,
       "Entries": [
-        "Dog prototype map -- イヌ\u3000プロトマップ"
+        "Hound"
       ]
     },
     {
       "ID": 11500001,
       "Entries": [
-        "Dog Protomap Strengthen visibility &amp; strengthen battle start -- イヌ\u3000プロトマップ 視界強化＆戦闘開始強化"
+        "Hound"
       ]
     },
     {
       "ID": 11500002,
       "Entries": [
-        "Dog prototype map Wide olfactory range -- イヌ\u3000プロトマップ 嗅覚範囲広い"
+        "Hound"
       ]
     },
     {
       "ID": 11501000,
       "Entries": [
-        "Dog samurai residence Visual enhancement -- イヌ\u3000武家屋敷\u3000視覚強化"
+        "Hound"
       ]
     },
     {
       "ID": 11501010,
       "Entries": [
-        "Dog samurai residence sensitive -- イヌ\u3000武家屋敷\u3000敏感"
+        "Hound"
       ]
     },
     {
       "ID": 11501020,
       "Entries": [
-        "Dog Samurai residence Watch dog of this family -- イヌ\u3000武家屋敷\u3000本家庭の見張り犬"
+        "Hound"
       ]
     },
     {
       "ID": 11501030,
       "Entries": [
-        "Dog samurai residence -- イヌ\u3000武家屋敷"
+        "Hound"
       ]
     },
     {
       "ID": 11501040,
       "Entries": [
-        "Dog samurai residence Difficult to return home -- イヌ\u3000武家屋敷\u3000帰巣しづらい"
+        "Hound"
       ]
     },
     {
       "ID": 11501050,
       "Entries": [
-        "Dog flaming entrance -- イヌ\u3000炎上玄関"
+        "Hound"
       ]
     },
     {
       "ID": 11502000,
       "Entries": [
-        "Inu Honjo -- イヌ\u3000本城"
+        "Hound"
       ]
     },
     {
       "ID": 11502100,
       "Entries": [
-        "Dog Honjo for surprise attack -- イヌ\u3000本城 奇襲用"
+        "Hound"
       ]
     },
     {
       "ID": 11503000,
       "Entries": [
-        "Dog submerged city_Sakuraba -- イヌ\u3000水没都_桜庭"
+        "Palace Hound"
       ]
     },
     {
       "ID": 11503100,
       "Entries": [
-        "Dog submerged city_next to the seven-sided warrior -- イヌ\u3000水没都_七面武者横"
+        "Palace Hound"
       ]
     },
     {
       "ID": 11504000,
       "Entries": [
-        "Dog sick village hidden -- イヌ\u3000病み村\u3000姿隠し"
+        "Hound"
       ]
     },
     {
       "ID": 11509000,
       "Entries": [
-        "Dog sample -- イヌ\u3000サンプル"
+        "Hound"
       ]
     },
     {
       "ID": 11700000,
       "Entries": [
-        "Crow -- カラス"
+        "Crow"
       ]
     },
     {
       "ID": 11800000,
       "Entries": [
-        "Lower man _ mallet -- 下男_木槌"
+        "Taro Troop"
       ]
     },
     {
       "ID": 11800001,
       "Entries": [
-        "Lower man _ mallet _ narrow field of view -- 下男_木槌_視界狭い"
+        "Taro Troop"
       ]
     },
     {
       "ID": 11800002,
       "Entries": [
-        "Lower man _ mallet Honjo zigzag fold -- 下男_木槌 本城\u3000つづら折り"
+        "Taro Troop"
       ]
     },
     {
       "ID": 11800010,
       "Entries": [
-        "Lower man _ mallet _ crying start -- 下男_木槌_泣き状態スタート"
+        "Taro Troop"
       ]
     },
     {
       "ID": 11800100,
       "Entries": [
-        "Younger man_Kanabo -- 下男_金砕棒"
+        "Taro Troop"
       ]
     },
     {
       "ID": 11800110,
       "Entries": [
-        "Lower man _ gold crushing stick _ crying start -- 下男_金砕棒_泣き状態スタート"
+        "Taro Troop"
       ]
     },
     {
       "ID": 11800200,
       "Entries": [
-        "Lower man _ bell with a string -- 下男_紐付き鐘"
+        "Taro Troop"
       ]
     },
     {
       "ID": 11800210,
       "Entries": [
-        "Lower man _ bell with a string Narrowing the field of view -- 下男_紐付き鐘\u3000視界狭め"
+        "Taro Troop"
       ]
     },
     {
       "ID": 11800400,
       "Entries": [
-        "Lower man _ shield -- 下男_盾"
+        "Taro Troop"
       ]
     },
     {
       "ID": 11801280,
       "Entries": [
-        "Lower man _ bell with a string kidnapped lower man temple [conversation] -- 下男_紐付き鐘 さらわれ下男 寺 【会話】"
+        "Taro Troop"
       ]
     },
     {
       "ID": 11802280,
       "Entries": [
-        "Lower man _ bell with a string kidnapped lower man castle merging with a bandit [conversation] -- 下男_紐付き鐘 さらわれ下男 城下 物売り野盗と合流 【会話】"
+        "Taro Troop"
       ]
     },
     {
       "ID": 11802281,
       "Entries": [
-        "Lower man _ Bell with ties After the kidnapped lower man castle Tokugawa attack [Conversation] -- 下男_紐付き鐘 さらわれ下男 城下 徳川襲来後 【会話】"
+        "Taro Troop"
       ]
     },
     {
       "ID": 11803000,
       "Entries": [
-        "Lower man _ mallet _ hidden prison -- 下男_木槌_隠し牢"
+        "Taro Troop"
       ]
     },
     {
       "ID": 11803100,
       "Entries": [
-        "Younger man_Kanabo_Hidden prison -- 下男_金砕棒_隠し牢"
+        "Taro Troop"
       ]
     },
     {
       "ID": 11809000,
       "Entries": [
-        "Lower man _ mallet sample -- 下男_木槌 サンプル"
+        "Taro Troop"
       ]
     },
     {
       "ID": 11809100,
       "Entries": [
-        "Lower man_Kanabo sample -- 下男_金砕棒 サンプル"
+        "Taro Troop"
       ]
     },
     {
       "ID": 11809200,
       "Entries": [
-        "Lower man_bell with string sample -- 下男_紐付き鐘 サンプル"
+        "Taro Troop"
       ]
     },
     {
       "ID": 11809400,
       "Entries": [
-        "Lower man _ shield sample -- 下男_盾 サンプル"
+        "Taro Troop"
       ]
     },
     {
       "ID": 11900000,
       "Entries": [
-        "Valley enemy_Zako -- 谷敵_ザコ"
+        "Sunken Valley Clan"
       ]
     },
     {
       "ID": 11900001,
       "Entries": [
-        "Valley enemy_Zako Downward visibility is narrow -- 谷敵_ザコ\u3000下方向視界狭い"
+        "Sunken Valley Clan"
       ]
     },
     {
       "ID": 11900002,
       "Entries": [
-        "Valley Enemy_ Fort Zako -- 谷敵_ザコ \u3000砦"
+        "Sunken Valley Clan"
       ]
     },
     {
       "ID": 11900003,
       "Entries": [
-        "Valley Enemy_ Fort Zako Come to Naruko -- 谷敵_ザコ \u3000砦\u3000鳴子になったら寄ってくる"
+        "Sunken Valley Clan"
       ]
     },
     {
       "ID": 11900004,
       "Entries": [
-        "Valley Enemy_Zako Narrow valley Downward visibility Narrow + short visibility -- 谷敵_ザコ \u3000狭い谷 下方向視界狭い+視界短め"
+        "Sunken Valley Clan"
       ]
     },
     {
       "ID": 11900005,
       "Entries": [
-        "Valley Enemy_Zako Narrow Valley Normal + Short visibility -- 谷敵_ザコ \u3000狭い谷 通常+視界短め"
+        "Sunken Valley Clan"
       ]
     },
     {
       "ID": 11900006,
       "Entries": [
-        "Valley Enemy_Zako Narrow valley Upward field of view wide + short field of view -- 谷敵_ザコ \u3000狭い谷 上方向視界広い+視界短め"
+        "Sunken Valley Clan"
       ]
     },
     {
       "ID": 11900007,
       "Entries": [
-        "Valley Enemy_Zako Narrow Valley Normal + Visibility is quite short -- 谷敵_ザコ \u3000狭い谷 通常+視界かなり短め"
+        "Sunken Valley Clan"
       ]
     },
     {
       "ID": 11900008,
       "Entries": [
-        "Valley enemy_Zako Wide view up, down, left and right -- 谷敵_ザコ \u3000上下左右視界広い"
+        "Sunken Valley Clan"
       ]
     },
     {
       "ID": 11900009,
       "Entries": [
-        "Valley enemy_Zako Wide valley layer Short visibility -- 谷敵_ザコ \u3000広い谷下層 視界短め"
+        "Sunken Valley Clan"
       ]
     },
     {
       "ID": 11900010,
       "Entries": [
-        "Valley enemy _ Zako Wide valley lower layer Long-sighted -- 谷敵_ザコ \u3000広い谷下層\u3000視長め"
+        "Sunken Valley Clan"
       ]
     },
     {
       "ID": 11900011,
       "Entries": [
-        "Valley Enemy_Zako Narrow Valley Normal + Visibility is quite short -- 谷敵_ザコ \u3000狭い谷 通常+視界かなり短め"
+        "Sunken Valley Clan"
       ]
     },
     {
       "ID": 11900100,
       "Entries": [
-        "Valley enemy_strong enemy (female sniper) upper layer -- 谷敵_強敵（女スナイパー）\u3000上層"
+        "Sunken Valley Clan"
       ]
     },
     {
@@ -1438,721 +1438,721 @@
     {
       "ID": 11900200,
       "Entries": [
-        "Valley Enemy_Shotgun Turn when Naruko becomes -- 谷敵_散弾 鳴子がなったら旋回 縦視界広い、横狭い"
+        "Sunken Valley Clan"
       ]
     },
     {
       "ID": 11900201,
       "Entries": [
-        "Valley Enemy_Shotgun When Naruko becomes, come closer and jump down the cliff -- 谷敵_散弾\u3000鳴子がなったら寄ってくる・崖飛び降りる"
+        "Sunken Valley Clan"
       ]
     },
     {
       "ID": 11900210,
       "Entries": [
-        "Valley enemy_shotgun Wide valley entrance -- 谷敵_散弾 広い谷入り口"
+        "Sunken Valley Clan"
       ]
     },
     {
       "ID": 11900300,
       "Entries": [
-        "Valley enemy_cannon -- 谷敵_大砲"
+        "Sunken Valley Clan"
       ]
     },
     {
       "ID": 11900301,
       "Entries": [
-        "Valley enemy_cannon_castle -- 谷敵_大砲_城下"
+        "Sunken Valley Clan"
       ]
     },
     {
       "ID": 11900310,
       "Entries": [
-        "Valley Enemy_Cannon Honjo -- 谷敵_大砲 本城"
+        "Sunken Valley Clan"
       ]
     },
     {
       "ID": 11901300,
       "Entries": [
-        "Valley Enemy_Cannon Valley Wide Valley_Lower -- 谷敵_大砲\u3000渓谷\u3000広い谷_下層"
+        "Sunken Valley Clan"
       ]
     },
     {
       "ID": 11905000,
       "Entries": [
-        "Valley Enemy_Zako Revenge Spirit -- 谷敵_ザコ 復讐霊"
+        "Sunken Valley Clan"
       ]
     },
     {
       "ID": 11905001,
       "Entries": [
-        "Valley Enemy_Zako Revenge Spirit -- 谷敵_ザコ 復讐霊"
+        "Sunken Valley Clan"
       ]
     },
     {
       "ID": 11905100,
       "Entries": [
-        "Valley enemy_strong enemy (female sniper) -- 谷敵_強敵（女スナイパー）"
+        "Sunken Valley Clan"
       ]
     },
     {
       "ID": 11905101,
       "Entries": [
-        "Valley enemy_strong enemy (female sniper) -- 谷敵_強敵（女スナイパー）"
+        "Sunken Valley Clan"
       ]
     },
     {
       "ID": 11909000,
       "Entries": [
-        "Valley Enemy_Zako Sample -- 谷敵_ザコ サンプル"
+        "Sunken Valley Clan"
       ]
     },
     {
       "ID": 11909100,
       "Entries": [
-        "Valley enemy _ sniper sample -- 谷敵_狙撃 サンプル"
+        "Sunken Valley Clan"
       ]
     },
     {
       "ID": 11909200,
       "Entries": [
-        "Valley Enemy_Shotgun Sample -- 谷敵_散弾 サンプル"
+        "Sunken Valley Clan"
       ]
     },
     {
       "ID": 11909300,
       "Entries": [
-        "Valley enemy_cannon sample -- 谷敵_大砲 サンプル"
+        "Sunken Valley Clan"
       ]
     },
     {
       "ID": 12000000,
       "Entries": [
-        "Sokushinbutsu _ with centipede -- 即身仏_ムカデあり"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12009000,
       "Entries": [
-        "Sokushinbutsu_Centipede sample -- 即身仏_ムカデあり サンプル"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100000,
       "Entries": [
-        "Sokushinbutsu_no centipede -- 即身仏_ムカデなし"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100001,
       "Entries": [
-        "Immediate Buddha_No Centipede_Phantom Monk -- 即身仏_ムカデなし_幻術僧"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100005,
       "Entries": [
-        "Sokushinbutsu_No centipede Main hall -- 即身仏_ムカデなし 本堂"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12100010,
       "Entries": [
-        "Sokushinbutsu_Poltergeist -- 即身仏_ポルターガイスト"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12102080,
       "Entries": [
-        "Sokushinbutsu_No centipede [Conversation] -- 即身仏_ムカデなし【会話】"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12109000,
       "Entries": [
-        "Sokushinbutsu_No centipede sample -- 即身仏_ムカデなし サンプル"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12109010,
       "Entries": [
-        "Sokushinbutsu_Poltergeist sample -- 即身仏_ポルターガイスト サンプル"
+        "Infested Seeker"
       ]
     },
     {
       "ID": 12110000,
       "Entries": [
-        "Cricket Temple -- コオロギ\u3000寺"
+        "Cricket"
       ]
     },
     {
       "ID": 12110001,
       "Entries": [
-        "Cricket_for defensive type -- コオロギ_守りタイプ用"
+        "Cricket"
       ]
     },
     {
       "ID": 12111000,
       "Entries": [
-        "Cricket dungeon -- コオロギ\u3000地下牢"
+        "Cricket"
       ]
     },
     {
       "ID": 12111001,
       "Entries": [
-        "Cricket_Defense type dungeon -- コオロギ_守りタイプ用\u3000地下牢"
+        "Cricket"
       ]
     },
     {
       "ID": 12118000,
       "Entries": [
-        "Hallucinatory character _ cricket -- 幻覚キャラ_コオロギ"
+        "Cricket"
       ]
     },
     {
       "ID": 12119000,
       "Entries": [
-        "Cricket sample -- コオロギ サンプル"
+        "Cricket"
       ]
     },
     {
       "ID": 12120000,
       "Entries": [
-        "Dummy character for poltergeist -- ポルターガイスト用ダミーキャラ"
+        "Dummy for Ghost"
       ]
     },
     {
       "ID": 12200000,
       "Entries": [
-        "Temple foundation Zako_fist -- 寺基礎ザコ_拳"
+        "Seeker"
       ]
     },
     {
       "ID": 12200001,
       "Entries": [
-        "Temple Foundation Zako_Fist Temple_Precincts 2 -- 寺基礎ザコ_拳\u3000寺_境内2"
+        "Seeker"
       ]
     },
     {
       "ID": 12200002,
       "Entries": [
-        "Temple Foundation Zako_Fist Temple_Mountain Road 1, 2 -- 寺基礎ザコ_拳\u3000寺_山道1、2"
+        "Seeker"
       ]
     },
     {
       "ID": 12200003,
       "Entries": [
-        "Temple Foundation Zako_Fist Corridor 1 -- 寺基礎ザコ_拳\u3000回廊1"
+        "Seeker"
       ]
     },
     {
       "ID": 12200080,
       "Entries": [
-        "Temple Foundation Zako_Fist Infinite Corridor Tips NPC [Conversation] -- 寺基礎ザコ_拳\u3000無限回廊ヒントNPC【会話】"
+        "Seeker"
       ]
     },
     {
       "ID": 12200100,
       "Entries": [
-        "Temple foundation Zako_ stick art -- 寺基礎ザコ_棒術"
+        "Seeker"
       ]
     },
     {
       "ID": 12200200,
       "Entries": [
-        "Temple Foundation Zako_Surgeon -- 寺基礎ザコ_術士"
+        "Seeker"
       ]
     },
     {
       "ID": 12200201,
       "Entries": [
-        "Temple Foundation Zako_Surgeon Temple_Precincts 2 -- 寺基礎ザコ_術士 寺_境内2"
+        "Seeker"
       ]
     },
     {
       "ID": 12200202,
       "Entries": [
-        "Temple Foundation Zako_Surgeon Temple_Mountain Road 4 -- 寺基礎ザコ_術士\u3000寺_山道4"
+        "Seeker"
       ]
     },
     {
       "ID": 12200203,
       "Entries": [
-        "Temple Foundation Zako_Surgeon Corridor 1 -- 寺基礎ザコ_術士 回廊1"
+        "Seeker"
       ]
     },
     {
       "ID": 12201280,
       "Entries": [
-        "Temple Foundation Zako Surgeon Immortality Experiment Doctor Dungeon [Conversation] -- 寺基礎ザコ 術士 不死実験の医僧 地下牢【会話】"
+        "Seeker"
       ]
     },
     {
       "ID": 12202080,
       "Entries": [
-        "Temple Foundation Zako Fist Sick Village Kannushi Sick Village [Conversation] -- 寺基礎ザコ 拳 病み村神主 病み村【会話】"
+        "Seeker"
       ]
     },
     {
       "ID": 12202081,
       "Entries": [
-        "Temple Foundation Zako Fist Kiri no Mori Chief Abbot Sick Village [Conversation] -- 寺基礎ザコ 拳 霧の森の住職 病み村【会話】"
+        "Seeker"
       ]
     },
     {
       "ID": 12209000,
       "Entries": [
-        "Temple foundation Zako_fist sample -- 寺基礎ザコ_拳 サンプル"
+        "Seeker"
       ]
     },
     {
       "ID": 12209100,
       "Entries": [
-        "Temple foundation Zako_ stick art sample -- 寺基礎ザコ_棒術 サンプル"
+        "Seeker"
       ]
     },
     {
       "ID": 12209200,
       "Entries": [
-        "Temple Foundation Zako_Surgeon Sample -- 寺基礎ザコ_術士 サンプル"
+        "Seeker"
       ]
     },
     {
       "ID": 12400000,
       "Entries": [
-        "Shamo chicken -- 軍鶏"
+        "Gamefowl"
       ]
     },
     {
       "ID": 12400001,
       "Entries": [
-        "Shamo Chicken Tutorial Team Attack Impact 100 -- 軍鶏\u3000チュートリアル\u3000チーム攻撃影響力を100"
+        "Gamefowl"
       ]
     },
     {
       "ID": 12409000,
       "Entries": [
-        "Shamo chicken sample -- 軍鶏 サンプル"
+        "Gamefowl"
       ]
     },
     {
       "ID": 12500000,
       "Entries": [
-        "Monkey bare hands -- 猿\u3000素手"
+        "Gamefowl"
       ]
     },
     {
       "ID": 12500001,
       "Entries": [
-        "Monkey bare hands short field of view -- 猿\u3000素手 視界短め"
+        "Gamefowl"
       ]
     },
     {
       "ID": 12500002,
       "Entries": [
-        "Monkey bare hands Immediate discovery distance longer -- 猿\u3000素手\u3000即発見距離長め"
+        "Gamefowl"
       ]
     },
     {
       "ID": 12500010,
       "Entries": [
-        "Monkey bare hand cliff jumping possible -- 猿\u3000素手 崖飛び降り可能"
+        "Gamefowl"
       ]
     },
     {
       "ID": 12500030,
       "Entries": [
-        "Monkey bare hand poisoning -- 猿\u3000素手毒かけ"
+        "Gamefowl"
       ]
     },
     {
       "ID": 12500099,
       "Entries": [
-        "Monkey bare hand demon monkey -- 猿\u3000素手\u3000鬼猿"
+        "Gamefowl"
       ]
     },
     {
       "ID": 12500100,
       "Entries": [
-        "Monkey gun jumping -- 猿\u3000銃\u3000跳躍"
+        "Gamefowl"
       ]
     },
     {
       "ID": 12500120,
       "Entries": [
-        "Monkey gun sniper -- 猿\u3000銃\u3000狙撃"
+        "Gamefowl"
       ]
     },
     {
       "ID": 12500130,
       "Entries": [
-        "Monkey gun sniper rifle upward recognition range expansion test -- 猿\u3000銃\u3000狙撃 上方認識範囲拡大テスト"
+        "Gamefowl"
       ]
     },
     {
       "ID": 12500150,
       "Entries": [
-        "Monkey gun sniper rifle surrounding -- 猿\u3000銃\u3000狙撃 二刀の取り巻き"
+        "Gamefowl"
       ]
     },
     {
       "ID": 12500151,
       "Entries": [
-        "Monkey gun Sniper rifle Surrounding two swords Only for distant hills -- 猿\u3000銃\u3000狙撃 二刀の取り巻き\u3000離れた高台専用"
+        "Gamefowl"
       ]
     },
     {
       "ID": 12500200,
       "Entries": [
-        "Monkey sword -- 猿\u3000刀"
+        "Gamefowl"
       ]
     },
     {
       "ID": 12500201,
       "Entries": [
-        "Monkey sword short visibility -- 猿\u3000刀\u3000視界短め"
+        "Gamefowl"
       ]
     },
     {
       "ID": 12500300,
       "Entries": [
-        "Two monkey swords -- 猿\u3000二刀"
+        "Gamefowl"
       ]
     },
     {
       "ID": 12500301,
       "Entries": [
-        "Monkey dual wield_no audiovisual -- 猿\u3000二刀_視聴覚無し"
+        "Gamefowl"
       ]
     },
     {
       "ID": 12500302,
       "Entries": [
-        "Monkey dual wield wide field of view -- 猿\u3000二刀 視界広い"
+        "Gamefowl"
       ]
     },
     {
       "ID": 12501000,
       "Entries": [
-        "Monkey bare hand temple Downward view wide -- 猿\u3000素手 寺\u3000下方向視界広い"
+        "Gamefowl"
       ]
     },
     {
       "ID": 12502120,
       "Entries": [
-        "Monkey gun sniper rifle revenge spirit _ temple -- 猿\u3000銃\u3000狙撃 復讐霊_寺"
+        "Gamefowl"
       ]
     },
     {
       "ID": 12509000,
       "Entries": [
-        "Monkey bare hand sample -- 猿\u3000素手 サンプル"
+        "Gamefowl"
       ]
     },
     {
       "ID": 12509080,
       "Entries": [
-        "Monkey bare hand jump control test -- 猿\u3000素手\u3000ジャンプ制御テスト"
+        "Gamefowl"
       ]
     },
     {
       "ID": 12509081,
       "Entries": [
-        "Monkey bare hand jump control test_no audiovisual -- 猿\u3000素手\u3000ジャンプ制御テスト_視聴覚無し"
+        "Gamefowl"
       ]
     },
     {
       "ID": 12509100,
       "Entries": [
-        "Monkey gun sample -- 猿\u3000銃 サンプル"
+        "Gamefowl"
       ]
     },
     {
       "ID": 12509200,
       "Entries": [
-        "Monkey sword sample -- 猿\u3000刀 サンプル"
+        "Gamefowl"
       ]
     },
     {
       "ID": 12509300,
       "Entries": [
-        "Monkey dual wield sample -- 猿\u3000二刀 サンプル"
+        "Gamefowl"
       ]
     },
     {
       "ID": 12600000,
       "Entries": [
-        "Monkey Bare-handed Chigo Monkey_Seeing Monkey -- 猿\u3000素手\u3000稚児猿_見る猿"
+        "Screen Monkey"
       ]
     },
     {
       "ID": 12600001,
       "Entries": [
-        "Monkey Bare hand Chigo monkey _ Seeing monkey _ Visual impairment -- 猿\u3000素手\u3000稚児猿_見る猿_視覚低下"
+        "Screen Monkey"
       ]
     },
     {
       "ID": 12600010,
       "Entries": [
-        "Monkey bare hand chigo monkey _ listening monkey -- 猿\u3000素手\u3000稚児猿_聞く猿"
+        "Screen Monkey"
       ]
     },
     {
       "ID": 12600011,
       "Entries": [
-        "Monkey Bare-handed Chigo Monkey_Hearing loss &amp; narrow upper vision -- 猿\u3000素手\u3000稚児猿_聴覚低下&上視界狭い"
+        "Screen Monkey"
       ]
     },
     {
       "ID": 12600020,
       "Entries": [
-        "Monkey Bare hand Chigo monkey _ Say monkey -- 猿\u3000素手\u3000稚児猿_言う猿"
+        "Screen Monkey"
       ]
     },
     {
       "ID": 12600030,
       "Entries": [
-        "Monkey Bare-handed Chigo Monkey_Visible Monkey -- 猿\u3000素手\u3000稚児猿_見え猿"
+        "Screen Monkey"
       ]
     },
     {
       "ID": 12600050,
       "Entries": [
-        "Monkey Bare Hands Chigo Monkey _ Escape Omnidirectional View Book Map -- 猿\u3000素手\u3000稚児猿_逃走用全方位視界\u3000本マップ"
+        "Screen Monkey"
       ]
     },
     {
       "ID": 12600051,
       "Entries": [
-        "Monkey Bare hand Chigo Monkey _ Escape omnidirectional view _ Listening monkey hearing good -- 猿\u3000素手\u3000稚児猿_逃走用全方位視界_聞く猿用聴覚良い"
+        "Screen Monkey"
       ]
     },
     {
       "ID": 12600052,
       "Entries": [
-        "Monkey Bare hand Chigo monkey _ Strengthen the sense of smell -- 猿\u3000素手\u3000稚児猿＿嗅覚を強化"
+        "Screen Monkey"
       ]
     },
     {
       "ID": 12600090,
       "Entries": [
-        "Monkey bare hand sample Chigo monkey _ omnidirectional view for escape -- 猿\u3000素手 サンプル\u3000稚児猿_逃走用全方位視界"
+        "Screen Monkey"
       ]
     },
     {
       "ID": 12600091,
       "Entries": [
-        "Monkey Bare Hand Sample Chigo Monkey _ Escape omnidirectional view _ Listening Monkey Hearing Good -- 猿\u3000素手 サンプル\u3000稚児猿_逃走用全方位視界_聞く猿用聴覚良い"
+        "Screen Monkey"
       ]
     },
     {
       "ID": 12600092,
       "Entries": [
-        "Monkey bare hand sample Chigo monkey For appearance check -- 猿\u3000素手 サンプル\u3000稚児猿 見た目チェック用"
+        "Screen Monkey"
       ]
     },
     {
       "ID": 12600094,
       "Entries": [
-        "Monkey bare hand sample Chigo monkey _ strengthening the sense of smell -- 猿\u3000素手 サンプル\u3000稚児猿＿嗅覚を強化"
+        "Screen Monkey"
       ]
     },
     {
       "ID": 13000000,
       "Entries": [
-        "Japanese style Innsmouth weak -- 和風インスマス\u3000弱"
+        "Palace Noble"
       ]
     },
     {
       "ID": 13000001,
       "Entries": [
-        "Japanese style Innsmouth for sick village _ does not react -- 和風インスマス\u3000病み村用_反応しない"
+        "Mist Noble - Ashina Depths"
       ]
     },
     {
       "ID": 13000010,
       "Entries": [
-        "Japanese style Innsmouth strong -- 和風インスマス\u3000強"
+        "Palace Noble"
       ]
     },
     {
       "ID": 13000011,
       "Entries": [
-        "Japanese style Innsmouth strong_for plane -- 和風インスマス\u3000強_平面用"
+        "Palace Noble"
       ]
     },
     {
       "ID": 13000012,
       "Entries": [
-        "Japanese style Innsmouth strong_for Sakuraba -- 和風インスマス\u3000強_桜庭用"
+        "Palace Noble"
       ]
     },
     {
       "ID": 13000013,
       "Entries": [
-        "Japanese style Innsmouth strong _ for patrol -- 和風インスマス\u3000強_巡回用"
+        "Palace Noble"
       ]
     },
     {
       "ID": 13000014,
       "Entries": [
-        "Japanese-style Innsmouth Strong_First Enemies -- 和風インスマス\u3000強_初接敵"
+        "Palace Noble"
       ]
     },
     {
       "ID": 13000015,
       "Entries": [
-        "Japanese style Innsmouth strong _ on a flat surface bridge -- 和風インスマス\u3000強_平面用\u3000橋の上"
+        "Palace Noble"
       ]
     },
     {
       "ID": 13000016,
       "Entries": [
-        "Japanese style Innsmouth strong _ for loophole -- 和風インスマス\u3000強_抜け道用"
+        "Palace Noble"
       ]
     },
     {
       "ID": 13001080,
       "Entries": [
-        "Japanese-style Innsmouth Sick Village A decent villager_ After Innsmouth [Conversation] -- 和風インスマス 病み村 まともな村人_インスマス後【会話】"
+        "Palace Noble"
       ]
     },
     {
       "ID": 13009000,
       "Entries": [
-        "Japanese style Innsmouth sample weak -- 和風インスマス サンプル\u3000弱"
+        "Palace Noble"
       ]
     },
     {
       "ID": 13009010,
       "Entries": [
-        "Japanese style Innsmouth sample strong -- 和風インスマス サンプル\u3000強"
+        "Palace Noble"
       ]
     },
     {
       "ID": 13100000,
       "Entries": [
-        "Genpei samurai sword -- 源平武者\u3000刀"
+        "Okami Warrior"
       ]
     },
     {
       "ID": 13100001,
       "Entries": [
-        "Genpei Samurai Sword_No Audiovisual -- 源平武者\u3000刀_視聴覚無し"
+        "Okami Warrior"
       ]
     },
     {
       "ID": 13100002,
       "Entries": [
-        "Genpei Samurai Sword_Visual Adjustment -- 源平武者\u3000刀_視覚調整"
+        "Okami Warrior"
       ]
     },
     {
       "ID": 13100010,
       "Entries": [
-        "Genpei Samurai Sword_Thunder_On Stage -- 源平武者\u3000刀_雷_舞台上"
+        "Okami Warrior"
       ]
     },
     {
       "ID": 13100011,
       "Entries": [
-        "Genpei Samurai Sword_Thunder_On Stage -- 源平武者\u3000刀_雷_舞台上"
+        "Okami Warrior"
       ]
     },
     {
       "ID": 13100100,
       "Entries": [
-        "Genpei Samurai Naginata -- 源平武者\u3000薙刀"
+        "Okami Warrior"
       ]
     },
     {
       "ID": 13100101,
       "Entries": [
-        "Genpei Samurai Naginata_for plane exit -- 源平武者\u3000薙刀_平面出口用"
+        "Okami Warrior"
       ]
     },
     {
       "ID": 13100200,
       "Entries": [
-        "Genpei warrior bow -- 源平武者\u3000弓"
+        "Okami Warrior"
       ]
     },
     {
       "ID": 13100201,
       "Entries": [
-        "Genpei Samurai Bow for Suzakumon -- 源平武者\u3000弓\u3000朱雀門用"
+        "Okami Warrior"
       ]
     },
     {
       "ID": 13100210,
       "Entries": [
-        "Genpei Samurai Bow Sword Sub -- 源平武者\u3000弓刀サブ"
+        "Okami Warrior"
       ]
     },
     {
       "ID": 13100211,
       "Entries": [
-        "Genpei Samurai Bow Sword Sub for Suzakumon -- 源平武者\u3000弓刀サブ\u3000朱雀門用"
+        "Okami Warrior"
       ]
     },
     {
       "ID": 13100300,
       "Entries": [
-        "Genpei Samurai Kemari -- 源平武者\u3000蹴鞠"
+        "Okami Warrior"
       ]
     },
     {
       "ID": 13100301,
       "Entries": [
-        "Genpei Samurai Kemari Very wide field of view -- 源平武者\u3000蹴鞠\u3000視界とても広い"
+        "Okami Leader Shizu"
       ]
     },
     {
       "ID": 13100302,
       "Entries": [
-        "Genpei Samurai Kemari_No audiovisual -- 源平武者\u3000蹴鞠_視聴覚無し"
+        "Okami Warrior"
       ]
     },
     {
       "ID": 13100305,
       "Entries": [
-        "Genpei Samurai Kemari_Three-dimensional A -- 源平武者\u3000蹴鞠_立体A"
+        "Okami Warrior"
       ]
     },
     {
       "ID": 13100306,
       "Entries": [
-        "Genpei Samurai Kemari_Three-dimensional B -- 源平武者\u3000蹴鞠_立体B"
+        "Okami Warrior"
       ]
     },
     {
       "ID": 13100307,
       "Entries": [
-        "Genpei Samurai Kemari_Three-dimensional C -- 源平武者\u3000蹴鞠_立体C"
+        "Okami Warrior"
       ]
     },
     {
       "ID": 13109000,
       "Entries": [
-        "Genpei samurai sword sample -- 源平武者\u3000刀\u3000サンプル"
+        "Okami Warrior"
       ]
     },
     {
       "ID": 13109100,
       "Entries": [
-        "Genpei Samurai Naginata Sample -- 源平武者\u3000薙刀\u3000サンプル"
+        "Okami Warrior"
       ]
     },
     {
       "ID": 13109200,
       "Entries": [
-        "Genpei Samurai Bow Sample -- 源平武者\u3000弓\u3000サンプル"
+        "Okami Warrior"
       ]
     },
     {
       "ID": 13109300,
       "Entries": [
-        "Genpei Samurai Kemari Sample -- 源平武者\u3000蹴鞠\u3000サンプル"
+        "Okami Warrior"
       ]
     },
     {
@@ -2206,25 +2206,25 @@
     {
       "ID": 13400000,
       "Entries": [
-        "Underwater neckless main castle -- 水中首なし\u3000本城"
+        "Headless - Ashina Castle"
       ]
     },
     {
       "ID": 13401000,
       "Entries": [
-        "Underwater neckless deep sea -- 水中首なし\u3000深海"
+        "Headless - Fountainhead Palace"
       ]
     },
     {
       "ID": 13401001,
       "Entries": [
-        "Underwater neckless deep sea illusion -- 水中首なし\u3000深海\u3000幻影"
+        "Headless Illusion - Fountainhead Palace"
       ]
     },
     {
       "ID": 13409000,
       "Entries": [
-        "Underwater neckless sample -- 水中首なし\u3000サンプル"
+        "Headless"
       ]
     },
     {
@@ -2236,103 +2236,103 @@
     {
       "ID": 13500010,
       "Entries": [
-        "Neckless non-combat -- 首無し\u3000非戦闘"
+        "Headless"
       ]
     },
     {
       "ID": 13500020,
       "Entries": [
-        "No neck, no sense of smell -- 首無し\u3000嗅覚なし"
+        "Headless"
       ]
     },
     {
       "ID": 13500090,
       "Entries": [
-        "Neckless sample -- 首無し\u3000サンプル"
+        "Headless"
       ]
     },
     {
       "ID": 13600000,
       "Entries": [
-        "Rappa -- らっぱ"
+        "Senpou Assassin"
       ]
     },
     {
       "ID": 13600001,
       "Entries": [
-        "Rappa_ No audiovisual -- らっぱ_ 視聴覚無し"
+        "Senpou Assassin"
       ]
     },
     {
       "ID": 13600002,
       "Entries": [
-        "Rappa_Shugendo_Wide view -- らっぱ_修験道_視界広い"
+        "Senpou Assassin"
       ]
     },
     {
       "ID": 13600003,
       "Entries": [
-        "Rappa_Shugendo_Long-distance jump only (do not jump) -- らっぱ_修験道_遠距離 ジャンプのみ（飛び降りしない）"
+        "Senpou Assassin"
       ]
     },
     {
       "ID": 13600004,
       "Entries": [
-        "Rappa_Shugendo_Do not jump long distances -- らっぱ_修験道_遠距離 ジャンプしない"
+        "Senpou Assassin"
       ]
     },
     {
       "ID": 13600010,
       "Entries": [
-        "Rappa_Kikasa -- らっぱ_木笠"
+        "Senpou Assassin"
       ]
     },
     {
       "ID": 13600020,
       "Entries": [
-        "Rappa_Honjo -- らっぱ_本城"
+        "Senpou Assassin"
       ]
     },
     {
       "ID": 13600021,
       "Entries": [
-        "Rappa_Honjo_Ninja Army Invasion Eavesdropping Tokugawa Rappa -- らっぱ_本城_忍軍襲来\u3000盗み聞き徳川らっぱ"
+        "Senpou Assassin"
       ]
     },
     {
       "ID": 13600100,
       "Entries": [
-        "Rappa_Honjo_Tokugawa Invasion Reeds -- らっぱ_本城_徳川襲来\u3000葦飛ばし"
+        "Senpou Assassin"
       ]
     },
     {
       "ID": 13600101,
       "Entries": [
-        "Rappa_Honjo_Ninja Army Invasion Reeds -- らっぱ_本城_忍軍襲来\u3000葦飛ばし"
+        "Senpou Assassin"
       ]
     },
     {
       "ID": 13603080,
       "Entries": [
-        "Rappa White Rappa_Honjo [Conversation] -- らっぱ 白らっぱ_本城【会話】"
+        "Blackhat Badger"
       ]
     },
     {
       "ID": 13603180,
       "Entries": [
-        "Rappa White Rappa_Castle [Conversation] -- らっぱ 白らっぱ_城下【会話】"
+        "Blackhat Badger"
       ]
     },
     {
       "ID": 13603280,
       "Entries": [
-        "Rappa White Rappa_Dungeon [Conversation] -- らっぱ 白らっぱ_地下牢【会話】"
+        "Blackhat Badger"
       ]
     },
     {
       "ID": 13609000,
       "Entries": [
-        "Rappa sample -- らっぱ サンプル"
+        "Senpou Assassin"
       ]
     },
     {
@@ -2446,175 +2446,175 @@
     {
       "ID": 14500000,
       "Entries": [
-        "Nightjars Proximity Honjo -- 夜鷹衆\u3000近接\u3000本城"
+        "Nightjar"
       ]
     },
     {
       "ID": 14500010,
       "Entries": [
-        "Nightjars Proximity Fall from Honjo kite -- 夜鷹衆\u3000近接\u3000本城\u3000凧から落下"
+        "Nightjar"
       ]
     },
     {
       "ID": 14500011,
       "Entries": [
-        "Nightjars Proximity Falling from Honjo kite Second body -- 夜鷹衆\u3000近接\u3000本城\u3000凧から落下 二体目"
+        "Nightjar"
       ]
     },
     {
       "ID": 14500020,
       "Entries": [
-        "Nightjars Proximity Honjo castle tower lower roof -- 夜鷹衆\u3000近接\u3000本城\u3000天守閣下層屋根"
+        "Nightjar"
       ]
     },
     {
       "ID": 14500030,
       "Entries": [
-        "Nightjars Proximity Honjo Lookout -- 夜鷹衆\u3000近接\u3000本城\u3000見張り用\u3000目が良い"
+        "Nightjar"
       ]
     },
     {
       "ID": 14500100,
       "Entries": [
-        "Nightjars Shuriken Honjo -- 夜鷹衆\u3000手裏剣\u3000本城"
+        "Nightjar"
       ]
     },
     {
       "ID": 14500110,
       "Entries": [
-        "Nightjars Shuriken Honjo first appearance -- 夜鷹衆\u3000手裏剣\u3000本城\u3000初見登場"
+        "Nightjar"
       ]
     },
     {
       "ID": 14503000,
       "Entries": [
-        "Nightjars Proximity Valley -- 夜鷹衆\u3000近接\u3000渓谷"
+        "Nightjar"
       ]
     },
     {
       "ID": 14503100,
       "Entries": [
-        "Nightjars Shuriken Valley -- 夜鷹衆\u3000手裏剣\u3000渓谷"
+        "Nightjar"
       ]
     },
     {
       "ID": 14505100,
       "Entries": [
-        "Nightjars Shuriken Revenge Spirit -- 夜鷹衆\u3000手裏剣\u3000復讐霊"
+        "Nightjar"
       ]
     },
     {
       "ID": 14505101,
       "Entries": [
-        "Nightjars Shuriken Revenge Spirit Vertical field of view -- 夜鷹衆\u3000手裏剣\u3000復讐霊\u3000縦の視界大"
+        "Nightjar"
       ]
     },
     {
       "ID": 14505102,
       "Entries": [
-        "Nightjars Shuriken Revenge Spirit -- 夜鷹衆\u3000手裏剣\u3000復讐霊"
+        "Nightjar"
       ]
     },
     {
       "ID": 14505500,
       "Entries": [
-        "Nightjars Proximity Valley Revenge Spirit -- 夜鷹衆\u3000近接\u3000渓谷\u3000復讐霊"
+        "Nightjar"
       ]
     },
     {
       "ID": 14509000,
       "Entries": [
-        "Nightjars proximity sample -- 夜鷹衆\u3000近接\u3000サンプル"
+        "Nightjar"
       ]
     },
     {
       "ID": 14509005,
       "Entries": [
-        "Nightjars Proximity sample jump control test -- 夜鷹衆\u3000近接\u3000サンプル\u3000ジャンプ制御テスト"
+        "Nightjar"
       ]
     },
     {
       "ID": 14509006,
       "Entries": [
-        "Nightjars Proximity Sample Jump Control Test_No Audiovisual -- 夜鷹衆\u3000近接\u3000サンプル\u3000ジャンプ制御テスト_視聴覚無し"
+        "Nightjar"
       ]
     },
     {
       "ID": 14509008,
       "Entries": [
-        "Nightjars Proximity sample First acceleration slamming test A -- 夜鷹衆\u3000近接\u3000サンプル\u3000初回加速叩き付けテストA"
+        "Nightjar"
       ]
     },
     {
       "ID": 14509009,
       "Entries": [
-        "Nightjars Proximity sample First acceleration slamming test B -- 夜鷹衆\u3000近接\u3000サンプル\u3000初回加速叩き付けテストB"
+        "Nightjar"
       ]
     },
     {
       "ID": 14509100,
       "Entries": [
-        "Nightjars Shuriken sample -- 夜鷹衆\u3000手裏剣\u3000サンプル"
+        "Nightjar"
       ]
     },
     {
       "ID": 14509101,
       "Entries": [
-        "Nightjars Shuriken Sample Honjo Test A -- 夜鷹衆\u3000手裏剣\u3000サンプル\u3000本城テストA"
+        "Nightjar"
       ]
     },
     {
       "ID": 14509102,
       "Entries": [
-        "Nightjars Shuriken Sample Honjo Test B -- 夜鷹衆\u3000手裏剣\u3000サンプル\u3000本城テストB"
+        "Nightjar"
       ]
     },
     {
       "ID": 14609000,
       "Entries": [
-        "Nightjar kite sample -- 夜鷹衆の凧\u3000サンプル"
+        "Nightjar"
       ]
     },
     {
       "ID": 14700000,
       "Entries": [
-        "Lonely people samurai residence -- 孤影衆\u3000武家屋敷"
+        "Lone Shadow"
       ]
     },
     {
       "ID": 14700001,
       "Entries": [
-        "Kokageshu Samurai Residence Burning Entrance_Doesn&#39;t play a role -- 孤影衆\u3000武家屋敷\u3000炎上玄関_取り巻き役にならない"
+        "Lone Shadow"
       ]
     },
     {
       "ID": 14700002,
       "Entries": [
-        "Lonely people Samurai residence Medium boss Burning entrance _ Do not play a role -- 孤影衆\u3000武家屋敷\u3000中ボス\u3000炎上玄関_取り巻き役にならない"
+        "Lone Shadow"
       ]
     },
     {
       "ID": 14700003,
       "Entries": [
-        "Kokageshu Samurai Residence Chasing after a long distance -- 孤影衆\u3000武家屋敷 追いかけてくる距長め"
+        "Lone Shadow"
       ]
     },
     {
       "ID": 14700004,
       "Entries": [
-        "Kokageshu Samurai Residence Truth Edition Shura Samurai&#39;s Companion -- 孤影衆\u3000武家屋敷 真相編\u3000修羅侍のお供"
+        "Lone Shadow"
       ]
     },
     {
       "ID": 14701000,
       "Entries": [
-        "Kokageshu Honjo -- 孤影衆\u3000本城"
+        "Lone Shadow"
       ]
     },
     {
       "ID": 14701001,
       "Entries": [
-        "Kokageshu Honjo Wider view -- 孤影衆\u3000本城\u3000視界広め"
+        "Lone Shadow"
       ]
     },
     {
@@ -2638,25 +2638,25 @@
     {
       "ID": 14701005,
       "Entries": [
-        "Kokageshu Honjo Wider view above -- 孤影衆\u3000本城\u3000上方視界広め"
+        "Lone Shadow"
       ]
     },
     {
       "ID": 14701006,
       "Entries": [
-        "Kokageshu Honjo Narrowing the field of view -- 孤影衆\u3000本城\u3000視界狭め"
+        "Lone Shadow"
       ]
     },
     {
       "ID": 14702000,
       "Entries": [
-        "Sickness Village Narrowing the field of vision -- 孤影衆\u3000病み村\u3000視界狭め"
+        "Lone Shadow"
       ]
     },
     {
       "ID": 14702001,
       "Entries": [
-        "Sickness of the lonely people Muranaka boss Narrowing the field of view -- 孤影衆\u3000病み村\u3000中ボス\u3000視界狭め"
+        "Lone Shadow"
       ]
     },
     {
@@ -2668,877 +2668,877 @@
     {
       "ID": 14709000,
       "Entries": [
-        "Lonely crowd strong sample -- 孤影衆\u3000強\u3000サンプル"
+        "Lone Shadow"
       ]
     },
     {
       "ID": 14709005,
       "Entries": [
-        "Lonely crowd strong sample_no audiovisual -- 孤影衆\u3000強\u3000サンプル_視聴覚無し"
+        "Lone Shadow"
       ]
     },
     {
       "ID": 14709100,
       "Entries": [
-        "Lonely crowd weak sample -- 孤影衆\u3000弱\u3000サンプル"
+        "Lone Shadow"
       ]
     },
     {
       "ID": 15000000,
       "Entries": [
-        "Villager Zombie _ Bare Hand -- 村人ゾンビ_素手"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15000001,
       "Entries": [
-        "Villager Zombie _ Bare Hand _ For the House of the Disliked -- 村人ゾンビ_素手_嫌われ者の家用"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15000010,
       "Entries": [
-        "Villager Zombie _ Bare Hand _ Run up -- 村人ゾンビ_素手_走り寄る"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15000011,
       "Entries": [
-        "Villager Zombie _ Bare Hand _ Run Up _ Platoon Speed High -- 村人ゾンビ_素手_走り寄る_小隊速度高"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15000012,
       "Entries": [
-        "Villager Zombie _ Bare Hand _ Run Up _ For Disliked House -- 村人ゾンビ_素手_走り寄る_嫌われ者の家用"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15000020,
       "Entries": [
-        "Villager Zombie _ Bare Hand _ Strong in sight -- 村人ゾンビ_素手_視界下に強い"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15000100,
       "Entries": [
-        "Villager Zombie_Rake -- 村人ゾンビ_熊手"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15000101,
       "Entries": [
-        "Villager Zombie_Rake_For the House of the Disliked -- 村人ゾンビ_熊手_嫌われ者の家用"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15000110,
       "Entries": [
-        "Villager Zombie _ Rake _ Run up -- 村人ゾンビ_熊手_走り寄る"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15000111,
       "Entries": [
-        "Villager Zombie_Rake_Running_Platoon Speed High -- 村人ゾンビ_熊手_走り寄る_小隊速度高"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15000200,
       "Entries": [
-        "Villager Zombie_Knife -- 村人ゾンビ_包丁"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15000300,
       "Entries": [
-        "Villager Zombie_Hoe -- 村人ゾンビ_鍬"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15000301,
       "Entries": [
-        "Villager Zombie_Hoe_For the House of the Disliked -- 村人ゾンビ_鍬_嫌われ者の家用"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15000310,
       "Entries": [
-        "Villager Zombie _ Hoe _ Run up -- 村人ゾンビ_鍬_走り寄る"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15000311,
       "Entries": [
-        "Villager Zombie_Hoe_Running_Platoon Speed High -- 村人ゾンビ_鍬_走り寄る_小隊速度高"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15000400,
       "Entries": [
-        "Villager Zombie_Bamboo Spear -- 村人ゾンビ_竹槍"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15000401,
       "Entries": [
-        "Villager Zombie_Bamboo Spear_For the House of the Disliked -- 村人ゾンビ_竹槍_嫌われ者の家用"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15000410,
       "Entries": [
-        "Villager Zombie_Bamboo Spear_Running -- 村人ゾンビ_竹槍_走り寄る"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15000411,
       "Entries": [
-        "Villager Zombie_Bamboo Spear_Running_Platoon Speed High -- 村人ゾンビ_竹槍_走り寄る_小隊速度高"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15000500,
       "Entries": [
-        "Villager Zombie_Weaving Machine -- 村人ゾンビ_機織り機"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15000501,
       "Entries": [
-        "Villager Zombie_Weaving Machine_For the House of the Disliked -- 村人ゾンビ_機織り機_嫌われ者の家用"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15000600,
       "Entries": [
-        "Villager Zombie_Prisoner -- 村人ゾンビ_囚人"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15000700,
       "Entries": [
-        "Villager Zombie_Underground Grab -- 村人ゾンビ_地中掴み"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15001000,
       "Entries": [
-        "Villager Zombie_Bare Hand Revenge Spirit_Temple -- 村人ゾンビ_素手\u3000復讐霊_寺"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15001100,
       "Entries": [
-        "Villager Zombie_Rake Revenge Spirit_Temple -- 村人ゾンビ_熊手 \u3000復讐霊_寺"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15001200,
       "Entries": [
-        "Villager Zombie_Knife Revenge Spirit_Temple -- 村人ゾンビ_包丁  復讐霊_寺"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15001300,
       "Entries": [
-        "Villager Zombie_Hoe Revenge Spirit_Temple -- 村人ゾンビ_鍬 \u3000 復讐霊_寺"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15001400,
       "Entries": [
-        "Villager Zombie_Bamboo Spear Revenge Spirit_Temple -- 村人ゾンビ_竹槍 復讐霊_寺"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15001500,
       "Entries": [
-        "Villager Zombie_Weaving Machine Revenge Spirit_Temple -- 村人ゾンビ_機織り機 復讐霊_寺"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15002380,
       "Entries": [
-        "Villager Zombie_Hoe Stable Resident B Castle [Conversation] -- 村人ゾンビ_鍬\u3000馬小屋の住人B\u3000城下【会話】"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15002480,
       "Entries": [
-        "Villager Zombie_Takeyari Stable Resident C Castle [Conversation] -- 村人ゾンビ_竹槍\u3000馬小屋の住人C\u3000城下【会話】"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15002580,
       "Entries": [
-        "Villager Zombie_Weaving Machine Stable Resident A Castle [Conversation] -- 村人ゾンビ_機織り機\u3000馬小屋の住人A\u3000城下【会話】"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15003080,
       "Entries": [
-        "Villager Zombie_Bare Hands Decent Resident Sick Village [Conversation] -- 村人ゾンビ_素手 まともな住人 病み村【会話】"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15004000,
       "Entries": [
-        "Villager Zombie_Bare Hand Revenge Spirit_Valley -- 村人ゾンビ_素手\u3000復讐霊_渓谷"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15004100,
       "Entries": [
-        "Villager Zombie_Rake Revenge Spirit_Valley -- 村人ゾンビ_熊手 \u3000復讐霊_渓谷"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15004200,
       "Entries": [
-        "Villager Zombie_Knife Revenge Spirit_Valley -- 村人ゾンビ_包丁  復讐霊_渓谷"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15004300,
       "Entries": [
-        "Villager Zombie_Hoe Revenge Spirit_Valley -- 村人ゾンビ_鍬  \u3000\u3000復讐霊_渓谷"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15004400,
       "Entries": [
-        "Villager Zombie_Bamboo Spear Revenge Spirit_Valley -- 村人ゾンビ_竹槍 \u3000復讐霊_渓谷"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15004500,
       "Entries": [
-        "Villager Zombie_Weaving Machine Revenge Spirit_Valley -- 村人ゾンビ_機織り機 復讐霊_渓谷"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15004700,
       "Entries": [
-        "Villager Zombie_Underground Grab Revenge Spirit_Valley -- 村人ゾンビ_地中掴み\u3000復讐霊_渓谷"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15009000,
       "Entries": [
-        "Villager Zombie_Bare Hand Sample -- 村人ゾンビ_素手 サンプル"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15009100,
       "Entries": [
-        "Villager Zombie_Rake Sample -- 村人ゾンビ_熊手 サンプル"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15009200,
       "Entries": [
-        "Villager Zombie_Knife Sample -- 村人ゾンビ_包丁 サンプル"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15009300,
       "Entries": [
-        "Villager Zombie_Hoe Sample -- 村人ゾンビ_鍬 サンプル"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15009400,
       "Entries": [
-        "Villager Zombie_Bamboo Spear Sample -- 村人ゾンビ_竹槍 サンプル"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15009500,
       "Entries": [
-        "Villager Zombie_Weaving Machine Sample -- 村人ゾンビ_機織り機 サンプル"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15009600,
       "Entries": [
-        "Villager Zombie_Prisoner Sample -- 村人ゾンビ_囚人 サンプル"
+        "Mibu Villager"
       ]
     },
     {
       "ID": 15100000,
       "Entries": [
-        "Hallucinatory character Villager Zombie_bare hands -- 幻覚キャラ\u3000村人ゾンビ_素手"
+        "Phantom Mibu Villager"
       ]
     },
     {
       "ID": 15100100,
       "Entries": [
-        "Hallucinatory character villager zombie _ rake -- 幻覚キャラ\u3000村人ゾンビ_熊手"
+        "Phantom Mibu Villager"
       ]
     },
     {
       "ID": 15100200,
       "Entries": [
-        "Hallucinatory character Villager Zombie_Knife -- 幻覚キャラ\u3000村人ゾンビ_包丁"
+        "Phantom Mibu Villager"
       ]
     },
     {
       "ID": 15100300,
       "Entries": [
-        "Hallucinatory character villager zombie _ hoe -- 幻覚キャラ\u3000村人ゾンビ_鍬"
+        "Phantom Mibu Villager"
       ]
     },
     {
       "ID": 15100400,
       "Entries": [
-        "Hallucinatory Character Villager Zombie_Bamboo Spear -- 幻覚キャラ\u3000村人ゾンビ_竹槍"
+        "Phantom Mibu Villager"
       ]
     },
     {
       "ID": 15100500,
       "Entries": [
-        "Hallucinatory character Villager Zombie_Weaving machine -- 幻覚キャラ\u3000村人ゾンビ_機織り機"
+        "Phantom Mibu Villager"
       ]
     },
     {
       "ID": 15109000,
       "Entries": [
-        "Hallucinatory character villager zombie _ bare hand sample -- 幻覚キャラ\u3000村人ゾンビ_素手\u3000サンプル"
+        "Phantom Mibu Villager"
       ]
     },
     {
       "ID": 15109100,
       "Entries": [
-        "Hallucinatory character villager zombie _ rake sample -- 幻覚キャラ\u3000村人ゾンビ_熊手\u3000サンプル"
+        "Phantom Mibu Villager"
       ]
     },
     {
       "ID": 15109200,
       "Entries": [
-        "Hallucinatory character villager zombie _ kitchen knife sample -- 幻覚キャラ\u3000村人ゾンビ_包丁\u3000サンプル"
+        "Phantom Mibu Villager"
       ]
     },
     {
       "ID": 15109300,
       "Entries": [
-        "Hallucinatory character villager zombie _ hoe sample -- 幻覚キャラ\u3000村人ゾンビ_鍬\u3000サンプル"
+        "Phantom Mibu Villager"
       ]
     },
     {
       "ID": 15109400,
       "Entries": [
-        "Hallucinatory character villager zombie _ bamboo spear sample -- 幻覚キャラ\u3000村人ゾンビ_竹槍\u3000サンプル"
+        "Phantom Mibu Villager"
       ]
     },
     {
       "ID": 15109500,
       "Entries": [
-        "Hallucinatory Character Villager Zombie_Weaving Machine Sample -- 幻覚キャラ\u3000村人ゾンビ_機織り機\u3000サンプル"
+        "Phantom Mibu Villager"
       ]
     },
     {
       "ID": 15500000,
       "Entries": [
-        "Bandit_sword -- 野盗_刀"
+        "Bandit"
       ]
     },
     {
       "ID": 15500001,
       "Entries": [
-        "Bandit_Sword_Yashiki-dori -- 野盗_刀_屋敷通り"
+        "Bandit"
       ]
     },
     {
       "ID": 15500002,
       "Entries": [
-        "Bandit_sword_indoor -- 野盗_刀_屋内"
+        "Bandit"
       ]
     },
     {
       "ID": 15500010,
       "Entries": [
-        "Bandit_Sword_Sick Village_In the Fog -- 野盗_刀_ 病み村_霧の中"
+        "Bandit"
       ]
     },
     {
       "ID": 15500080,
       "Entries": [
-        "Bandit_Sword Selling Bandit Castle_Shop [Conversation] -- 野盗_刀\u3000物売り野盗 城下_ショップ【会話】"
+        "Bandit"
       ]
     },
     {
       "ID": 15500081,
       "Entries": [
-        "Bandit_Sword Selling Bandit Castle_Survival after the Tokugawa invasion [Conversation] -- 野盗_刀\u3000物売り野盗 城下_徳川襲来後\u3000生存【会話】"
+        "Bandit"
       ]
     },
     {
       "ID": 15500100,
       "Entries": [
-        "Bandit_ax -- 野盗_斧"
+        "Bandit"
       ]
     },
     {
       "ID": 15500110,
       "Entries": [
-        "Bandit_Ax_Sick Village_In the Fog -- 野盗_斧_病み村_霧の中"
+        "Bandit"
       ]
     },
     {
       "ID": 15500200,
       "Entries": [
-        "Bandit_Akira Sword Torch -- 野盗_刀松明"
+        "Bandit"
       ]
     },
     {
       "ID": 15500201,
       "Entries": [
-        "Bandit_Katana Torch_Shurikenzaka -- 野盗_刀松明_手裏剣坂"
+        "Bandit"
       ]
     },
     {
       "ID": 15500202,
       "Entries": [
-        "Bandit_Katana Torch_Yashiki-dori -- 野盗_刀松明_屋敷通り"
+        "Bandit"
       ]
     },
     {
       "ID": 15500203,
       "Entries": [
-        "Bandit_Akira Sword Matsu_Honke -- 野盗_刀松明_本家庭"
+        "Bandit"
       ]
     },
     {
       "ID": 15500205,
       "Entries": [
-        "Bandit_Akira Torch_ Do not act around -- 野盗_刀松明_取り巻き行動しない"
+        "Bandit"
       ]
     },
     {
       "ID": 15500300,
       "Entries": [
-        "Bandit_Sword Shield -- 野盗_刀盾"
+        "Bandit"
       ]
     },
     {
       "ID": 15500301,
       "Entries": [
-        "Bandit_Sword Shield -- 野盗_刀盾"
+        "Bandit"
       ]
     },
     {
       "ID": 15500305,
       "Entries": [
-        "Bandit_Sword Shield_Do not act around -- 野盗_刀盾_取り巻き行動しない"
+        "Bandit"
       ]
     },
     {
       "ID": 15500400,
       "Entries": [
-        "Bandit_bow (sub sword) -- 野盗_弓（サブ刀）"
+        "Bandit"
       ]
     },
     {
       "ID": 15500401,
       "Entries": [
-        "Bandit_Bow (sub-sword) _Yashiki-dori -- 野盗_弓（サブ刀）_屋敷通り"
+        "Bandit"
       ]
     },
     {
       "ID": 15500402,
       "Entries": [
-        "Bandit_bow (sub-sword) _fixed battery -- 野盗_弓（サブ刀）_固定砲台"
+        "Bandit"
       ]
     },
     {
       "ID": 15500403,
       "Entries": [
-        "Bandit_Bow (sub-sword) _Fixed turret_Visual a little short -- 野盗_弓（サブ刀）_固定砲台_視覚少し短い"
+        "Bandit"
       ]
     },
     {
       "ID": 15500404,
       "Entries": [
-        "Bandit_Bow (sub-sword) _Home -- 野盗_弓（サブ刀）_本家庭"
+        "Bandit"
       ]
     },
     {
       "ID": 15500405,
       "Entries": [
-        "Bandit_bow (sub-sword) _indoor -- 野盗_弓（サブ刀）_屋内"
+        "Bandit"
       ]
     },
     {
       "ID": 15500406,
       "Entries": [
-        "Bandit_Bow (sub-sword) _Fixed battery_E3 Koguchi -- 野盗_弓（サブ刀）_固定砲台_E3虎口"
+        "Bandit"
       ]
     },
     {
       "ID": 15500407,
       "Entries": [
-        "Bandit_bow (sub-sword) _in front of the main house entrance -- 野盗_弓（サブ刀）_本家入り口前"
+        "Bandit"
       ]
     },
     {
       "ID": 15500408,
       "Entries": [
-        "Bandit_bow (sub-sword) _indoor_distance view -- 野盗_弓（サブ刀）_屋内_距離眺め"
+        "Bandit"
       ]
     },
     {
       "ID": 15500412,
       "Entries": [
-        "Bandit_Bow (sub-sword) _Fixed battery_Sick village -- 野盗_弓（サブ刀）_固定砲台_病み村"
+        "Bandit"
       ]
     },
     {
       "ID": 15500500,
       "Entries": [
-        "Bandit_Drunk_Sword -- 野盗_酔っ払い_刀"
+        "Bandit"
       ]
     },
     {
       "ID": 15500600,
       "Entries": [
-        "Bandit_Drunk_Ax -- 野盗_酔っ払い_斧"
+        "Bandit"
       ]
     },
     {
       "ID": 15501080,
       "Entries": [
-        "Bandit_Sword Selling Bandit Samurai Residence [Conversation] -- 野盗_刀\u3000物売り野盗 武家屋敷【会話】"
+        "Bandit"
       ]
     },
     {
       "ID": 15502000,
       "Entries": [
-        "Bandit_Sword Temple -- 野盗_刀 寺"
+        "Bandit"
       ]
     },
     {
       "ID": 15502100,
       "Entries": [
-        "Bandit_Ax Temple -- 野盗_斧 寺"
+        "Bandit"
       ]
     },
     {
       "ID": 15502200,
       "Entries": [
-        "Bandit_Katana Torch Temple -- 野盗_刀松明\u3000寺"
+        "Bandit"
       ]
     },
     {
       "ID": 15502300,
       "Entries": [
-        "Bandit_Sword Shield Temple -- 野盗_刀盾 寺"
+        "Bandit"
       ]
     },
     {
       "ID": 15502400,
       "Entries": [
-        "Bandit_bow (sub-sword) temple -- 野盗_弓（サブ刀）\u3000寺"
+        "Bandit"
       ]
     },
     {
       "ID": 15502510,
       "Entries": [
-        "Bandit_Drunk_Ax Temple -- 野盗_酔っ払い_斧 寺"
+        "Bandit"
       ]
     },
     {
       "ID": 15509000,
       "Entries": [
-        "Bandit_sword sample -- 野盗_刀 サンプル"
+        "Bandit"
       ]
     },
     {
       "ID": 15509100,
       "Entries": [
-        "Bandit_ax sample -- 野盗_斧 サンプル"
+        "Bandit"
       ]
     },
     {
       "ID": 15509200,
       "Entries": [
-        "Bandit_Sword Torch Sample -- 野盗_刀松明 サンプル"
+        "Bandit"
       ]
     },
     {
       "ID": 15509300,
       "Entries": [
-        "Bandit_Sword Shield Sample -- 野盗_刀盾 サンプル"
+        "Bandit"
       ]
     },
     {
       "ID": 15509400,
       "Entries": [
-        "Bandit_bow (sub sword) sample -- 野盗_弓（サブ刀） サンプル"
+        "Bandit"
       ]
     },
     {
       "ID": 15509500,
       "Entries": [
-        "Bandit_Drunk_Sword Sample -- 野盗_酔っ払い_刀 サンプル"
+        "Bandit"
       ]
     },
     {
       "ID": 15509510,
       "Entries": [
-        "Bandit_Drunk_Ax Sample -- 野盗_酔っ払い_斧 サンプル"
+        "Bandit"
       ]
     },
     {
       "ID": 17000000,
       "Entries": [
-        "Tokugawa Samurai _ Sword -- 徳川侍_刀"
+        "Interior Ministry Samurai"
       ]
     },
     {
       "ID": 17000001,
       "Entries": [
-        "Tokugawa Samurai_Sword_Busshi Demon -- 徳川侍_刀_仏師鬼やられ役"
+        "Interior Ministry Samurai"
       ]
     },
     {
       "ID": 17000002,
       "Entries": [
-        "Tokugawa Samurai_Sword_Slightly wider &amp; stronger on top -- 徳川侍_刀_少し広め＆上にも強め"
+        "Interior Ministry Samurai"
       ]
     },
     {
       "ID": 17000010,
       "Entries": [
-        "Tokugawa Samurai _ sword for large stairs -- 徳川侍_刀 大階段用"
+        "Interior Ministry Samurai"
       ]
     },
     {
       "ID": 17000100,
       "Entries": [
-        "Tokugawa Samurai_Kodachi -- 徳川侍_小太刀"
+        "Interior Ministry Samurai"
       ]
     },
     {
       "ID": 17000110,
       "Entries": [
-        "Tokugawa Samurai_Kodachi for large stairs -- 徳川侍_小太刀 大階段用"
+        "Interior Ministry Samurai"
       ]
     },
     {
       "ID": 17000200,
       "Entries": [
-        "Tokugawa Samurai_Flamthrower -- 徳川侍_火炎放射器"
+        "Interior Ministry Samurai"
       ]
     },
     {
       "ID": 17000201,
       "Entries": [
-        "Samurai Tokugawa_Flamethrower_Busshi Demon -- 徳川侍_火炎放射器_仏師鬼やられ役"
+        "Interior Ministry Samurai"
       ]
     },
     {
       "ID": 17000202,
       "Entries": [
-        "Tokugawa Samurai_Flamthrower_Strengthen up and down -- 徳川侍_火炎放射器_上下に強め"
+        "Interior Ministry Samurai"
       ]
     },
     {
       "ID": 17000210,
       "Entries": [
-        "Tokugawa Samurai_Flamthrower for large stairs -- 徳川侍_火炎放射器 大階段用"
+        "Interior Ministry Samurai"
       ]
     },
     {
       "ID": 17000300,
       "Entries": [
-        "Tokugawa Samurai_Incendiary Gun -- 徳川侍_焼夷銃"
+        "Interior Ministry Samurai"
       ]
     },
     {
       "ID": 17000301,
       "Entries": [
-        "Tokugawa Samurai_Incendiary Gun_Battery 1 -- 徳川侍_焼夷銃_砲台1"
+        "Interior Ministry Samurai"
       ]
     },
     {
       "ID": 17000302,
       "Entries": [
-        "Tokugawa Samurai_Incendiary Gun_Battery 2 -- 徳川侍_焼夷銃_砲台2"
+        "Interior Ministry Samurai"
       ]
     },
     {
       "ID": 17000303,
       "Entries": [
-        "Tokugawa Samurai_Incendiary Gun_Battery 3 -- 徳川侍_焼夷銃_砲台3"
+        "Interior Ministry Samurai"
       ]
     },
     {
       "ID": 17000304,
       "Entries": [
-        "Tokugawa Samurai_Incendiary Gun_Tokugawa Invasion Hashigami -- 徳川侍_焼夷銃_徳川襲来橋上"
+        "Interior Ministry Samurai"
       ]
     },
     {
       "ID": 17000305,
       "Entries": [
-        "Tokugawa Samurai_Incendiary Gun_Battery 4 -- 徳川侍_焼夷銃_砲台4"
+        "Interior Ministry Samurai"
       ]
     },
     {
       "ID": 17000310,
       "Entries": [
-        "Tokugawa Samurai_Incendiary Gun for large stairs -- 徳川侍_焼夷銃 大階段用"
+        "Interior Ministry Samurai"
       ]
     },
     {
       "ID": 17000350,
       "Entries": [
-        "Tokugawa Samurai _ sword (light) -- 徳川侍_刀（軽）"
+        "Interior Ministry Samurai"
       ]
     },
     {
       "ID": 17000351,
       "Entries": [
-        "Tokugawa Samurai _ sword (light) -- 徳川侍_刀（軽）"
+        "Interior Ministry Samurai"
       ]
     },
     {
       "ID": 17009000,
       "Entries": [
-        "Tokugawa Samurai_Sword Sample -- 徳川侍_刀 サンプル"
+        "Interior Ministry Samurai"
       ]
     },
     {
       "ID": 17009100,
       "Entries": [
-        "Tokugawa Samurai_Kodachi sample -- 徳川侍_小太刀 サンプル"
+        "Interior Ministry Samurai"
       ]
     },
     {
       "ID": 17009200,
       "Entries": [
-        "Tokugawa Samurai_flamethrower sample -- 徳川侍_火炎放射器 サンプル"
+        "Interior Ministry Samurai"
       ]
     },
     {
       "ID": 17009300,
       "Entries": [
-        "Tokugawa Samurai_Incendiary Gun Sample -- 徳川侍_焼夷銃 サンプル"
+        "Interior Ministry Samurai"
       ]
     },
     {
       "ID": 50000000,
       "Entries": [
-        "Haunting Monk Protomap -- 破戒僧\u3000プロトマップ"
+        "Corrupted Monk"
       ]
     },
     {
       "ID": 50000001,
       "Entries": [
-        "Haunting Monk Protomap Behind the scenes -- 破戒僧\u3000プロトマップ\u3000背後警戒"
+        "Corrupted Monk"
       ]
     },
     {
       "ID": 50050000,
       "Entries": [
-        "Phantom Protomap of the Haunting Monk -- 破戒僧の幻影\u3000プロトマップ"
+        "Corrupted Monk Clone"
       ]
     },
     {
       "ID": 50100000,
       "Entries": [
-        "Valley Great Snake Protomap -- 渓谷の大蛇\u3000プロトマップ"
+        "Great Serpent"
       ]
     },
     {
       "ID": 50101000,
       "Entries": [
-        "Great Snake Castle -- 大蛇\u3000城下"
+        "Great Serpent"
       ]
     },
     {
       "ID": 50101050,
       "Entries": [
-        "Oja Castle Castle Dummy character for display that seems to be found 0 -- 大蛇\u3000城下\u3000見つかりそう表示用ダミーキャラ0"
+        "Great Serpent"
       ]
     },
     {
       "ID": 50101051,
       "Entries": [
-        "Oja Castle Dummy character for display that seems to be found 1 -- 大蛇\u3000城下\u3000見つかりそう表示用ダミーキャラ1"
+        "Great Serpent"
       ]
     },
     {
       "ID": 50101052,
       "Entries": [
-        "Oja Castle Castle Dummy character 2 for display that seems to be found -- 大蛇\u3000城下\u3000見つかりそう表示用ダミーキャラ2"
+        "Great Serpent"
       ]
     },
     {
       "ID": 50101053,
       "Entries": [
-        "Large Snake Castle Dummy character for display that seems to be found 3 -- 大蛇\u3000城下\u3000見つかりそう表示用ダミーキャラ3"
+        "Great Serpent"
       ]
     },
     {
       "ID": 50101054,
       "Entries": [
-        "Large Snake Castle Dummy character for display that seems to be found 4 -- 大蛇\u3000城下\u3000見つかりそう表示用ダミーキャラ4"
+        "Great Serpent"
       ]
     },
     {
       "ID": 50102000,
       "Entries": [
-        "Large Snake Snake Valley A -- 大蛇\u3000蛇谷A"
+        "Great Serpent"
       ]
     },
     {
       "ID": 50102010,
       "Entries": [
-        "Large Snake Snake Valley B -- 大蛇\u3000蛇谷B"
+        "Great Serpent"
       ]
     },
     {
       "ID": 50103000,
       "Entries": [
-        "Large Snake Burrow A -- 大蛇\u3000巣穴A"
+        "Great Serpent"
       ]
     },
     {
       "ID": 50103010,
       "Entries": [
-        "Large Snake Burrow B -- 大蛇\u3000巣穴B"
+        "Great Serpent"
       ]
     },
     {
       "ID": 50103050,
       "Entries": [
-        "Large snake burrow Dummy character for display that seems to be found 0 -- 大蛇\u3000巣穴\u3000見つかりそう表示用ダミーキャラ0"
+        "Great Serpent"
       ]
     },
     {
       "ID": 50103051,
       "Entries": [
-        "Large snake burrow Dummy character for display that seems to be found 1 -- 大蛇\u3000巣穴\u3000見つかりそう表示用ダミーキャラ1"
+        "Great Serpent"
       ]
     },
     {
       "ID": 50103052,
       "Entries": [
-        "Large snake burrow Dummy character for display that seems to be found 2 -- 大蛇\u3000巣穴\u3000見つかりそう表示用ダミーキャラ2"
+        "Great Serpent"
       ]
     },
     {
       "ID": 50103053,
       "Entries": [
-        "Large snake burrow Dummy character for display that seems to be found 3 -- 大蛇\u3000巣穴\u3000見つかりそう表示用ダミーキャラ3"
+        "Great Serpent"
       ]
     },
     {
       "ID": 50200000,
       "Entries": [
-        "Akaoni Castle -- 赤鬼 城下"
+        "Chained Orge"
       ]
     },
     {
@@ -3550,91 +3550,91 @@
     {
       "ID": 50200080,
       "Entries": [
-        "Akaoni Castle [Conversation] -- 赤鬼 城下【会話】"
+        "Chained Orge"
       ]
     },
     {
       "ID": 50200180,
       "Entries": [
-        "Red Demon (Innsmouth) _ Submerged City [Conversation] -- 赤鬼(インスマウス)_水没都【会話】"
+        "Chained Orge"
       ]
     },
     {
       "ID": 50201000,
       "Entries": [
-        "Chained Ogre - Ashina Castle"
+        "Chained Orge"
       ]
     },
     {
       "ID": 50204080,
       "Entries": [
-        "Red Demon _ Dungeon _ Immortal Experiment Doctor _ Deformed State [Conversation] -- 赤鬼_地下牢_不死実験の医僧_異形化状態【会話】"
+        "Chained Orge"
       ]
     },
     {
       "ID": 50209000,
       "Entries": [
-        "Red demon sample -- 赤鬼 サンプル"
+        "Chained Orge"
       ]
     },
     {
       "ID": 50210080,
       "Entries": [
-        "White Innsmouth_Submerged City [Conversation] -- 白人インスマウス_水没都【会話】"
+        "Great Carp Attendant (Conversation)"
       ]
     },
     {
       "ID": 50300000,
       "Entries": [
-        "Straw doll test map -- 藁人形\u3000テストマップ"
+        "Straw Doll"
       ]
     },
     {
       "ID": 50310000,
       "Entries": [
-        "Straw doll bug prototype map -- 藁人形の蟲\u3000プロトマップ"
+        "Straw Doll"
       ]
     },
     {
       "ID": 50310001,
       "Entries": [
-        "Straw Doll Bug Protomap Pretending to be Dead -- 藁人形の蟲\u3000プロトマップ\u3000死んだふり中"
+        "Straw Doll"
       ]
     },
     {
       "ID": 50400000,
       "Entries": [
-        "Straw doll (new model) Protomap -- 藁人形（新モデル）\u3000プロトマップ"
+        "Straw Doll"
       ]
     },
     {
       "ID": 50500000,
       "Entries": [
-        "Nishikigoi Submerged City -- 錦鯉\u3000水没都"
+        "Great Colored Carp"
       ]
     },
     {
       "ID": 50500080,
       "Entries": [
-        "Nishikigoi Submerged City Feeding [Conversation] -- 錦鯉\u3000水没都 餌やり【会話】"
+        "Great Colored Carp"
       ]
     },
     {
       "ID": 50509000,
       "Entries": [
-        "Nishikigoi sample -- 錦鯉\u3000サンプル"
+        "Great Colored Carp"
       ]
     },
     {
       "ID": 50600000,
       "Entries": [
-        "Shin Ninja Army Chief Samurai Residence -- 真・忍軍の長\u3000武家屋敷"
+        "Owl (Father)"
       ]
     },
     {
       "ID": 50600080,
       "Entries": [
-        "Ninja Army Chief Honjo [Conversation] -- 忍軍の長 本城【会話】"
+        "Owl"
       ]
     },
     {
@@ -3646,55 +3646,55 @@
     {
       "ID": 50601080,
       "Entries": [
-        "Ninja Army Chief Samurai Residence [Conversation] -- 忍軍の長 武家屋敷【会話】"
+        "Owl"
       ]
     },
     {
       "ID": 50609000,
       "Entries": [
-        "Ninja Chief Sample -- 忍軍の長\u3000サンプル"
+        "Owl"
       ]
     },
     {
       "ID": 50630000,
       "Entries": [
-        "Old / Ninja Army Chief (Back) Samurai Residence -- 老・忍軍の長（裏）\u3000武家屋敷"
+        "Owl"
       ]
     },
     {
       "ID": 50709000,
       "Entries": [
-        "Long owl sample -- 長の梟\u3000サンプル"
+        "Owl"
       ]
     },
     {
       "ID": 50709300,
       "Entries": [
-        "Long owl (back) sample -- 長の梟（裏）\u3000サンプル"
+        "Owl"
       ]
     },
     {
       "ID": 50800000,
       "Entries": [
-        "Horse-riding warrior -- 騎馬武者"
+        "Gyoubu"
       ]
     },
     {
       "ID": 50809000,
       "Entries": [
-        "Cavalry warrior sample -- 騎馬武者\u3000サンプル"
+        "Gyoubu"
       ]
     },
     {
       "ID": 50900000,
       "Entries": [
-        "Butterflies -- お蝶"
+        "Lady Butterfly"
       ]
     },
     {
       "ID": 50909000,
       "Entries": [
-        "Butterfly sample -- お蝶\u3000サンプル"
+        "Lady Butterfly"
       ]
     },
     {
@@ -3724,97 +3724,97 @@
     {
       "ID": 51009000,
       "Entries": [
-        "Yasha Ape (in front of HU) sample -- 夜叉猿（HU前）\u3000サンプル"
+        "Guardian Ape"
       ]
     },
     {
       "ID": 51009100,
       "Entries": [
-        "Yasha Ape (after HU) sample -- 夜叉猿（HU後）\u3000サンプル"
+        "Guardian Ape"
       ]
     },
     {
       "ID": 52000000,
       "Entries": [
-        "Mermaid dragon sample -- 人魚竜 サンプル"
+        "Divine Dragon"
       ]
     },
     {
       "ID": 52009000,
       "Entries": [
-        "Mermaid dragon sample -- 人魚竜 サンプル"
+        "Divine Dragon"
       ]
     },
     {
       "ID": 53000000,
       "Entries": [
-        "Dummy for the main body of the old dragon -- 翁竜\u3000本体用ダミー"
+        "Divine Dragon"
       ]
     },
     {
       "ID": 53000010,
       "Entries": [
-        "Okiryu Combatant -- 翁竜\u3000戦闘員"
+        "Old Dragon"
       ]
     },
     {
       "ID": 53009000,
       "Entries": [
-        "Old dragon sample -- 翁竜\u3000サンプル"
+        "Old Dragon"
       ]
     },
     {
       "ID": 53100000,
       "Entries": [
-        "Tentacles -- 触手"
+        "Old Dragon Treebranch"
       ]
     },
     {
       "ID": 53100010,
       "Entries": [
-        "Tentacle_Mermaid Dragon for scaffolding -- 触手_人魚竜戦足場用"
+        "Old Dragon Treebranch"
       ]
     },
     {
       "ID": 53109000,
       "Entries": [
-        "Tentacle sample -- 触手\u3000サンプル"
+        "Old Dragon Treebranch"
       ]
     },
     {
       "ID": 53200000,
       "Entries": [
-        "Okiryu_Large -- 翁竜_大"
+        "Old Dragon"
       ]
     },
     {
       "ID": 54000000,
       "Entries": [
-        "Revived Kensei -- 蘇った剣聖"
+        "Sword Saint Isshin"
       ]
     },
     {
       "ID": 54000080,
       "Entries": [
-        "Sword of the sickbed Holy Honjo [Conversation] -- 病床の剣聖 本城【会話】"
+        "Sword Saint Isshin"
       ]
     },
     {
       "ID": 54000100,
       "Entries": [
-        "Revived Kensei (after HU) -- 蘇った剣聖(HU後)"
+        "Sword Saint Isshin"
       ]
     },
     {
       "ID": 54030000,
       "Entries": [
-        "Revived Kensei (back) -- 蘇った剣聖（裏）"
+        "Sword Saint Isshin"
       ]
     },
     {
       "ID": 54030100,
       "Entries": [
-        "Revived Kensei (back) (after HU) -- 蘇った剣聖（裏）(HU後)"
+        "Sword Saint Isshin"
       ]
     },
     {
@@ -3844,67 +3844,67 @@
     {
       "ID": 70000000,
       "Entries": [
-        "Female player -- 女奏者"
+        "O'Rin of the Water"
       ]
     },
     {
       "ID": 70000900,
       "Entries": [
-        "Female player conversation test -- 女奏者\u3000会話テスト"
+        "O'Rin of the Water"
       ]
     },
     {
       "ID": 70009000,
       "Entries": [
-        "Female player sample -- 女奏者\u3000サンプル"
+        "O'Rin of the Water"
       ]
     },
     {
       "ID": 70100000,
       "Entries": [
-        "Buddhist priest -- 仏師"
+        "Sculptor"
       ]
     },
     {
       "ID": 70100080,
       "Entries": [
-        "Buddhist teacher [conversation] -- 仏師【会話】"
+        "Sculptor"
       ]
     },
     {
       "ID": 70200000,
       "Entries": [
-        "Buddhist priest (demon) (in front of HU) -- 仏師(鬼)（HU前）"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70200100,
       "Entries": [
-        "Buddhist priest (demon) (after HU) -- 仏師(鬼)（HU後）"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70209000,
       "Entries": [
-        "Buddhist priest (demon) (in front of HU) sample -- 仏師(鬼)（HU前）\u3000サンプル"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70209100,
       "Entries": [
-        "Buddhist priest (demon) (after HU) sample -- 仏師(鬼)（HU後）\u3000サンプル"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70210000,
       "Entries": [
-        "Demon Buddha -- 鬼仏"
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 70219000,
       "Entries": [
-        "Demon Buddha sample -- 鬼仏\u3000サンプル"
+        "Demon of Hatred"
       ]
     },
     {
@@ -3940,43 +3940,43 @@
     {
       "ID": 72000080,
       "Entries": [
-        "Prince_Hidden Prison Tsukimi Tower [Conversation] -- 皇子_隠し牢 月見櫓【会話】"
+        "Lord Kuro"
       ]
     },
     {
       "ID": 72000081,
       "Entries": [
-        "Prince_hidden prison loophole [conversation] -- 皇子_隠し牢 抜け道【会話】"
+        "Lord Kuro"
       ]
     },
     {
       "ID": 72000082,
       "Entries": [
-        "Prince_Hidden Prison Susukino [Conversation] -- 皇子_隠し牢 すすき野原【会話】"
+        "Lord Kuro"
       ]
     },
     {
       "ID": 72001080,
       "Entries": [
-        "Lord Kuro (Conversation - Kuro's Room)"
+        "Lord Kuro"
       ]
     },
     {
       "ID": 72001081,
       "Entries": [
-        "Prince_Honjo_Tenshukaku [Conversation] -- 皇子_本城_天守閣【会話】"
+        "Lord Kuro"
       ]
     },
     {
       "ID": 73000080,
       "Entries": [
-        "Chigo_Temple [Conversation] -- 稚児_寺【会話】"
+        "Senpou Priest"
       ]
     },
     {
       "ID": 73001080,
       "Entries": [
-        "Chigo_Infinite Corridor [Conversation] -- 稚児_無限回廊【会話】"
+        "Monk - Hall of Illusion"
       ]
     },
     {
@@ -3994,7 +3994,7 @@
     {
       "ID": 74000081,
       "Entries": [
-        "Isei no Musume Honjo [Conversation] -- 医聖の娘 本城【会話】"
+        "Emma, the Gentle Blade"
       ]
     },
     {
@@ -4012,619 +4012,619 @@
     {
       "ID": 74001080,
       "Entries": [
-        "Isei no Musume Araji Temple [Conversation] -- 医聖の娘 荒れ寺【会話】"
+        "Emma, the Gentle Blade"
       ]
     },
     {
       "ID": 74100080,
       "Entries": [
-        "Fascinated Samurai Hidden Prison [Conversation] -- 魅了された侍 隠し牢【会話】"
+        "Jinzaemon Kumano"
       ]
     },
     {
       "ID": 74101080,
       "Entries": [
-        "Fascinated Samurai Dungeon [Conversation] -- 魅了された侍 地下牢【会話】"
+        "Jinzaemon Kumano"
       ]
     },
     {
       "ID": 74101081,
       "Entries": [
-        "Fascinated Samurai Dungeon_Experimental Body [Conversation] -- 魅了された侍 地下牢_実験体【会話】"
+        "Jinzaemon Kumano"
       ]
     },
     {
       "ID": 74102080,
       "Entries": [
-        "Fascinated Samurai Sick Village_Entrance [Conversation] -- 魅了された侍 病み村_入り口【会話】"
+        "Jinzaemon Kumano"
       ]
     },
     {
       "ID": 74102081,
       "Entries": [
-        "Fascinated Samurai Sick Village_In front of the square [Conversation] -- 魅了された侍 病み村_広場前【会話】"
+        "Jinzaemon Kumano"
       ]
     },
     {
       "ID": 74200080,
       "Entries": [
-        "Selling bandits Castle [Conversation] -- 物売り野盗 城下【会話】"
+        "Anayama the Peddler"
       ]
     },
     {
       "ID": 74200081,
       "Entries": [
-        "Selling bandits Castle _ Survival when Tokugawa invades [Conversation] -- 物売り野盗 城下_徳川襲来時\u3000生存【会話】"
+        "Anayama the Peddler"
       ]
     },
     {
       "ID": 74201080,
       "Entries": [
-        "Soldier Bandit Samurai Residence_Past [Conversation] -- 物売り野盗 武家屋敷_過去【会話】"
+        "Anayama the Peddler"
       ]
     },
     {
       "ID": 74300080,
       "Entries": [
-        "Shop clerk Castle A [Conversation] -- ショップ店員\u3000城下A【会話】"
+        "Memorial Mob"
       ]
     },
     {
       "ID": 74300081,
       "Entries": [
-        "Shop clerk Castle B [Conversation] -- ショップ店員\u3000城下B【会話】"
+        "Memorial Mob"
       ]
     },
     {
       "ID": 74300082,
       "Entries": [
-        "Araji Shop Clerk Castle B [Conversation] -- 荒れ寺ショップ店員\u3000城下B【会話】"
+        "Anayama the Peddler"
       ]
     },
     {
       "ID": 74301080,
       "Entries": [
-        "Shop clerk valley [conversation] -- ショップ店員\u3000渓谷【会話】"
+        "Memorial Mob"
       ]
     },
     {
       "ID": 74302080,
       "Entries": [
-        "Shop clerk Temple [Conversation] -- ショップ店員\u3000寺【会話】"
+        "Memorial Mob"
       ]
     },
     {
       "ID": 74303080,
       "Entries": [
-        "Shop clerk Dungeon [Conversation] -- ショップ店員\u3000地下牢【会話】"
+        "Memorial Mob"
       ]
     },
     {
       "ID": 74304080,
       "Entries": [
-        "Shop clerk Hidden prison [conversation] -- ショップ店員\u3000隠し牢【会話】"
+        "Memorial Mob"
       ]
     },
     {
       "ID": 74305080,
       "Entries": [
-        "Shop clerk Honjo [Conversation] -- ショップ店員\u3000本城【会話】"
+        "Memorial Mob"
       ]
     },
     {
       "ID": 74305081,
       "Entries": [
-        "Araji Shop Clerk Honjo [Conversation] -- 荒れ寺ショップ店員\u3000本城【会話】"
+        "Anayama the Peddler"
       ]
     },
     {
       "ID": 74306080,
       "Entries": [
-        "Shop clerk Sick village [conversation] -- ショップ店員\u3000病み村【会話】"
+        "Memorial Mob"
       ]
     },
     {
       "ID": 74400080,
       "Entries": [
-        "Yaohioka Nun Honjo [Conversation] -- 八百比丘尼\u3000本城【会話】"
+        "Praying Woman"
       ]
     },
     {
       "ID": 74401080,
       "Entries": [
-        "Yayobioka Nun Valley_Upper [Conversation] -- 八百比丘尼\u3000渓谷_上層【会話】"
+        "Praying Woman"
       ]
     },
     {
       "ID": 74401081,
       "Entries": [
-        "Yayobioka Nun Valley_Lower Level [Conversation] -- 八百比丘尼\u3000渓谷_下層【会話】"
+        "Praying Woman"
       ]
     },
     {
       "ID": 74402080,
       "Entries": [
-        "Yayobioka Nanji Temple_Middle [Conversation] -- 八百比丘尼\u3000寺_中腹【会話】"
+        "Praying Woman"
       ]
     },
     {
       "ID": 74402081,
       "Entries": [
-        "Yayobioka Nanji Temple_Main Hall [Conversation] -- 八百比丘尼\u3000寺_本堂【会話】"
+        "Praying Woman"
       ]
     },
     {
       "ID": 74403080,
       "Entries": [
-        "Yaohioka Nun Dungeon_In front of the execution table [Conversation] -- 八百比丘尼\u3000地下牢_処刑台前【会話】"
+        "Praying Woman"
       ]
     },
     {
       "ID": 74500080,
       "Entries": [
-        "Suzu Auntie Castle [Conversation] -- 鈴婆\u3000城下【会話】"
+        "Inosuke Nogami's Mother"
       ]
     },
     {
       "ID": 74501080,
       "Entries": [
-        "Suzuma Samurai Residence [Conversation] -- 鈴婆\u3000武家屋敷【会話】"
+        "Inosuke Nogami's Mother"
       ]
     },
     {
       "ID": 74600080,
       "Entries": [
-        "Suzuba&#39;s son Castle [Conversation] -- 鈴ばばあの息子\u3000城下【会話】"
+        "Inosuke Nogami\n"
       ]
     },
     {
       "ID": 74601080,
       "Entries": [
-        "Suzuba&#39;s son Samurai residence [Conversation] -- 鈴ばばあの息子\u3000武家屋敷【会話】"
+        "Inosuke Nogami\n"
       ]
     },
     {
       "ID": 74700080,
       "Entries": [
-        "The kidnapped lower man temple [conversation] -- さらわれ下男 寺 【会話】"
+        "Kotaro"
       ]
     },
     {
       "ID": 74700081,
       "Entries": [
-        "The kidnapped man temple_infinite corridor [conversation] -- さらわれ下男 寺_無限回廊 【会話】"
+        "Kotaro"
       ]
     },
     {
       "ID": 74701080,
       "Entries": [
-        "The kidnapped young man joins the castle sales bandit [conversation] -- さらわれ下男 城下 物売り野盗と合流【会話】"
+        "Kotaro"
       ]
     },
     {
       "ID": 74701081,
       "Entries": [
-        "The kidnapped young man when the castle Tokugawa invades [conversation] -- さらわれ下男 城下 徳川襲来時\u3000【会話】"
+        "Kotaro"
       ]
     },
     {
       "ID": 74702080,
       "Entries": [
-        "The kidnapped young man dungeon crucifixion [conversation] -- さらわれ下男 地下牢 磔【会話】"
+        "Kotaro"
       ]
     },
     {
       "ID": 74702081,
       "Entries": [
-        "The kidnapped young man dungeon experimental body [conversation] -- さらわれ下男 地下牢 実験体【会話】"
+        "Kotaro"
       ]
     },
     {
       "ID": 74800080,
       "Entries": [
-        "Sick village priest _ Before becoming Innsmouth [Conversation] -- 病み村神主_インスマウス化前【会話】"
+        "Mibu Village Priest"
       ]
     },
     {
       "ID": 74800081,
       "Entries": [
-        "Sick village priest _ After becoming Innsmouth [Conversation] -- 病み村神主_インスマウス化後【会話】"
+        "Mibu Village Priest"
       ]
     },
     {
       "ID": 74900080,
       "Entries": [
-        "Immortal Experiment Doctor Dungeon [Conversation] -- 不死実験の医僧 地下牢【会話】"
+        "Doujun"
       ]
     },
     {
       "ID": 74900081,
       "Entries": [
-        "Immortal Experiment Doctor Dungeon Monsterization [Conversation] -- 不死実験の医僧 地下牢\u3000怪物化【会話】"
+        "Doujun"
       ]
     },
     {
       "ID": 75000080,
       "Entries": [
-        "A decent resident sick village [conversation] -- まともな住人 病み村【会話】"
+        "Mibu Villager Basket"
       ]
     },
     {
       "ID": 75100080,
       "Entries": [
-        "White Rappa_Castle [Conversation] -- 白らっぱ_城下【会話】"
+        "Blackhat Badger"
       ]
     },
     {
       "ID": 75101080,
       "Entries": [
-        "White Rappa_Dungeon [Conversation] -- 白らっぱ_地下牢【会話】"
+        "Blackhat Badger"
       ]
     },
     {
       "ID": 75101081,
       "Entries": [
-        "White Rappa_Dungeon_Experimental Body [Conversation] -- 白らっぱ_地下牢_実験体【会話】"
+        "Blackhat Badger"
       ]
     },
     {
       "ID": 75102080,
       "Entries": [
-        "White Rappa_Temple_Before flying a kite [Conversation] -- 白らっぱ_寺_凧揚げ前【会話】"
+        "Blackhat Badger"
       ]
     },
     {
       "ID": 75102081,
       "Entries": [
-        "White Rappa_Temple_Training Ground [Conversation] -- 白らっぱ_寺_修行場【会話】"
+        "Blackhat Badger"
       ]
     },
     {
       "ID": 75103080,
       "Entries": [
-        "White Rappa_Honjo_Shop [Conversation] -- 白らっぱ_本城_ショップ【会話】"
+        "Blackhat Badger"
       ]
     },
     {
       "ID": 75103081,
       "Entries": [
-        "White Rappa_Honjo_Tokugawa Invasion [Conversation] -- 白らっぱ_本城_徳川襲来時【会話】"
+        "Blackhat Badger"
       ]
     },
     {
       "ID": 90001003,
       "Entries": [
-        "NTC NPC Ochimusha _ Jiu-Jitsu _ Gotenmae-Goten -- NTC NPC落武者_体術寄り_御殿前-御殿"
+        "Ashina Soldier - Test\n"
       ]
     },
     {
       "ID": 90002000,
       "Entries": [
-        "NTC NPC Ochimusha_Balance -- NTC NPC落武者_バランス"
+        "Ashina Soldier - Test\n"
       ]
     },
     {
       "ID": 90002001,
       "Entries": [
-        "NTC NPC Ochimusha_Balance_Toraguchi &amp; Goten -- NTC NPC落武者_バランス_虎口 & 御殿"
+        "Ashina Soldier - Test\n"
       ]
     },
     {
       "ID": 90009000,
       "Entries": [
-        "NTC NPC Ochimusha_for behavior check -- NTC NPC落武者_挙動確認用"
+        "Ashina Soldier - Test\n"
       ]
     },
     {
       "ID": 91000000,
       "Entries": [
-        "NTC dog -- NTC イヌ"
+        "Hound - Test\n"
       ]
     },
     {
       "ID": 91000003,
       "Entries": [
-        "NTC Dog_Slope Breakthrough 3 -- NTC イヌ_坂突破3"
+        "Hound - Test\n"
       ]
     },
     {
       "ID": 95001000,
       "Entries": [
-        "NTC Ochimusha_Sword_One-handed -- NTC 落武者_刀_片手持ち"
+        "Ashina Soldier - Test\n"
       ]
     },
     {
       "ID": 95001001,
       "Entries": [
-        "NTC Ochimusha_Sword_One-handed_Exclusive -- NTC 落武者_刀_片手持ち_専守"
+        "Ashina Soldier - Test\n"
       ]
     },
     {
       "ID": 95001002,
       "Entries": [
-        "NTC Ochimusha_Sword_One-handed_Plaza_Samurai General&#39;s companion -- NTC 落武者_刀_片手持ち_広場_侍大将のお供"
+        "Ashina Soldier - Test\n"
       ]
     },
     {
       "ID": 95001003,
       "Entries": [
-        "NTC Ochimusha_Sword_One-handed_For first battle -- NTC 落武者_刀_片手持ち_初戦闘用"
+        "Ashina Soldier - Test\n"
       ]
     },
     {
       "ID": 95001004,
       "Entries": [
-        "NTC Ochimusha_Sword_One-handed_Do not go in the direction of sound -- NTC 落武者_刀_片手持ち_音方向に行かない"
+        "Ashina Soldier - Test\n"
       ]
     },
     {
       "ID": 95001010,
       "Entries": [
-        "NTC Ochimusha_Sword_One-handed_Stopper -- NTC 落武者_刀_片手持ち_ストッパー"
+        "Ashina Soldier - Test\n"
       ]
     },
     {
       "ID": 95001011,
       "Entries": [
-        "NTC Ochimusha_Sword_One-handed_Stopper Short field of view -- NTC 落武者_刀_片手持ち_ストッパー\u3000短視界"
+        "Ashina Soldier - Test\n"
       ]
     },
     {
       "ID": 95001012,
       "Entries": [
-        "NTC Ochimusha_Sword_One-handed_Stopper_Fixed position -- NTC 落武者_刀_片手持ち_ストッパー_位置固定"
+        "Ashina Soldier - Test\n"
       ]
     },
     {
       "ID": 95001090,
       "Entries": [
-        "NTC Ochimusha_Sword_One-handed_Suspension bridge collapse aiming only -- NTC 落武者_刀_片手持ち_吊橋崩落狙い専用"
+        "Ashina Soldier - Test\n"
       ]
     },
     {
       "ID": 95002000,
       "Entries": [
-        "NTC Ochimusha_Sword_Eight Phases -- NTC 落武者_刀_八相"
+        "Ashina Soldier - Test\n"
       ]
     },
     {
       "ID": 95002004,
       "Entries": [
-        "NTC Ochimusha_Sword_Eight Phases_Large visual height -- NTC 落武者_刀_八相_視覚高さ幅大きめ"
+        "Ashina Soldier - Test\n"
       ]
     },
     {
       "ID": 95002010,
       "Entries": [
-        "NTC Ochimusha_Sword_Eight Phase_Stopper -- NTC 落武者_刀_八相_ストッパー"
+        "Ashina Soldier - Test\n"
       ]
     },
     {
       "ID": 95002011,
       "Entries": [
-        "NTC Ochimusha_Sword_Eight Phase_Stopper Short field of view -- NTC 落武者_刀_八相_ストッパー\u3000短視界"
+        "Ashina Soldier - Test\n"
       ]
     },
     {
       "ID": 95003000,
       "Entries": [
-        "NTC Ochimusha_Spear -- NTC 落武者_槍"
+        "Ashina Soldier - Test\n"
       ]
     },
     {
       "ID": 95003001,
       "Entries": [
-        "NTC Ochimusha_Spear_Narrow visual sense -- NTC 落武者_槍_視覚幅狭い"
+        "Ashina Soldier - Test\n"
       ]
     },
     {
       "ID": 95003010,
       "Entries": [
-        "NTC Ochimusha_Spear_Stopper -- NTC 落武者_槍_ストッパー"
+        "Ashina Soldier - Test\n"
       ]
     },
     {
       "ID": 95004000,
       "Entries": [
-        "NTC Ochimusha_Matchlock -- NTC 落武者_火縄銃"
+        "Ashina Soldier - Test\n"
       ]
     },
     {
       "ID": 95004001,
       "Entries": [
-        "NTC Ochimusha_Matchlock_Breakthrough Situation_Steep Slope -- NTC 落武者_火縄銃_突破シチュエーション_急坂"
+        "Ashina Soldier - Test\n"
       ]
     },
     {
       "ID": 95004006,
       "Entries": [
-        "NTC Ochimusha_Matchlock_Ishigakigami -- NTC 落武者_火縄銃_石垣上"
+        "Ashina Soldier - Test\n"
       ]
     },
     {
       "ID": 95004007,
       "Entries": [
-        "NTC Ochimusha_Matchlock_Yaguramon -- NTC 落武者_火縄銃_櫓門前"
+        "Ashina Soldier - Test\n"
       ]
     },
     {
       "ID": 95004008,
       "Entries": [
-        "NTC Ochimusha_Matchlock Fixed Battery -- NTC 落武者_火縄銃 固定砲台"
+        "Ashina Soldier - Test\n"
       ]
     },
     {
       "ID": 95004009,
       "Entries": [
-        "NTC Ochimusha_Matchlock Yaguramon Surveillance Outdoor -- NTC 落武者_火縄銃 櫓門監視 屋外"
+        "Ashina Soldier - Test\n"
       ]
     },
     {
       "ID": 95004010,
       "Entries": [
-        "NTC Ochimusha_Matchlock Yaguramon Surveillance Indoors -- NTC 落武者_火縄銃 櫓門監視\u3000屋内"
+        "Ashina Soldier - Test\n"
       ]
     },
     {
       "ID": 95201001,
       "Entries": [
-        "NTC Samurai General_Visibility angle enhanced version -- NTC 侍大将_視界角度強化版"
+        "Samurai General - Test\n"
       ]
     },
     {
       "ID": 95201050,
       "Entries": [
-        "NTC Samurai General_Visual short -- NTC 侍大将_視覚短い"
+        "Samurai General - Test\n"
       ]
     },
     {
       "ID": 95211000,
       "Entries": [
-        "NTC Samurai General_Komiyama Test -- NTC 侍大将_小宮山テスト"
+        "Samurai General - Test\n"
       ]
     },
     {
       "ID": 95221000,
       "Entries": [
-        "NTC Samurai General Tominaga Test -- NTC 侍大将\u3000富永テスト"
+        "Samurai General - Test\n"
       ]
     },
     {
       "ID": 95231000,
       "Entries": [
-        "NTC Samurai General Sasaki Test -- NTC 侍大将\u3000佐々木テスト"
+        "Samurai General - Test\n"
       ]
     },
     {
       "ID": 95301000,
       "Entries": [
-        "NTC Centipede (Melee Combat Type) -- NTC ムカデ（近接戦闘タイプ）"
+        "Centipede - Test\n"
       ]
     },
     {
       "ID": 95301010,
       "Entries": [
-        "NTC Centipede (Horaku ball type): Long-distance type upper stage -- NTC ムカデ（ほうらく玉タイプ）：遠距離型上段"
+        "Centipede - Test\n"
       ]
     },
     {
       "ID": 95301011,
       "Entries": [
-        "NTC Centipede (Horaku ball type): Long-distance type middle stage -- NTC ムカデ（ほうらく玉タイプ）：遠距離型中段"
+        "Centipede - Test\n"
       ]
     },
     {
       "ID": 95301020,
       "Entries": [
-        "NTC Centipede (Horaku ball type): Short-distance type -- NTC ムカデ（ほうらく玉タイプ）：近距離型"
+        "Centipede - Test\n"
       ]
     },
     {
       "ID": 95400000,
       "Entries": [
-        "NTC Crow -- NTC カラス"
+        "Crow - Test\n"
       ]
     },
     {
       "ID": 95601000,
       "Entries": [
-        "NTC Centipede (Melee Combat Type) -- NTC ムカデ（近接戦闘タイプ）"
+        "Centipede - Test\n"
       ]
     },
     {
       "ID": 96001000,
       "Entries": [
-        "NTC Buddhist Monk -- NTC 破戒僧"
+        "Sculptor - Test\n"
       ]
     },
     {
       "ID": 96001001,
       "Entries": [
-        "NTC Buddhist Monk_ Behind the scenes -- NTC 破戒僧_背後警戒"
+        "Sculptor - Test\n"
       ]
     },
     {
       "ID": 96001002,
       "Entries": [
-        "NTC Haunting Monk_Gap -- NTC 破戒僧_隙"
+        "Corrupted Monk - Test\n"
       ]
     },
     {
       "ID": 96001005,
       "Entries": [
-        "NTC Haunting Monk_Phantom -- NTC 破戒僧_幻影"
+        "Corrupted Monk - Test\n"
       ]
     },
     {
       "ID": 96001010,
       "Entries": [
-        "NTC Haunting Monk_Wide Range Magic Dummy_Foreground -- NTC 破戒僧_広範囲幻術用ダミー_手前"
+        "Corrupted Monk - Test\n"
       ]
     },
     {
       "ID": 96001011,
       "Entries": [
-        "NTC Haunting Monk_Wide Range Magic Dummy_Oku -- NTC 破戒僧_広範囲幻術用ダミー_奥"
+        "Corrupted Monk - Test\n"
       ]
     },
     {
       "ID": 96100000,
       "Entries": [
-        "NTC Valley Snake -- NTC 渓谷の大蛇"
+        "Great Serpent - Test\n"
       ]
     },
     {
       "ID": 96500000,
       "Entries": [
-        "NTC Handmaiden Aunt -- NTC 侍女おば"
+        "Old Main - Test\n"
       ]
     },
     {
       "ID": 96600000,
       "Entries": [
-        "NTC lookout -- NTC 見張り番"
+        "Sentry - Test\n"
       ]
     },
     {
       "ID": 96600001,
       "Entries": [
-        "NTC Lookout _ Visual Distance Enhancement -- NTC 見張り番_視覚距離強化"
+        "Sentry - Test\n"
       ]
     },
     {
       "ID": 98000000,
       "Entries": [
-        "NTC Shinobi Confirmation_General Purpose -- NTC 忍殺確認_汎用"
+        "\n"
       ]
     },
     {
       "ID": 98100000,
       "Entries": [
-        "NTC Shinobi Killing Confirmation_For characters without warning animation -- NTC 忍殺確認_警戒アニメが無いキャラ用"
+        "\n"
       ]
     },
     {
       "ID": 98200000,
       "Entries": [
-        "NTC Shinobi Confirmation_Large -- NTC 忍殺確認_大型"
+        "\n"
       ]
     },
     {
       "ID": 98300000,
       "Entries": [
-        "NTC shinobi confirmation_4 foot walking -- NTC 忍殺確認_4足歩行"
+        "\n"
       ]
     },
     {
       "ID": 98400000,
       "Entries": [
-        "For checking NTC swashbuckler animation -- NTC剣戟アニメ確認用"
+        "\n"
       ]
     },
     {
       "ID": 98500000,
       "Entries": [
-        "Experiment_Ochimusha_Blind -- 実験_落武者_盲目"
+        "\n"
       ]
     }
   ]

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/RematchWarpParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/RematchWarpParam.json
@@ -10,115 +10,115 @@
     {
       "ID": 1,
       "Entries": [
-        ""
+        "Gyoubu Oniwa"
       ]
     },
     {
       "ID": 2,
       "Entries": [
-        ""
+        "Lady Butterfly"
       ]
     },
     {
       "ID": 3,
       "Entries": [
-        ""
+        "Genichiro Ashina"
       ]
     },
     {
       "ID": 4,
       "Entries": [
-        ""
+        "Folding Screen Monkeys"
       ]
     },
     {
       "ID": 5,
       "Entries": [
-        ""
+        "Guardian Ape"
       ]
     },
     {
       "ID": 6,
       "Entries": [
-        ""
+        "Headless Ape"
       ]
     },
     {
       "ID": 7,
       "Entries": [
-        ""
+        "Corrupted Monk"
       ]
     },
     {
       "ID": 8,
       "Entries": [
-        ""
+        "True Monk"
       ]
     },
     {
       "ID": 9,
       "Entries": [
-        ""
+        "Great Shinobi Owl"
       ]
     },
     {
       "ID": 10,
       "Entries": [
-        ""
+        "Owl (Father)"
       ]
     },
     {
       "ID": 11,
       "Entries": [
-        ""
+        "Divine Dragon"
       ]
     },
     {
       "ID": 12,
       "Entries": [
-        ""
+        "Emma"
       ]
     },
     {
       "ID": 13,
       "Entries": [
-        ""
+        "Isshin Ashina"
       ]
     },
     {
       "ID": 14,
       "Entries": [
-        ""
+        "Genichiro, Way of Tomoe"
       ]
     },
     {
       "ID": 15,
       "Entries": [
-        ""
+        "Isshin the Sword Saint"
       ]
     },
     {
       "ID": 16,
       "Entries": [
-        ""
+        "Demon of Hatred"
       ]
     },
     {
       "ID": 17,
       "Entries": [
-        ""
+        "Inner Genichiro"
       ]
     },
     {
       "ID": 18,
       "Entries": [
-        ""
+        "Inner Father"
       ]
     },
     {
       "ID": 19,
       "Entries": [
-        ""
+        "Inner Isshin"
       ]
     }
   ]

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/ShopLineupParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/ShopLineupParam.json
@@ -4,7 +4,7 @@
     {
       "ID": 1,
       "Entries": [
-        "Don't remove"
+        "Default"
       ]
     },
     {

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/SpEffectParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/SpEffectParam.json
@@ -400,7 +400,7 @@
     {
       "ID": 100,
       "Entries": [
-        "Demon Buddha recovery effect 1 -- 鬼仏回復効果1"
+        "Idol Recovery Effect"
       ]
     },
     {
@@ -10084,7 +10084,7 @@
     {
       "ID": 113000,
       "Entries": [
-        "Shuriken_Trunk recovery speed reduction -- 手裏剣_体幹回復速度減少"
+        "Shuriken Posture Recovery Reduction"
       ]
     },
     {
@@ -17308,7 +17308,7 @@
     {
       "ID": 3509070,
       "Entries": [
-        "[NTC] Butterfly_Butterfly change -- 【NTC】お蝶_蝶々変化"
+        "Lady Butterfly - Release Illusion"
       ]
     },
     {

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/SpEffectParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/SpEffectParam.json
@@ -2272,49 +2272,49 @@
     {
       "ID": 4000,
       "Entries": [
-        "Sustained damage floor [Poison_Interval adjustment_Valley valley bottom (deep)] -- 持続ダメージ床【毒_間隔調整_渓谷谷底（深）】"
+        "Poison Swamp"
       ]
     },
     {
       "ID": 4001,
       "Entries": [
-        "Sustained damage floor [Poison_Effect body_Valley valley bottom (deep)] -- 持続ダメージ床【毒_効果本体_渓谷谷底（深）】"
+        "Poison Swamp"
       ]
     },
     {
       "ID": 4002,
       "Entries": [
-        "Sustained damage floor [Poison_Interval adjustment_Valley valley bottom (shallow)] -- 持続ダメージ床【毒_間隔調整_渓谷谷底（浅）】"
+        "Poison Swamp"
       ]
     },
     {
       "ID": 4003,
       "Entries": [
-        "Sustained damage floor [Poison_Effect body_Valley valley bottom (shallow)] -- 持続ダメージ床【毒_効果本体_渓谷谷底（浅）】"
+        "Poison Swamp"
       ]
     },
     {
       "ID": 4010,
       "Entries": [
-        "Sustained Damage Floor [Weak Flame + Damage_Interval Adjustment_Castle] -- 持続ダメージ床【弱炎+ダメージ_間隔調整_城下】"
+        "Environmental Flame"
       ]
     },
     {
       "ID": 4011,
       "Entries": [
-        "Sustained Damage Floor [Weak Flame + Damage_Effect Body (Damage) _Castle] -- 持続ダメージ床【弱炎+ダメージ_効果本体（ダメージ）_城下】"
+        "Environmental Flame"
       ]
     },
     {
       "ID": 4012,
       "Entries": [
-        "Sustained damage floor [Weak flame + damage _ effect body (flaming) _ castle] -- 持続ダメージ床【弱炎+ダメージ_効果本体（炎上）_城下】"
+        "Environmental Flame"
       ]
     },
     {
       "ID": 4014,
       "Entries": [
-        "Sustained Damage Floor [Flame_Smoke Signal_Castle] -- 持続ダメージ床【炎_狼煙_城下】"
+        "Environmental Flame"
       ]
     },
     {
@@ -2326,19 +2326,19 @@
     {
       "ID": 4020,
       "Entries": [
-        "Sustained damage floor [Strong flame + damage_interval adjustment_samurai residence] -- 持続ダメージ床【強炎+ダメージ_間隔調整_武家屋敷】"
+        "Environmental Flame"
       ]
     },
     {
       "ID": 4021,
       "Entries": [
-        "Sustained damage floor [Strong flame + damage _ effect body (damage) _ samurai residence] -- 持続ダメージ床【強炎+ダメージ_効果本体（ダメージ）_武家屋敷】"
+        "Environmental Flame"
       ]
     },
     {
       "ID": 4022,
       "Entries": [
-        "Sustained damage floor [strong flame + damage _ effect body (flaming) _ samurai residence] -- 持続ダメージ床【強炎+ダメージ_効果本体（炎上）_武家屋敷】"
+        "Environmental Flame"
       ]
     },
     {
@@ -2476,229 +2476,229 @@
     {
       "ID": 5020,
       "Entries": [
-        "General-purpose effect for logic judgment 1 -- ロジック判定用 汎用効果1"
+        "General Purpose for Logic"
       ]
     },
     {
       "ID": 5021,
       "Entries": [
-        "General-purpose effect for logic judgment 2 -- ロジック判定用 汎用効果2"
+        "General Purpose for Logic"
       ]
     },
     {
       "ID": 5022,
       "Entries": [
-        "General-purpose effect for logic judgment 3 -- ロジック判定用 汎用効果3"
+        "General Purpose for Logic"
       ]
     },
     {
       "ID": 5023,
       "Entries": [
-        "General-purpose effect for logic judgment 4 -- ロジック判定用 汎用効果4"
+        "General Purpose for Logic"
       ]
     },
     {
       "ID": 5024,
       "Entries": [
-        "General-purpose effect for logic judgment 5 -- ロジック判定用 汎用効果5"
+        "General Purpose for Logic"
       ]
     },
     {
       "ID": 5025,
       "Entries": [
-        "General-purpose effect for logic judgment 6 -- ロジック判定用 汎用効果6"
+        "General Purpose for Logic"
       ]
     },
     {
       "ID": 5026,
       "Entries": [
-        "General-purpose effect for logic judgment 7 -- ロジック判定用 汎用効果7"
+        "General Purpose for Logic"
       ]
     },
     {
       "ID": 5027,
       "Entries": [
-        "General-purpose effect for logic judgment 8 -- ロジック判定用 汎用効果8"
+        "General Purpose for Logic"
       ]
     },
     {
       "ID": 5028,
       "Entries": [
-        "General-purpose effect for logic judgment 9 -- ロジック判定用 汎用効果9"
+        "General Purpose for Logic"
       ]
     },
     {
       "ID": 5029,
       "Entries": [
-        "General-purpose effect for logic judgment 10 -- ロジック判定用 汎用効果10"
+        "General Purpose for Logic"
       ]
     },
     {
       "ID": 5030,
       "Entries": [
-        "General-purpose effect for logic judgment 11 -- ロジック判定用 汎用効果11"
+        "General Purpose for Logic"
       ]
     },
     {
       "ID": 5031,
       "Entries": [
-        "General-purpose effect for logic judgment 12 -- ロジック判定用 汎用効果12"
+        "General Purpose for Logic"
       ]
     },
     {
       "ID": 5032,
       "Entries": [
-        "General-purpose effect for logic judgment 13 -- ロジック判定用 汎用効果13"
+        "General Purpose for Logic"
       ]
     },
     {
       "ID": 5033,
       "Entries": [
-        "General-purpose effect for logic judgment 14 -- ロジック判定用 汎用効果14"
+        "General Purpose for Logic"
       ]
     },
     {
       "ID": 5034,
       "Entries": [
-        "General-purpose effect for logic judgment 15 -- ロジック判定用 汎用効果15"
+        "General Purpose for Logic"
       ]
     },
     {
       "ID": 5035,
       "Entries": [
-        "General-purpose effect for logic judgment 16 -- ロジック判定用 汎用効果16"
+        "General Purpose for Logic"
       ]
     },
     {
       "ID": 5036,
       "Entries": [
-        "General-purpose effect for logic judgment 17 -- ロジック判定用 汎用効果17"
+        "General Purpose for Logic"
       ]
     },
     {
       "ID": 5037,
       "Entries": [
-        "General-purpose effect for logic judgment 18 -- ロジック判定用 汎用効果18"
+        "General Purpose for Logic"
       ]
     },
     {
       "ID": 5038,
       "Entries": [
-        "General-purpose effect for logic judgment 19 -- ロジック判定用 汎用効果19"
+        "General Purpose for Logic"
       ]
     },
     {
       "ID": 5039,
       "Entries": [
-        "General-purpose effect for logic judgment 20 -- ロジック判定用 汎用効果20"
+        "General Purpose for Logic"
       ]
     },
     {
       "ID": 5040,
       "Entries": [
-        "MP reduction -1 -- MP減少-1"
+        ""
       ]
     },
     {
       "ID": 5041,
       "Entries": [
-        "MP reduction-2 -- MP減少-2"
+        ""
       ]
     },
     {
       "ID": 5042,
       "Entries": [
-        "MP reduction-3 -- MP減少-3"
+        ""
       ]
     },
     {
       "ID": 5043,
       "Entries": [
-        "MP reduction-4 -- MP減少-4"
+        ""
       ]
     },
     {
       "ID": 5044,
       "Entries": [
-        "MP reduction-5 -- MP減少-5"
+        ""
       ]
     },
     {
       "ID": 5045,
       "Entries": [
-        "MP recovery +1 -- MP回復+1"
+        ""
       ]
     },
     {
       "ID": 5046,
       "Entries": [
-        "MP recovery +2 -- MP回復+2"
+        ""
       ]
     },
     {
       "ID": 5047,
       "Entries": [
-        "MP recovery +3 -- MP回復+3"
+        ""
       ]
     },
     {
       "ID": 5048,
       "Entries": [
-        "MP recovery +4 -- MP回復+4"
+        ""
       ]
     },
     {
       "ID": 5049,
       "Entries": [
-        "MP recovery +5 -- MP回復+5"
+        ""
       ]
     },
     {
       "ID": 5060,
       "Entries": [
-        "Apply corpse reaction -- 死体反応を適用する"
+        "Apply Corpse Reaction"
       ]
     },
     {
       "ID": 5061,
       "Entries": [
-        "Corpse reaction pattern 0 -- 死体反応パターン0"
+        "Corpse Reaction Pattern"
       ]
     },
     {
       "ID": 5062,
       "Entries": [
-        "Corpse reaction pattern 1 -- 死体反応パターン1"
+        "Corpse Reaction Pattern"
       ]
     },
     {
       "ID": 5063,
       "Entries": [
-        "Corpse reaction pattern 2 -- 死体反応パターン2"
+        "Corpse Reaction Pattern"
       ]
     },
     {
       "ID": 5100,
       "Entries": [
-        "EvE enemy weakening doping_attack 75% defense 125% -- EvE用敵弱体化ドーピング_攻75％防125％"
+        "Enemy vs Enemy Power Reduction"
       ]
     },
     {
       "ID": 5101,
       "Entries": [
-        "EvE enemy weakening doping_attack 50% defense 125% -- EvE用敵弱体化ドーピング_攻50％防125％"
+        "Enemy vs Enemy Power Reduction"
       ]
     },
     {
       "ID": 5102,
       "Entries": [
-        "EvE enemy weakening doping_attack 25% defense 125% -- EvE用敵弱体化ドーピング_攻25％防125％"
+        "Enemy vs Enemy Power Reduction"
       ]
     },
     {
       "ID": 5110,
       "Entries": [
-        "EvE Samurai Residence Swordsman Doping_Attack 50% Defense 150% -- EvE武家屋敷剣客用ドーピング_攻50％防150％"
+        "Enemy vs Enemy Power Reduction"
       ]
     },
     {
@@ -5644,7 +5644,7 @@
     {
       "ID": 8500,
       "Entries": [
-        "Remaining machine protection (demon Buddha) -- 残機プロテクト（鬼仏）"
+        "Unseen Aid"
       ]
     },
     {

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/SpEffectParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/SpEffectParam.json
@@ -5662,481 +5662,481 @@
     {
       "ID": 9000,
       "Entries": [
-        "Contact Medicine"
+        "Poison Type 1"
       ]
     },
     {
       "ID": 9001,
       "Entries": [
-        "Poison Bloodsmoke Ninjutsu"
+        "Poison Type 2"
       ]
     },
     {
       "ID": 9002,
       "Entries": [
-        "Poison Bestowal Ninjutsu"
+        "Poison Type 3"
       ]
     },
     {
       "ID": 9003,
       "Entries": [
-        "Sabimaru Poison"
+        "Poison Type 4"
       ]
     },
     {
       "ID": 9004,
       "Entries": [
-        "Sabimaru Poison"
+        "Poison Type 5"
       ]
     },
     {
       "ID": 9005,
       "Entries": [
-        "Sabimaru Poison"
+        "Poison Type 6"
       ]
     },
     {
       "ID": 9006,
       "Entries": [
-        "Sabimaru Poison"
+        "Poison Type 7"
       ]
     },
     {
       "ID": 9007,
       "Entries": [
-        "Sabimaru Poison"
+        "Poison Type 8"
       ]
     },
     {
       "ID": 9008,
       "Entries": [
-        "Sabimaru Poison"
+        "Poison Type 9"
       ]
     },
     {
       "ID": 9009,
       "Entries": [
-        "Sabimaru Poison Mist"
+        "Poison Type 10"
       ]
     },
     {
       "ID": 9010,
       "Entries": [
-        "Enemy Poison (Sample)"
+        "Poison Type 11"
       ]
     },
     {
       "ID": 9011,
       "Entries": [
-        "Gecko - Poison"
+        "Poison Type 12"
       ]
     },
     {
       "ID": 9012,
       "Entries": [
-        "Juzou - Poison Spit"
+        "Poison Type 13"
       ]
     },
     {
       "ID": 9013,
       "Entries": [
-        "Juzou - Poison Weapon Buff"
+        "Poison Type 14"
       ]
     },
     {
       "ID": 9014,
       "Entries": [
-        "Senpou Assassin - Poison Spread"
+        "Poison Type 15"
       ]
     },
     {
       "ID": 9015,
       "Entries": [
-        "Senpou Assassin - Poison Projectile"
+        "Poison Type 16"
       ]
     },
     {
       "ID": 9016,
       "Entries": [
-        "Bandit - Poison Arrow"
+        "Poison Type 17"
       ]
     },
     {
       "ID": 9017,
       "Entries": [
-        "Old Dragon of the Tree - Poison Cough"
+        "Poison Type 18"
       ]
     },
     {
       "ID": 9018,
       "Entries": [
-        "Lone Shadow - Poison Hand"
+        "Poison Type 19"
       ]
     },
     {
       "ID": 9019,
       "Entries": [
-        "Great Shinobi Owl - Poison Throw"
+        "Poison Type 20"
       ]
     },
     {
       "ID": 9020,
       "Entries": [
-        "Sabimaru Effect on Okami"
+        "Poison Effect on Okami"
       ]
     },
     {
       "ID": 9040,
       "Entries": [
-        "Contact Medicine Poison"
+        "Poison DoT Type 1"
       ]
     },
     {
       "ID": 9041,
       "Entries": [
-        "Ninjutsu Poison DoT"
+        "Poison DoT Type 2"
       ]
     },
     {
       "ID": 9043,
       "Entries": [
-        "Poison Damage 05 [PC_Firecracker Poison]"
+        "Poison DoT Type 3"
       ]
     },
     {
       "ID": 9045,
       "Entries": [
-        "Sabimaru Poison DoT"
+        "Poison DoT Type 4"
       ]
     },
     {
       "ID": 9049,
       "Entries": [
-        "Poison Swamp"
+        "Poison DoT Type 5"
       ]
     },
     {
       "ID": 9050,
       "Entries": [
-        "General Enemy Poison DoT"
+        "Poison DoT Type 6"
       ]
     },
     {
       "ID": 9080,
       "Entries": [
-        "Female poison additional damage permission -- 女毒追加ダメージ許可"
+        "O'Rin Poison Additional Effect Permission"
       ]
     },
     {
       "ID": 9100,
       "Entries": [
-        "Burning damage 00 [PC_Shaving 25] -- 炎上ダメージ00【PC_削り25】"
+        "Burn Type 0"
       ]
     },
     {
       "ID": 9101,
       "Entries": [
-        "Burning damage 01 [PC_Shaving 33] -- 炎上ダメージ01【PC_削り33】"
+        "Burn Type 1"
       ]
     },
     {
       "ID": 9102,
       "Entries": [
-        "Burning damage 02 [PC_Shaving 50] -- 炎上ダメージ02【PC_削り50】"
+        "Burn Type 2"
       ]
     },
     {
       "ID": 9103,
       "Entries": [
-        "Burning damage 03 [PC_Shaving 67] -- 炎上ダメージ03【PC_削り67】"
+        "Burn Type 3"
       ]
     },
     {
       "ID": 9104,
       "Entries": [
-        "Burning damage 04 [PC_Shaving 75] -- 炎上ダメージ04【PC_削り75】"
+        "Burn Type 4"
       ]
     },
     {
       "ID": 9105,
       "Entries": [
-        "Burning damage 05 [PC_Shaving 100] -- 炎上ダメージ05【PC_削り100】"
+        "Burn Type 5"
       ]
     },
     {
       "ID": 9106,
       "Entries": [
-        "Burning damage 06 [PC_Shaving 125] -- 炎上ダメージ06【PC_削り125】"
+        "Burn Type 6"
       ]
     },
     {
       "ID": 9107,
       "Entries": [
-        "Burning damage 07 [PC_Shaving 150] -- 炎上ダメージ07【PC_削り150】"
+        "Burn Type 7"
       ]
     },
     {
       "ID": 9108,
       "Entries": [
-        "Burning damage 08 [PC_Shaving 175] -- 炎上ダメージ08【PC_削り175】"
+        "Burn Type 8"
       ]
     },
     {
       "ID": 9109,
       "Entries": [
-        "Burning damage 09 [PC_Shaving 200] -- 炎上ダメージ09【PC_削り200】"
+        "Burn Type 9"
       ]
     },
     {
       "ID": 9110,
       "Entries": [
-        "Burn damage 10 [Enemy_Sample] -- 炎上ダメージ10【敵_サンプル】"
+        "Burn Type 10"
       ]
     },
     {
       "ID": 9111,
       "Entries": [
-        "Burning damage 11 [Centipede_flaming floor] -- 炎上ダメージ11【ムカデ_炎床】"
+        "Burn Type 11"
       ]
     },
     {
       "ID": 9112,
       "Entries": [
-        "Burning damage 12 [Bandit_Fire arrow] -- 炎上ダメージ12【野盗_火矢】"
+        "Burn Type 12"
       ]
     },
     {
       "ID": 9113,
       "Entries": [
-        "Burning damage 13 [Demon Buddhist _ Flame floor] -- 炎上ダメージ13【鬼仏師_炎床】"
+        "Burn Type 13"
       ]
     },
     {
       "ID": 9114,
       "Entries": [
-        "Burning damage 14 [Fire cow_rush] -- 炎上ダメージ14【火牛_突進】"
+        "Burn Type 14"
       ]
     },
     {
       "ID": 9115,
       "Entries": [
-        "Burning damage 15 [Bandit_Torches] -- 炎上ダメージ15【野盗_松明】"
+        "Burn Type 15"
       ]
     },
     {
       "ID": 9116,
       "Entries": [
-        "Burning Damage 16 [Demon Buddhist Master_Flame Arm] -- 炎上ダメージ16【鬼仏師_炎腕】"
+        "Burn Type 16"
       ]
     },
     {
       "ID": 9117,
       "Entries": [
-        "Flame damage 17 [Tokugawa Samurai_Flame radiation] -- 炎上ダメージ17【徳川侍_火炎放射】"
+        "Burn Type 17"
       ]
     },
     {
       "ID": 9118,
       "Entries": [
-        "Burning damage 18 [Tokugawa Samurai_Incendiary Gun] -- 炎上ダメージ18【徳川侍_焼夷銃】"
+        "Burn Type 18"
       ]
     },
     {
       "ID": 9119,
       "Entries": [
-        "Burning Damage 19 [Shura Samurai_Ignition Encha Slash] -- 炎上ダメージ19【修羅侍_発火エンチャ斬り】"
+        "Burn Type 19"
       ]
     },
     {
       "ID": 9120,
       "Entries": [
-        "Burning damage 20 [Shura Samurai_Fire Breathing] -- 炎上ダメージ20【修羅侍_火吹き】"
+        "Burn Type 20"
       ]
     },
     {
       "ID": 9121,
       "Entries": [
-        "Burning damage 21 [Fire cow_burning] -- 炎上ダメージ21【火牛_炎上しかけ】"
+        "Burn Type 21"
       ]
     },
     {
       "ID": 9122,
       "Entries": [
-        "Burning damage 22 [Fire cow_flaming slip damage] -- 炎上ダメージ22【火牛_炎上スリップダメージ】"
+        "Burn Type 22"
       ]
     },
     {
       "ID": 9123,
       "Entries": [
-        "Burning damage 23 [Sword sword holy _ weak flame] -- 炎上ダメージ23【病床剣聖_弱炎】"
+        "Burn Type 23"
       ]
     },
     {
       "ID": 9124,
       "Entries": [
-        "Burn damage 24 [Sword sword holy _ strong flame] -- 炎上ダメージ24【病床剣聖_強炎】"
+        "Burn Type 24"
       ]
     },
     {
       "ID": 9125,
       "Entries": [
-        "Flame Damage 25 [Nightjars_Flame Encha Attack] -- 炎上ダメージ25【夜鷹衆_炎エンチャ攻撃】"
+        "Burn Type 25"
       ]
     },
     {
       "ID": 9200,
       "Entries": [
-        "Scary damage 00 -- 怖気ダメージ00"
+        "Terror Type 1"
       ]
     },
     {
       "ID": 9201,
       "Entries": [
-        "Scary damage 01 -- 怖気ダメージ01"
+        "Terror Type 2"
       ]
     },
     {
       "ID": 9202,
       "Entries": [
-        "Scary damage 02 -- 怖気ダメージ02"
+        "Terror Type 3"
       ]
     },
     {
       "ID": 9203,
       "Entries": [
-        "Scary damage 03 -- 怖気ダメージ03"
+        "Terror Type 4"
       ]
     },
     {
       "ID": 9204,
       "Entries": [
-        "Scary damage 04 -- 怖気ダメージ04"
+        "Terror Type 5"
       ]
     },
     {
       "ID": 9205,
       "Entries": [
-        "Scary damage 05 -- 怖気ダメージ05"
+        "Terror Type 6"
       ]
     },
     {
       "ID": 9206,
       "Entries": [
-        "Scary damage 06 -- 怖気ダメージ06"
+        "Terror Type 7"
       ]
     },
     {
       "ID": 9207,
       "Entries": [
-        "Scary damage 07 -- 怖気ダメージ07"
+        "Terror Type 8"
       ]
     },
     {
       "ID": 9208,
       "Entries": [
-        "Scary damage 08 -- 怖気ダメージ08"
+        "Terror Type 9"
       ]
     },
     {
       "ID": 9209,
       "Entries": [
-        "Scary damage 09 -- 怖気ダメージ09"
+        "Terror Type 10"
       ]
     },
     {
       "ID": 9210,
       "Entries": [
-        "Scary damage 10 [enemy_sample] -- 怖気ダメージ10【敵_サンプル】"
+        "Terror Type 11"
       ]
     },
     {
       "ID": 9211,
       "Entries": [
-        "Scary Damage 11 [Seven-sided Warrior_Grief Bullet (Weak)] -- 怖気ダメージ11【七面武者_怨霊弾丸（弱）】"
+        "Terror Type 12"
       ]
     },
     {
       "ID": 9212,
       "Entries": [
-        "Scary Damage 12 [Seven-sided Warrior_Grief Bullet (Strong)] -- 怖気ダメージ12【七面武者_怨霊弾丸（強）】"
+        "Terror Type 13"
       ]
     },
     {
       "ID": 9213,
       "Entries": [
-        "Scary damage 13 [Neckless_Attack (weak)] -- 怖気ダメージ13【首なし_攻撃（弱）】"
+        "Terror Type 14"
       ]
     },
     {
       "ID": 9214,
       "Entries": [
-        "Scary damage 13 [Neckless_Attack (Middle)] -- 怖気ダメージ13【首なし_攻撃（中）】"
+        "Terror Type 15"
       ]
     },
     {
       "ID": 9215,
       "Entries": [
-        "Scary damage 14 [Neckless_Attack (strong)] -- 怖気ダメージ14【首なし_攻撃（強）】"
+        "Terror Type 16"
       ]
     },
     {
       "ID": 9216,
       "Entries": [
-        "Scary damage 16 [Yasha Ape_Roar] -- 怖気ダメージ16【夜叉猿_咆哮】"
+        "Terror Type 17"
       ]
     },
     {
       "ID": 9218,
       "Entries": [
-        "Scary damage 17 [Demon monkey _ all attacks] -- 怖気ダメージ17【鬼猿_全攻撃】"
+        "Terror Type 18"
       ]
     },
     {
       "ID": 9219,
       "Entries": [
-        "Scary Damage 19 [Seven-sided Warrior_Grief Field] -- 怖気ダメージ19【七面武者_怨霊フィールド】"
+        "Terror Type 19"
       ]
     },
     {
       "ID": 9220,
       "Entries": [
-        "Scary damage 20 [Yasha Ape&#39;s mad roar] -- 怖気ダメージ20【夜叉猿の発狂咆哮】"
+        "Terror Type 20"
       ]
     },
     {
       "ID": 9221,
       "Entries": [
-        "Scary Damage 21 [Underwater Neckless Hair Bullet] -- 怖気ダメージ21【水中首なしの髪の毛弾丸】"
+        "Terror Type 21"
       ]
     },
     {
       "ID": 9222,
       "Entries": [
-        "Scary damage 22 [Village zombies_mad dumplings_parents] -- 怖気ダメージ22【村人ゾンビ_発狂団子_親】"
+        "Terror Type 22"
       ]
     },
     {
       "ID": 9223,
       "Entries": [
-        "Scary damage 23 [Village zombie _ Mad dumpling _ Child] -- 怖気ダメージ23【村人ゾンビ_発狂団子_子】"
+        "Terror Type 23"
       ]
     },
     {
       "ID": 9250,
       "Entries": [
-        "Scary_abnormal icon display -- 怖気_状態異常アイコン表示"
+        "Terror Display Icon"
       ]
     },
     {
       "ID": 9280,
       "Entries": [
-        "Fear Resistance Shaving Permit"
+        "Terror Resistance Shaving Permit"
       ]
     },
     {
       "ID": 9281,
       "Entries": [
-        "Fear_Resistance Shaving Hold -- 怖気_耐性削り保留"
+        "Terror Resistance Shaving Hold"
       ]
     },
     {
@@ -6442,7 +6442,7 @@
     {
       "ID": 9800,
       "Entries": [
-        "Firecracker debuff -- 爆竹デバフ"
+        "Purple Fume Spark Debuff"
       ]
     },
     {
@@ -8134,7 +8134,7 @@
     {
       "ID": 100392,
       "Entries": [
-        "PC: Iron fan damage level for overwriting _ provisional -- PC：鉄扇ダメージレベル上書用_暫定"
+        "Loaded Umbrella - Overwriting Damage Level"
       ]
     },
     {
@@ -8236,121 +8236,121 @@
     {
       "ID": 104000,
       "Entries": [
-        "Critical symbol SFX_for enemy attack_piercing -- クリティカル記号SFX_敵攻撃用_刺突"
+        "Critical VFX - Thrust"
       ]
     },
     {
       "ID": 104001,
       "Entries": [
-        "Critical symbol SFX_for enemy attack_ground -- クリティカル記号SFX_敵攻撃用_対地"
+        "Critical VFX - Sweep"
       ]
     },
     {
       "ID": 104002,
       "Entries": [
-        "Critical symbol SFX_for enemy attack_light fire / anti-aircraft -- クリティカル記号SFX_敵攻撃用_軽射/対空"
+        "Critical VFX - Light Flame / Anti-air"
       ]
     },
     {
       "ID": 104005,
       "Entries": [
-        "Critical symbol SFX_for enemy attack_flame -- クリティカル記号SFX_敵攻撃用_火炎"
+        "Critical VFX - Flame"
       ]
     },
     {
       "ID": 104010,
       "Entries": [
-        "Critical symbol SFX_piercing -- クリティカル記号SFX_刺突"
+        "Critical VFX - Thrust Counter"
       ]
     },
     {
       "ID": 104011,
       "Entries": [
-        "Critical symbol SFX_ground -- クリティカル記号SFX_対地"
+        "Critical VFX - Sweep Counter"
       ]
     },
     {
       "ID": 104012,
       "Entries": [
-        "Critical symbol SFX_light / anti-aircraft -- クリティカル記号SFX_軽射/対空"
+        "Critical VFX - Anti-air"
       ]
     },
     {
       "ID": 104015,
       "Entries": [
-        "Critical symbol SFX_flame -- クリティカル記号SFX_火炎"
+        "Critical VFX - Flame"
       ]
     },
     {
       "ID": 104016,
       "Entries": [
-        "Critical symbol SFX_anti-spirit -- クリティカル記号SFX_対霊"
+        "Critical VFX - Anti-apparition"
       ]
     },
     {
       "ID": 104017,
       "Entries": [
-        "Critical symbol SFX_ Anti-aircraft (Kick rush first stage kick-up only) -- クリティカル記号SFX_対空（蹴りラッシュ初段蹴り上げ専用）"
+        "Critical VFX - Anti-air (Senpou Leaping Kicks / High Monk Kick-up)"
       ]
     },
     {
       "ID": 104018,
       "Entries": [
-        "Critical symbol SFX_Anti-aircraft (Kicking rush first stage kicking only) _Always Ver. -- クリティカル記号SFX_対空（蹴りラッシュ初段蹴り上げ専用）_常時Ver."
+        "Critical VFX - Anti-air (Senpou Leaping Kicks / High Monk Kick-up)"
       ]
     },
     {
       "ID": 104020,
       "Entries": [
-        "Critical symbol SFX_reaction system_firecracker -- クリティカル記号SFX_リアクション系_爆竹"
+        "Critical VFX - Firecracker"
       ]
     },
     {
       "ID": 104021,
       "Entries": [
-        "Critical symbol SFX_reaction system_ax -- クリティカル記号SFX_リアクション系_斧"
+        "Critical VFX - Axe"
       ]
     },
     {
       "ID": 104022,
       "Entries": [
-        "Critical symbol SFX_reaction system_female poison -- クリティカル記号SFX_リアクション系_女毒"
+        "Critical VFX - O'Rin Poison"
       ]
     },
     {
       "ID": 104023,
       "Entries": [
-        "Critical symbol SFX_reaction system_spear -- クリティカル記号SFX_リアクション系_槍"
+        "Critical VFX - Spear"
       ]
     },
     {
       "ID": 104024,
       "Entries": [
-        "Critical symbol SFX_reaction system_enemy turning -- クリティカル記号SFX_リアクション系_敵回し"
+        "Critical VFX - Divine Abduction"
       ]
     },
     {
       "ID": 104025,
       "Entries": [
-        "Critical symbol SFX_reaction system_seed ringing -- クリティカル記号SFX_リアクション系_種鳴らし"
+        "Critical VFX - Snap Seed"
       ]
     },
     {
       "ID": 104026,
       "Entries": [
-        "Critical symbol SFX_reaction system_finger whistle -- クリティカル記号SFX_リアクション系_指笛"
+        "Critical VFX - Finger Whistle"
       ]
     },
     {
       "ID": 104030,
       "Entries": [
-        "Critical symbol SFX_Reaction system playback permission_Firecracker -- クリティカル記号SFX_リアクション系再生許可_爆竹"
+        "Critical VFX - Hitting Beast With Firecrackers"
       ]
     },
     {
       "ID": 104031,
       "Entries": [
-        "Critical symbol SFX_Reaction system playback permission_Ax -- クリティカル記号SFX_リアクション系再生許可_斧"
+        "Critical VFX - Axe Play Permission"
       ]
     },
     {
@@ -8452,19 +8452,19 @@
     {
       "ID": 106030,
       "Entries": [
-        "Spirit enchantment -- 霊エンチャント"
+        "Living Force - Anti-apparition"
       ]
     },
     {
       "ID": 106031,
       "Entries": [
-        "Reinforcement of spirit enchantment_anti-spirit guard -- 霊エンチャント_対霊ガード強化"
+        "Living Force - Anti-apparition Guard"
       ]
     },
     {
       "ID": 106032,
       "Entries": [
-        "Spirit Enchantment_Anti-spirit Jasuga Strengthening -- 霊エンチャント_対霊ジャスガ強化"
+        "Living Force - Anti-apparition Deflection"
       ]
     },
     {
@@ -8584,7 +8584,7 @@
     {
       "ID": 107100,
       "Entries": [
-        "Prosthetic hand ninja _ firecracker _ cool time activation trigger -- 義手忍具_爆竹_クールタイム発動トリガー"
+        "Firecracker Cooldown"
       ]
     },
     {
@@ -8608,121 +8608,121 @@
     {
       "ID": 107600,
       "Entries": [
-        "Prosthetic hand ninja _ iron fan _ charge LV0 monitoring / holding -- 義手忍具_鉄扇_チャージLV0監視/保持"
+        "Loaded Umbrella - Projectile Level 0"
       ]
     },
     {
       "ID": 107601,
       "Entries": [
-        "Prosthetic hand ninja _ iron fan _ charge LV1 monitoring / holding -- 義手忍具_鉄扇_チャージLV1監視/保持"
+        "Loaded Umbrella - Projectile Level 1"
       ]
     },
     {
       "ID": 107602,
       "Entries": [
-        "Prosthetic hand ninja _ iron fan _ charge LV2 monitoring / holding -- 義手忍具_鉄扇_チャージLV2監視/保持"
+        "Loaded Umbrella - Projectile Level 2"
       ]
     },
     {
       "ID": 107603,
       "Entries": [
-        "Prosthetic hand ninja _ iron fan _ charge LV3 monitoring / holding -- 義手忍具_鉄扇_チャージLV3監視/保持"
+        "Loaded Umbrella - Projectile Level 3"
       ]
     },
     {
       "ID": 107610,
       "Entries": [
-        "Prosthetic hand Ninja _ Iron fan _ Charge LV1 is in operation -- 義手忍具_鉄扇_チャージLV1発動中"
+        "Loaded Umbrella - Projectile Level 1 Being Used"
       ]
     },
     {
       "ID": 107611,
       "Entries": [
-        "Prosthetic hand Ninja _ Iron fan _ Charge LV2 is active -- 義手忍具_鉄扇_チャージLV2発動中"
+        "Loaded Umbrella - Projectile Level 2 Being Used"
       ]
     },
     {
       "ID": 107612,
       "Entries": [
-        "Prosthetic hand ninja _ iron fan _ charge LV3 is active -- 義手忍具_鉄扇_チャージLV3発動中"
+        "Loaded Umbrella - Projectile Level 3 Being Used"
       ]
     },
     {
       "ID": 107615,
       "Entries": [
-        "Prosthetic hand ninja _ iron fan _ charge reset -- 義手忍具_鉄扇_チャージリセット"
+        "Loaded Umbrella - Projectile Charge Reset"
       ]
     },
     {
       "ID": 107621,
       "Entries": [
-        "Prosthetic hand Ninja _ Iron fan _ Charge _1 Accumulate in 1 time -- 義手忍具_鉄扇_チャージ_1回で溜まる"
+        "Loaded Umbrella - Charge Accumulation 1"
       ]
     },
     {
       "ID": 107622,
       "Entries": [
-        "Prosthetic hand Ninja _ Iron fan _ Charge-Accumulate in 2 times -- 義手忍具_鉄扇_チャージ_2回で溜まる"
+        "Loaded Umbrella - Charge Accumulation 2"
       ]
     },
     {
       "ID": 107623,
       "Entries": [
-        "Prosthetic hand Ninja _ Iron fan _ Charge _ Accumulate in 3 times -- 義手忍具_鉄扇_チャージ_3回で溜まる"
+        "Loaded Umbrella - Charge Accumulation 3"
       ]
     },
     {
       "ID": 107624,
       "Entries": [
-        "Prosthetic hand Ninja _ Iron fan _ Charge _ Accumulate in 4 times -- 義手忍具_鉄扇_チャージ_4回で溜まる"
+        "Loaded Umbrella - Charge Accumulation 4"
       ]
     },
     {
       "ID": 107625,
       "Entries": [
-        "Prosthetic hand Ninja _ Iron fan _ Charge _ Accumulate in 5 times -- 義手忍具_鉄扇_チャージ_5回で溜まる"
+        "Loaded Umbrella - Charge Accumulation 5"
       ]
     },
     {
       "ID": 107626,
       "Entries": [
-        "Prosthetic hand Ninja _ Iron fan _ Charge _ Accumulate in 6 times -- 義手忍具_鉄扇_チャージ_6回で溜まる"
+        "Loaded Umbrella - Charge Accumulation 6"
       ]
     },
     {
       "ID": 107627,
       "Entries": [
-        "Prosthetic hand Ninja _ Iron fan _ Charge _ Accumulate in 7 times -- 義手忍具_鉄扇_チャージ_7回で溜まる"
+        "Loaded Umbrella - Charge Accumulation 7"
       ]
     },
     {
       "ID": 107628,
       "Entries": [
-        "Prosthetic hand Ninja _ Iron fan _ Charge _ Accumulate in 8 times -- 義手忍具_鉄扇_チャージ_8回で溜まる"
+        "Loaded Umbrella - Charge Accumulation 8"
       ]
     },
     {
       "ID": 107629,
       "Entries": [
-        "Prosthetic hand Ninja _ Iron fan _ Charge _ Accumulate in 9 times -- 義手忍具_鉄扇_チャージ_9回で溜まる"
+        "Loaded Umbrella - Charge Accumulation 9"
       ]
     },
     {
       "ID": 107630,
       "Entries": [
-        "Prosthetic hand Ninja _ Iron fan _ Charge _ Accumulate in 10 times -- 義手忍具_鉄扇_チャージ_10回で溜まる"
+        "Loaded Umbrella - Charge Accumulation 10"
       ]
     },
     {
       "ID": 107640,
       "Entries": [
-        "Prosthetic hand ninja _ iron fan _ charge monitoring / holding possible -- 義手忍具_鉄扇_チャージ監視/保持可能"
+        "Loaded Umbrella - Projected Force Allow Use"
       ]
     },
     {
       "ID": 107641,
       "Entries": [
-        "Prosthetic hand ninja _ iron fan _ charge can be added -- 義手忍具_鉄扇_チャージ加算可能"
+        "Loaded Umbrella - Charge Can Be Added"
       ]
     },
     {
@@ -8794,19 +8794,19 @@
     {
       "ID": 107710,
       "Entries": [
-        "Enemy turn AI sound bullet"
+        "Divine Abduction - AI Sound"
       ]
     },
     {
       "ID": 107711,
       "Entries": [
-        "Enemy Turn Reaction Transparency"
+        "Divine Abduction - Reaction"
       ]
     },
     {
       "ID": 107712,
       "Entries": [
-        "Enemy Turn Reaction Short-term Blind"
+        "Divine Abduction - Short Blind"
       ]
     },
     {
@@ -10270,73 +10270,73 @@
     {
       "ID": 127060,
       "Entries": [
-        "Money throwing _ possession LV0 -- 銭投げ_所持LV0"
+        "Sen Throw Consumption - No Money"
       ]
     },
     {
       "ID": 127061,
       "Entries": [
-        "Money throwing _ possession LV1 -- 銭投げ_所持LV1"
+        "Sen Throw Consumption - Little Money"
       ]
     },
     {
       "ID": 127062,
       "Entries": [
-        "Money throwing _ possession LV2 -- 銭投げ_所持LV2"
+        "Sen Throw Consumption - Some Money"
       ]
     },
     {
       "ID": 127063,
       "Entries": [
-        "Money throwing _ possession LV3 -- 銭投げ_所持LV3"
+        "Sen Throw Consumption - A Lot of Money"
       ]
     },
     {
       "ID": 127070,
       "Entries": [
-        "Money throwing _ consumption LV0 accumulation -- 銭投げ_消費LV0溜め"
+        "Sen Throw Charge Consumption - No Money"
       ]
     },
     {
       "ID": 127071,
       "Entries": [
-        "Money throwing _ consumption LV0 -- 銭投げ_消費LV0"
+        "Sen Throw Consumption - No Money"
       ]
     },
     {
       "ID": 127072,
       "Entries": [
-        "Money throwing _ consumption LV1 accumulation -- 銭投げ_消費LV1溜め"
+        "Sen Throw Charge Consumption - Little Money"
       ]
     },
     {
       "ID": 127073,
       "Entries": [
-        "Money throwing _ consumption LV1 -- 銭投げ_消費LV1"
+        "Sen Throw Consumption - Little Money"
       ]
     },
     {
       "ID": 127074,
       "Entries": [
-        "Money throwing _ consumption LV2 accumulation -- 銭投げ_消費LV2溜め"
+        "Sen Throw Charge Consumption - Some Money"
       ]
     },
     {
       "ID": 127075,
       "Entries": [
-        "Money throwing _ consumption LV2 -- 銭投げ_消費LV2"
+        "Sen Throw Consumption - Some Money"
       ]
     },
     {
       "ID": 127076,
       "Entries": [
-        "Money throwing _ consumption LV3 accumulation -- 銭投げ_消費LV3溜め"
+        "Sen Throw Charge Consumption - A Lot of Money"
       ]
     },
     {
       "ID": 127077,
       "Entries": [
-        "Money throwing _ consumption LV3 -- 銭投げ_消費LV3"
+        "Sen Throw Consumption - A Lot of Money"
       ]
     },
     {
@@ -12586,19 +12586,19 @@
     {
       "ID": 230100,
       "Entries": [
-        "Firecracker_special attack character definition -- 爆竹_特攻キャラ定義"
+        "Flag as Beast for Firecracker"
       ]
     },
     {
       "ID": 230110,
       "Entries": [
-        "Firecracker _ vs. non-special attack character attack -- 爆竹_対非特攻キャラ攻撃"
+        "Firecracker Normal Stun"
       ]
     },
     {
       "ID": 230111,
       "Entries": [
-        "Firecracker _ vs. special attack character attack -- 爆竹_対特攻キャラ攻撃"
+        "Firecracker Beast Stun"
       ]
     },
     {
@@ -12640,67 +12640,67 @@
     {
       "ID": 230500,
       "Entries": [
-        "Finger whistle_enemy madness_effect can be activated -- 指笛_敵狂わせ_効果発動可能"
+        "Finger Whistle - Enemy Affected by Beast Madness"
       ]
     },
     {
       "ID": 230510,
       "Entries": [
-        "Finger whistle_enemy madness_invoking_parent -- 指笛_敵狂わせ_発動中_親"
+        "Finger Whistle - Beast Madness Trigger"
       ]
     },
     {
       "ID": 230511,
       "Entries": [
-        "Finger whistle _ Enemy madness _ Activated _ Parent _ Minor Ver. -- 指笛_敵狂わせ_発動中_親_短調Ver."
+        "Malcontent - Apparition Madness Trigger"
       ]
     },
     {
       "ID": 230515,
       "Entries": [
-        "Finger whistle_enemy madness_invoking -- 指笛_敵狂わせ_発動中"
+        "Finger Whistle - Beast Madness"
       ]
     },
     {
       "ID": 230516,
       "Entries": [
-        "Finger whistle_enemy madness_invoking_minor Ver. -- 指笛_敵狂わせ_発動中_短調Ver."
+        "Malcontent - Apparition Madness"
       ]
     },
     {
       "ID": 230518,
       "Entries": [
-        "Finger whistle_enemy AI activation -- 指笛_敵AI起動"
+        "Finger Whistle - AI Sound"
       ]
     },
     {
       "ID": 230519,
       "Entries": [
-        "Finger whistle_enemy AI activation_minor Ver. -- 指笛_敵AI起動_短調Ver."
+        "Malcontent - Apparition AI Sound"
       ]
     },
     {
       "ID": 230520,
       "Entries": [
-        "Finger whistle LV3_minor_effect can be activated -- 指笛LV3_短調_効果発動可能"
+        "Malcontent - Enemy Affected by Apparition Madness"
       ]
     },
     {
       "ID": 230530,
       "Entries": [
-        "Finger whistle LV3_minor_invocation -- 指笛LV3_短調_発動"
+        "Malcontent"
       ]
     },
     {
       "ID": 230540,
       "Entries": [
-        "Finger whistle LV3_minor_invalid -- 指笛LV3_短調_無効"
+        "Malcontent - Apparition Madness Invalid"
       ]
     },
     {
       "ID": 230541,
       "Entries": [
-        "Finger whistle LV3_minor_cancellation timing -- 指笛LV3_短調_キャンセルタイミング"
+        "Malcontent - Apparition Madness Cancel"
       ]
     },
     {
@@ -12790,7 +12790,7 @@
     {
       "ID": 230645,
       "Entries": [
-        "Anti-spirit _ ghost barrier erase -- 対霊_怨霊バリア消し"
+        "Remove Apparition Barrier"
       ]
     },
     {
@@ -15964,7 +15964,7 @@
     {
       "ID": 3147000,
       "Entries": [
-        "[NTC] Kokageshu_Dog Whistle -- 【NTC】孤影衆_犬笛"
+        "Lone Shadow - Dog Whistle"
       ]
     },
     {
@@ -16360,7 +16360,7 @@
     {
       "ID": 3155140,
       "Entries": [
-        "[NTC] Bandit_Aburatsubo downs the flames -- 【NTC】野盗_油壺により炎上ダウン"
+        "Bandit - Oil"
       ]
     },
     {

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/SwordArtsParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/SwordArtsParam.json
@@ -4,895 +4,895 @@
     {
       "ID": 0,
       "Entries": [
-        "test data -- テストデータ"
+        "\n"
       ]
     },
     {
       "ID": 1,
       "Entries": [
-        "No arts -- アーツなし"
+        "\n"
       ]
     },
     {
       "ID": 10,
       "Entries": [
-        "Bare hand: Right hand arts activated -- 素手：右手アーツ発動"
+        "\n"
       ]
     },
     {
       "ID": 60,
       "Entries": [
-        "Small shield: Right hand arts activated -- 小盾：右手アーツ発動"
+        "\n"
       ]
     },
     {
       "ID": 70,
       "Entries": [
-        "Large shield: Right hand arts activated -- 大盾：右手アーツ発動"
+        "\n"
       ]
     },
     {
       "ID": 80,
       "Entries": [
-        "Middle shield: Right hand arts activated -- 中盾：右手アーツ発動"
+        "\n"
       ]
     },
     {
       "ID": 90,
       "Entries": [
-        "Small shield: Parry -- 小盾：パリィ"
+        "\n"
       ]
     },
     {
       "ID": 91,
       "Entries": [
-        "Middle shield: Parry -- 中盾：パリィ"
+        "\n"
       ]
     },
     {
       "ID": 92,
       "Entries": [
-        "Small Shield: Spell Parry -- 小盾：スペルパリィ"
+        "\n"
       ]
     },
     {
       "ID": 93,
       "Entries": [
-        "Middle shield: Spell Parry -- 中盾：スペルパリィ"
+        "\n"
       ]
     },
     {
       "ID": 99,
       "Entries": [
-        "Dagger: Parry -- 短剣：パリィ"
+        "\n"
       ]
     },
     {
       "ID": 100,
       "Entries": [
-        "Dagger: Strong Rock Step -- 短剣：強ロックステップ"
+        "\n"
       ]
     },
     {
       "ID": 101,
       "Entries": [
-        "Dagger: Shield Penetration: Do not store one-shot weapons -- 短剣：盾貫通：ワンショット武器収納しない"
+        "\n"
       ]
     },
     {
       "ID": 102,
       "Entries": [
-        "Dagger: Underground Prisoner: One Shot -- 短剣：地下の囚人：ワンショット"
+        "\n"
       ]
     },
     {
       "ID": 103,
       "Entries": [
-        "Dagger: Candlestick: Do not store one-shot weapons -- 短剣：燭台：ワンショット武器収納しない"
+        "\n"
       ]
     },
     {
       "ID": 104,
       "Entries": [
-        "Dagger: Rosalia: One Shot -- 短剣：ロザリア：ワンショット"
+        "\n"
       ]
     },
     {
       "ID": 105,
       "Entries": [
-        "Dagger: Fang: Do not store one-shot weapons -- 短剣：牙突：ワンショット武器収納しない"
+        "\n"
       ]
     },
     {
       "ID": 200,
       "Entries": [
-        "Straight sword: stance -- 直剣：構え"
+        "\n"
       ]
     },
     {
       "ID": 201,
       "Entries": [
-        "Straight sword: Stepping on -- 直剣：踏み込み"
+        "\n"
       ]
     },
     {
       "ID": 202,
       "Entries": [
-        "Straight sword: Candlestick: One-shot Weapon not stored -- 直剣：燭台：ワンショット武器収納しない"
+        "\n"
       ]
     },
     {
       "ID": 203,
       "Entries": [
-        "Straight sword: Sun: Do not store one-shot weapons -- 直剣：太陽：ワンショット武器収納しない"
+        "\n"
       ]
     },
     {
       "ID": 204,
       "Entries": [
-        "Straight sword: Brother: Ready -- 直剣：弟：構え"
+        "\n"
       ]
     },
     {
       "ID": 205,
       "Entries": [
-        "Straight Sword: Dark Knight: Ready -- 直剣：ダークナイト：構え"
+        "\n"
       ]
     },
     {
       "ID": 300,
       "Entries": [
-        "Great sword: stance -- 大剣：構え"
+        "\n"
       ]
     },
     {
       "ID": 301,
       "Entries": [
-        "Great Sword: King of the Dead: One Shot -- 大剣：死霊の王：ワンショット"
+        "\n"
       ]
     },
     {
       "ID": 302,
       "Entries": [
-        "Great Sword: Last Boss: One Shot -- 大剣：ラスボス：ワンショット"
+        "\n"
       ]
     },
     {
       "ID": 303,
       "Entries": [
-        "Great Sword: Moonlight: One Shot -- 大剣：月光：ワンショット"
+        "\n"
       ]
     },
     {
       "ID": 304,
       "Entries": [
-        "Great Sword: Old King: Ready -- 大剣：老王：構え"
+        "\n"
       ]
     },
     {
       "ID": 305,
       "Entries": [
-        "Great Sword: Twin Princes Combined: Ready -- 大剣：双皇子合体：構え"
+        "\n"
       ]
     },
     {
       "ID": 306,
       "Entries": [
-        "Great Sword: Altri: Ready -- 大剣：アルトリ：構え"
+        "\n"
       ]
     },
     {
       "ID": 307,
       "Entries": [
-        "Great Sword: Executioner Sword: Stepping on -- 大剣：エグゼキューショナーソード：踏み込み"
+        "\n"
       ]
     },
     {
       "ID": 308,
       "Entries": [
-        "Great Sword: Bastard Sword: Stepping on -- 大剣：バスタードソード：踏み込み"
+        "\n"
       ]
     },
     {
       "ID": 309,
       "Entries": [
-        "Great Sword: Storm Ruler: Special Position -- 大剣：ストームルーラー：特殊構え"
+        "\n"
       ]
     },
     {
       "ID": 310,
       "Entries": [
-        "Great sword: Patience -- 大剣：我慢"
+        "\n"
       ]
     },
     {
       "ID": 400,
       "Entries": [
-        "Oversized sword: Stepping on -- 特大剣：踏み込み"
+        "\n"
       ]
     },
     {
       "ID": 401,
       "Entries": [
-        "Oversized Sword: Watcher: Parry -- 特大剣：監視者：パリィ"
+        "\n"
       ]
     },
     {
       "ID": 402,
       "Entries": [
-        "Oversized sword: assault -- 特大剣：突撃"
+        "\n"
       ]
     },
     {
       "ID": 403,
       "Entries": [
-        "Oversized Sword: Old King: Stepping on -- 特大剣：老王：踏み込み"
+        "\n"
       ]
     },
     {
       "ID": 404,
       "Entries": [
-        "Oversized sword: Twin prince brother: Stepping on -- 特大剣：双皇子兄：踏み込み"
+        "\n"
       ]
     },
     {
       "ID": 405,
       "Entries": [
-        "Oversized sword: Step on (horizontal rotation) -- 特大剣：踏み込み（横回転）"
+        "\n"
       ]
     },
     {
       "ID": 406,
       "Entries": [
-        "Oversized Sword: Black Knight: Stepping on -- 特大剣：黒騎士：踏み込み"
+        "\n"
       ]
     },
     {
       "ID": 407,
       "Entries": [
-        "Oversized Sword: Smoke: Stepping on -- 特大剣：煙：踏み込み"
+        "\n"
       ]
     },
     {
       "ID": 500,
       "Entries": [
-        "Sword: Ready -- 刺剣：構え"
+        "\n"
       ]
     },
     {
       "ID": 501,
       "Entries": [
-        "Sword: Fang: One Shot -- 刺剣：牙突：ワンショット"
+        "\n"
       ]
     },
     {
       "ID": 502,
       "Entries": [
-        "Sword: Ricard: One-shot Weapon not stored -- 刺剣：リカール：ワンショット武器収納しない"
+        "\n"
       ]
     },
     {
       "ID": 600,
       "Entries": [
-        "Curved sword: Rotate -- 曲剣：回転"
+        "\n"
       ]
     },
     {
       "ID": 601,
       "Entries": [
-        "Sword: Missing month: One shot -- 曲剣：欠月：ワンショット"
+        "\n"
       ]
     },
     {
       "ID": 602,
       "Entries": [
-        "Sword: King of Storms: Rotation -- 曲剣：嵐の王：回転"
+        "\n"
       ]
     },
     {
       "ID": 603,
       "Entries": [
-        "Curved Sword: Sulliburn: Rotate -- 曲剣：サリバーン：回転"
+        "\n"
       ]
     },
     {
       "ID": 604,
       "Entries": [
-        "Sword: Shortel: Rotate -- 曲剣：ショーテル：回転"
+        "\n"
       ]
     },
     {
       "ID": 605,
       "Entries": [
-        "Light sword: Rotate -- 軽曲剣：回転"
+        "\n"
       ]
     },
     {
       "ID": 606,
       "Entries": [
-        "Light sword: Painting protection: Rotation -- 軽曲剣：絵画守り：回転"
+        "\n"
       ]
     },
     {
       "ID": 700,
       "Entries": [
-        "Omagari Sword: Rotation -- 大曲剣：回転"
+        "\n"
       ]
     },
     {
       "ID": 701,
       "Entries": [
-        "Omagari Sword: Wolf: Rotate -- 大曲剣：オオカミ：回転"
+        "\n"
       ]
     },
     {
       "ID": 702,
       "Entries": [
-        "Omagari Sword: Skeleton: Rotate -- 大曲剣：スケルトン：回転"
+        "\n"
       ]
     },
     {
       "ID": 703,
       "Entries": [
-        "Omagari Sword: Forest Keeper: Rotation -- 大曲剣：森の番人：回転"
+        "\n"
       ]
     },
     {
       "ID": 800,
       "Entries": [
-        "Sword: stance -- 刀：構え"
+        "\n"
       ]
     },
     {
       "ID": 801,
       "Entries": [
-        "Sword: Seppuku sword: One shot -- 刀：腹切り刀：ワンショット"
+        "\n"
       ]
     },
     {
       "ID": 802,
       "Entries": [
-        "Sword: Clothesline: Ready -- 刀：物干し竿：構え"
+        "\n"
       ]
     },
     {
       "ID": 803,
       "Entries": [
-        "Sword: Fang: One shot -- 刀：牙突：ワンショット"
+        "\n"
       ]
     },
     {
       "ID": 900,
       "Entries": [
-        "Ax: Walk Rye -- 斧：ウォークライ"
+        "\n"
       ]
     },
     {
       "ID": 901,
       "Entries": [
-        "Ax: Cut meat: One shot -- 斧：肉断ち：ワンショット"
+        "\n"
       ]
     },
     {
       "ID": 902,
       "Entries": [
-        "Ax: 4 Knights: One Shot -- 斧：4騎士：ワンショット"
+        "\n"
       ]
     },
     {
       "ID": 903,
       "Entries": [
-        "Ax: Strong Rock Step -- 斧：強ロックステップ"
+        "\n"
       ]
     },
     {
       "ID": 1000,
       "Entries": [
-        "Large Ax: Walk Rye -- 大斧：ウォークライ"
+        "\n"
       ]
     },
     {
       "ID": 1001,
       "Entries": [
-        "Large Ax: Dragon King: One Shot -- 大斧：竜王：ワンショット"
+        "\n"
       ]
     },
     {
       "ID": 1002,
       "Entries": [
-        "Large Ax: Firewood Demon: One Shot -- 大斧：薪デーモン：ワンショット"
+        "\n"
       ]
     },
     {
       "ID": 1003,
       "Entries": [
-        "Large Ax: Guardian Knight: One Shot -- 大斧：守護騎士：ワンショット"
+        "\n"
       ]
     },
     {
       "ID": 1004,
       "Entries": [
-        "Large Ax: Harek: Walk Rye -- 大斧：ハレック：ウォークライ"
+        "\n"
       ]
     },
     {
       "ID": 1005,
       "Entries": [
-        "Large ax: Sharpen: One shot -- 大斧：研ぐ：ワンショット"
+        "\n"
       ]
     },
     {
       "ID": 1100,
       "Entries": [
-        "Hammer: Patience -- 槌：我慢"
+        "\n"
       ]
     },
     {
       "ID": 1101,
       "Entries": [
-        "Hammer: Walk Rye -- 槌：ウォークライ"
+        "\n"
       ]
     },
     {
       "ID": 1102,
       "Entries": [
-        "Hammer: Magic enhancement -- 槌：魔法強化"
+        "\n"
       ]
     },
     {
       "ID": 1103,
       "Entries": [
-        "Hammer: Pick: Patience -- 槌：ピック：我慢（気合）"
+        "\n"
       ]
     },
     {
       "ID": 1200,
       "Entries": [
-        "Otsuchi: Patience -- 大槌：我慢"
+        "\n"
       ]
     },
     {
       "ID": 1201,
       "Entries": [
-        "Otsuchi: Ash Demon: Patience -- 大槌：灰デーモン：我慢"
+        "\n"
       ]
     },
     {
       "ID": 1202,
       "Entries": [
-        "Otsuchi: Gargoyle: Patience -- 大槌：ガーゴイル：我慢"
+        "\n"
       ]
     },
     {
       "ID": 1203,
       "Entries": [
-        "Otsuchi: Walk Rye -- 大槌：ウォークライ"
+        "\n"
       ]
     },
     {
       "ID": 1204,
       "Entries": [
-        "Otsuchi: Black dog: Patience -- 大槌：黒犬：我慢"
+        "\n"
       ]
     },
     {
       "ID": 1205,
       "Entries": [
-        "Gavel: Rotation -- 大槌：回転"
+        "\n"
       ]
     },
     {
       "ID": 1206,
       "Entries": [
-        "Otsuchi: Ice ax: Patience -- 大槌：ピッケル：我慢（気合）"
+        "\n"
       ]
     },
     {
       "ID": 1300,
       "Entries": [
-        "Spear: Assault -- 槍：突撃"
+        "\n"
       ]
     },
     {
       "ID": 1301,
       "Entries": [
-        "Spear: King of Storms: One Shot -- 槍：嵐の王：ワンショット"
+        "\n"
       ]
     },
     {
       "ID": 1302,
       "Entries": [
-        "Spear: Rosalia: One Shot -- 槍：ロザリア：ワンショット"
+        "\n"
       ]
     },
     {
       "ID": 1303,
       "Entries": [
-        "Spear: Fang: One Shot -- 槍：牙突：ワンショット"
+        "\n"
       ]
     },
     {
       "ID": 1304,
       "Entries": [
-        "Spear: Sullivan: Magical Enhancement -- 槍：サリヴァーン：魔法強化"
+        "\n"
       ]
     },
     {
       "ID": 1305,
       "Entries": [
-        "Spear: Not good: One shot -- 槍：なりそこない：ワンショット"
+        "\n"
       ]
     },
     {
       "ID": 1306,
       "Entries": [
-        "Spear: Lance: Assault -- 槍：ランス：突撃"
+        "\n"
       ]
     },
     {
       "ID": 1307,
       "Entries": [
-        "Spear: Fork: Assault -- 槍：フォーク：突撃"
+        "\n"
       ]
     },
     {
       "ID": 1308,
       "Entries": [
-        "Spear: Dragon hunting: Assault -- 槍：竜狩り：突撃"
+        "\n"
       ]
     },
     {
       "ID": 1309,
       "Entries": [
-        "Spear: Gargoyle: Assault -- 槍：ガーゴイル：突撃"
+        "\n"
       ]
     },
     {
       "ID": 1310,
       "Entries": [
-        "Spear: Cardinal: Assault -- 槍：枢機卿：突撃"
+        "\n"
       ]
     },
     {
       "ID": 1311,
       "Entries": [
-        "Spear: Rotate -- 槍：回転"
+        "\n"
       ]
     },
     {
       "ID": 1400,
       "Entries": [
-        "Halberd: Rotate -- 斧槍：回転"
+        "\n"
       ]
     },
     {
       "ID": 1401,
       "Entries": [
-        "Halberd: Royal Castle Fat: Rotating -- 斧槍：王城デブ：回転"
+        "\n"
       ]
     },
     {
       "ID": 1402,
       "Entries": [
-        "Halberd: Gunda: Assault -- 斧槍：グンダ：突撃"
+        "\n"
       ]
     },
     {
       "ID": 1403,
       "Entries": [
-        "Halberd: Mother Dragon: One Shot -- 斧槍：母ドラゴン：ワンショット"
+        "\n"
       ]
     },
     {
       "ID": 1404,
       "Entries": [
-        "Halberd: Moonlight Witch: One Shot -- 斧槍：月光魔女：ワンショット"
+        "\n"
       ]
     },
     {
       "ID": 1405,
       "Entries": [
-        "Halberd: Crescent: Walk Rye -- 斧槍：三日月：ウォークライ"
+        "\n"
       ]
     },
     {
       "ID": 1406,
       "Entries": [
-        "Halberd: Charge -- 斧槍：突撃"
+        "\n"
       ]
     },
     {
       "ID": 1407,
       "Entries": [
-        "Halberd: Patience -- 斧槍：我慢"
+        "\n"
       ]
     },
     {
       "ID": 1500,
       "Entries": [
-        "Sickle: Headshot -- 鎌：ヘッドショット"
+        "\n"
       ]
     },
     {
       "ID": 1501,
       "Entries": [
-        "Sickle: Thirsty: One shot -- 鎌：渇望：ワンショット"
+        "\n"
       ]
     },
     {
       "ID": 1502,
       "Entries": [
-        "Sickle: Sullivan: One Shot -- 鎌：サリヴァーン：ワンショット"
+        "\n"
       ]
     },
     {
       "ID": 1503,
       "Entries": [
-        "Sickle: Twin Prince: One Shot -- 鎌：双皇子：ワンショット"
+        "\n"
       ]
     },
     {
       "ID": 1600,
       "Entries": [
-        "Whip: Do not store one-shot weapons -- 鞭：ワンショット武器収納しない"
+        "\n"
       ]
     },
     {
       "ID": 1601,
       "Entries": [
-        "Whip: Ash Demon: Do not store one-shot weapons -- 鞭：灰デーモン：ワンショット武器収納しない"
+        "\n"
       ]
     },
     {
       "ID": 1700,
       "Entries": [
-        "Fist: Strong rock step -- 拳：強ロックステップ"
+        "\n"
       ]
     },
     {
       "ID": 1701,
       "Entries": [
-        "Fist: Firewood Demon Knuckle: Rotate -- 拳：薪のデーモンナックル：回転"
+        "\n"
       ]
     },
     {
       "ID": 1702,
       "Entries": [
-        "Fist: Dark Hand: Throw -- 拳：ダークハンド：投げ"
+        "\n"
       ]
     },
     {
       "ID": 1703,
       "Entries": [
-        "Fist: Cestvs: Patience -- 拳：セスタス：我慢"
+        "\n"
       ]
     },
     {
       "ID": 1800,
       "Entries": [
-        "Claws: Headshot -- 爪：ヘッドショット"
+        "\n"
       ]
     },
     {
       "ID": 1801,
       "Entries": [
-        "Nail: One shot -- 爪：ワンショット"
+        "\n"
       ]
     },
     {
       "ID": 1802,
       "Entries": [
-        "Claw: Strong lock step -- 爪：強ロックステップ"
+        "\n"
       ]
     },
     {
       "ID": 1900,
       "Entries": [
-        "Koyumi: Rapid fire -- 小弓：連射"
+        "\n"
       ]
     },
     {
       "ID": 1901,
       "Entries": [
-        "Koyumi: Shot -- 小弓：強射"
+        "\n"
       ]
     },
     {
       "ID": 1902,
       "Entries": [
-        "Small bow: diffusion -- 小弓：拡散"
+        "\n"
       ]
     },
     {
       "ID": 1903,
       "Entries": [
-        "Koyumi: Sullivan: Strong fire -- 小弓：サリヴァーン：強射"
+        "\n"
       ]
     },
     {
       "ID": 2000,
       "Entries": [
-        "Large bow: Penetration -- 大弓：貫通"
+        "\n"
       ]
     },
     {
       "ID": 2001,
       "Entries": [
-        "Large bow: Penetration -- 大弓：貫通"
+        "\n"
       ]
     },
     {
       "ID": 2101,
       "Entries": [
-        "Crossbow: One shot -- クロスボウ：ワンショット"
+        "\n"
       ]
     },
     {
       "ID": 2102,
       "Entries": [
-        "Crossbow: Strong rock step -- クロスボウ：強ロックステップ"
+        "\n"
       ]
     },
     {
       "ID": 2200,
       "Entries": [
-        "Wand: Magic enhancement -- 杖：魔法強化"
+        "\n"
       ]
     },
     {
       "ID": 2201,
       "Entries": [
-        "Wand: Crystal Elder: Magical Enhancement -- 杖：結晶古老：魔法強化"
+        "\n"
       ]
     },
     {
       "ID": 2202,
       "Entries": [
-        "Wand: Zombie Crow: Magical Enhancement -- 杖：ゾンビ烏：魔法強化"
+        "\n"
       ]
     },
     {
       "ID": 2203,
       "Entries": [
-        "Wand: Logan: Magic enhancement -- 杖：ローガン：魔法強化"
+        "\n"
       ]
     },
     {
       "ID": 2300,
       "Entries": [
-        "Talisman: Patience Chant (Middle) -- タリスマン：我慢詠唱（中）"
+        "\n"
       ]
     },
     {
       "ID": 2301,
       "Entries": [
-        "Bell: Magic enhancement (regeneration) -- 鈴：魔法強化（リジェネ）"
+        "\n"
       ]
     },
     {
       "ID": 2302,
       "Entries": [
-        "Talisman: One Shot (Full) -- タリスマン：ワンショット（フル）"
+        "\n"
       ]
     },
     {
       "ID": 2303,
       "Entries": [
-        "Talisman: Patience Chant (Weak) -- タリスマン：我慢詠唱（弱）"
+        "\n"
       ]
     },
     {
       "ID": 2304,
       "Entries": [
-        "Talisman: Patience Chant (Strong) -- タリスマン：我慢詠唱（強）"
+        "\n"
       ]
     },
     {
       "ID": 2400,
       "Entries": [
-        "Fire of Magic: One Shot (Full) -- 呪術の火：ワンショット（フル）"
+        "\n"
       ]
     },
     {
       "ID": 2500,
       "Entries": [
-        "Twin Dagger: Strong Rock Step -- 双短剣：強ロックステップ"
+        "\n"
       ]
     },
     {
       "ID": 2600,
       "Entries": [
-        "Double sword: Rotate -- 双直剣：回転"
+        "\n"
       ]
     },
     {
       "ID": 2700,
       "Entries": [
-        "Hyperbolic sword: Rotate -- 双曲剣：回転"
+        "\n"
       ]
     },
     {
       "ID": 2701,
       "Entries": [
-        "Hyperbolic Sword: Elite: Rotate -- 双曲剣：エリート：回転"
+        "\n"
       ]
     },
     {
       "ID": 2710,
       "Entries": [
-        "Hyperbolic Sword: Kiaran: Rotation -- 双曲剣：キアラン：回転"
+        "\n"
       ]
     },
     {
       "ID": 2720,
       "Entries": [
-        "Hyperbolic Sword: Tracker: Rotate -- 双曲剣：追跡者：回転"
+        "\n"
       ]
     },
     {
       "ID": 2800,
       "Entries": [
-        "Twin sword: Headshot -- 双刀：ヘッドショット"
+        "\n"
       ]
     },
     {
       "ID": 2900,
       "Entries": [
-        "Twin spear: Charge -- 双槍：突撃"
+        "\n"
       ]
     },
     {
       "ID": 3000,
       "Entries": [
-        "Twin ax: Rotate -- 双斧：回転"
+        "\n"
       ]
     },
     {
       "ID": 3100,
       "Entries": [
-        "Twin mallet: Rotation -- 双槌：回転"
+        "\n"
       ]
     },
     {
       "ID": 3200,
       "Entries": [
-        "Middle shield: One shot (full) -- 中盾：ワンショット（フル）"
+        "\n"
       ]
     },
     {
       "ID": 3201,
       "Entries": [
-        "Middle shield: Thorn shield: One shot (full) -- 中盾：トゲの盾：ワンショット（フル）"
+        "\n"
       ]
     },
     {
       "ID": 3300,
       "Entries": [
-        "Pavise: One Shot (Full) -- 大盾：ワンショット（フル）"
+        "\n"
       ]
     },
     {
       "ID": 3301,
       "Entries": [
-        "Large shield: Gunda: One shot (full) -- 大盾：グンダ：ワンショット（フル）"
+        "\n"
       ]
     },
     {
       "ID": 3310,
       "Entries": [
-        "Large shield: Havel: One shot (full) -- 大盾：ハベル：ワンショット（フル）"
+        "\n"
       ]
     },
     {
       "ID": 3320,
       "Entries": [
-        "Large shield: Skeleton: One shot (full) -- 大盾：骸骨：ワンショット（フル）"
+        "\n"
       ]
     },
     {
       "ID": 3400,
       "Entries": [
-        "Small shield: One shot (full) -- 小盾：ワンショット（フル）"
+        "\n"
       ]
     }
   ]

--- a/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/ThrowParam.json
+++ b/src/Smithbox.Data/Assets/PARAM/SDT/Param Row Names/English/ThrowParam.json
@@ -4,7 +4,7 @@
     {
       "ID": 0,
       "Entries": [
-        "Don&#39;t erase it! -- 消すな！"
+        "Default"
       ]
     },
     {


### PR DESCRIPTION
SDT: Row Names Update:

- `AtkParam_Pc`, `BehaviorParam_PC`, `Bullet`, `CalcCorrectGraph`, `HitMtrlParam`, `LodPlatform`, `NpcThinkParam`, `RematchWarpParam` - all rows translated
- `ActionButtonParam` - A bit of cleanup in preparation for actual translation
- `AttackElementCorrectParam`, `CharMakeMenuListItemParam`, `CharMakeMenuListTopParam`, `FaceGenParam`, `ItemLotParam`, `SwordArtsParam`  - remove DS3 leftovers
- `CharaInitParam` - removed all test rows, leaving only the important one named, for clarity
- `EquipParamGoods` - removed test / debug row names for clarity
- `EquipParamWeapon` - labelled Virtual Weapons correctly
- `SpEffectParam` - translated rows which were related to `AtkParam_Pc` or `Bullet` during their translation
- `ActionGuideParam`, `ActionUnlockParam`, `AiSoundParam`, `BudgetParam`, `BulletCreateLimitParam`, `EquipParamAccessory`, `Magic`, `NpcParam`, `ShopLineupParam`, `ThrowParam` - very minor changes
